### PR TITLE
Add augmented line connections

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -276,6 +276,22 @@ rule cluster_network:
     script: "scripts/cluster_network.py"
 
 
+rule augmented_line_connection:
+    input:
+        network='networks/elec_s{simpl}_{clusters}.nc',
+        regions_onshore="resources/regions_onshore_elec_s{simpl}_{clusters}.geojson",
+        regions_offshore="resources/regions_offshore_elec_s{simpl}_{clusters}.geojson",
+    output:
+        network='networks/elec_s{simpl}_{clusters}.nc',
+        regions_onshore="resources/regions_onshore_elec_s{simpl}_{clusters}.geojson",
+        regions_offshore="resources/regions_offshore_elec_s{simpl}_{clusters}.geojson",
+    log: "logs/augmented_line_connection/elec_s{simpl}_{clusters}.log"
+    benchmark: "benchmarks/augmented_line_connection/elec_s{simpl}_{clusters}"
+    threads: 1
+    resources: mem=3000
+    script: "scripts/augmented_line_connection.py"
+
+
 rule add_extra_components:
     input:
         network='networks/elec_s{simpl}_{clusters}.nc',

--- a/Snakefile
+++ b/Snakefile
@@ -276,20 +276,22 @@ rule cluster_network:
     script: "scripts/cluster_network.py"
 
 
-rule augmented_line_connection:
+rule augmented_line_connections:
     input:
+        tech_costs=COSTS,
         network='networks/elec_s{simpl}_{clusters}.nc',
         regions_onshore="resources/regions_onshore_elec_s{simpl}_{clusters}.geojson",
         regions_offshore="resources/regions_offshore_elec_s{simpl}_{clusters}.geojson",
     output:
         network='networks/elec_s{simpl}_{clusters}.nc',
+        network_unmeshed='networks/elec_s{simpl}_{clusters}_no_augmented_connections.nc',
         regions_onshore="resources/regions_onshore_elec_s{simpl}_{clusters}.geojson",
         regions_offshore="resources/regions_offshore_elec_s{simpl}_{clusters}.geojson",
-    log: "logs/augmented_line_connection/elec_s{simpl}_{clusters}.log"
-    benchmark: "benchmarks/augmented_line_connection/elec_s{simpl}_{clusters}"
+    log: "logs/augmented_line_connections/elec_s{simpl}_{clusters}.log"
+    benchmark: "benchmarks/augmented_line_connections/elec_s{simpl}_{clusters}"
     threads: 1
     resources: mem=3000
-    script: "scripts/augmented_line_connection.py"
+    script: "scripts/augmented_line_connections.py"
 
 
 rule add_extra_components:

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -29,7 +29,7 @@ countries: ["NG", "NE"]
   #["ZA"]  # South Africa
 
 augmented_line_connection:
-  connectivity_upgrade: 3  # https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation.html#networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation
+  connectivity_upgrade: 3  # min. lines connection per node, https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation.html#networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation
   new_line_type: "HVDC"  # or "HVAC"
   min_expansion: 1  # [MW]
 

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -28,6 +28,10 @@ countries: ["NG", "NE"]
   #["MA"]  # Morroco
   #["ZA"]  # South Africa
 
+augmented_line_connection:
+  connectivity_upgrade: 3  # https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation.html#networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation
+  new_line_type: "HVDC"  # or "HVAC"
+  
 # if True clusters to GADM shapes, if False Voronoi cells will be clustered
 cluster_options:
   alternative_clustering: False

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -31,7 +31,8 @@ countries: ["NG", "NE"]
 augmented_line_connection:
   connectivity_upgrade: 3  # https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation.html#networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation
   new_line_type: "HVDC"  # or "HVAC"
-  
+  min_expansion: 1  # [MW]
+
 # if True clusters to GADM shapes, if False Voronoi cells will be clustered
 cluster_options:
   alternative_clustering: False

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -29,7 +29,7 @@ countries: ["NG", "BJ"]
   #["ZA"]  # South Africa
 
 augmented_line_connection:
-  connectivity_upgrade: 3  # https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation.html#networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation
+  connectivity_upgrade: 3  # min. lines connection per node, https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation.html#networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation
   new_line_type: "HVDC"  # or "HVAC"
   min_expansion: 1  # [MW]
 

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -31,6 +31,7 @@ countries: ["NG", "BJ"]
 augmented_line_connection:
   connectivity_upgrade: 3  # https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation.html#networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation
   new_line_type: "HVDC"  # or "HVAC"
+  min_expansion: 1  # [MW]
 
 # if True clusters to GADM shapes, if False Voronoi cells will be clustered
 cluster_options:

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -28,6 +28,10 @@ countries: ["NG", "BJ"]
   #["MA"]  # Morroco
   #["ZA"]  # South Africa
 
+augmented_line_connection:
+  connectivity_upgrade: 3  # https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation.html#networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation
+  new_line_type: "HVDC"  # or "HVAC"
+
 # if True clusters to GADM shapes, if False Voronoi cells will be clustered
 cluster_options:
   alternative_clustering: False

--- a/scripts/augmented_line_connections.py
+++ b/scripts/augmented_line_connections.py
@@ -61,9 +61,10 @@ if __name__ == "__main__":
         from _helpers import mock_snakemake
 
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
-        snakemake = mock_snakemake(
-            "augmented_line_connections", network="elec", simpl="", clusters="60"
-        )
+        snakemake = mock_snakemake("augmented_line_connections",
+                                   network="elec",
+                                   simpl="",
+                                   clusters="60")
     configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input.network)
@@ -97,17 +98,19 @@ if __name__ == "__main__":
     G.add_weighted_edges_from(network_lines.loc[:, attrs].values)
 
     # find all complement edges
-    complement_edges = pd.DataFrame(complement(G).edges, columns=["bus0", "bus1"])
+    complement_edges = pd.DataFrame(complement(G).edges,
+                                    columns=["bus0", "bus1"])
     complement_edges["length"] = complement_edges.apply(haversine, axis=1)
 
     # apply k_edge_augmentation weighted by length of complement edges
     k_edge = k_edge_option
-    augmentation = k_edge_augmentation(G, k_edge, avail=complement_edges.values)
+    augmentation = k_edge_augmentation(G,
+                                       k_edge,
+                                       avail=complement_edges.values)
     new_network_lines = pd.DataFrame(augmentation, columns=["bus0", "bus1"])
     new_network_lines["length"] = new_network_lines.apply(haversine, axis=1)
     new_network_lines.index = new_network_lines.apply(
-        lambda x: f"lines new {x.bus0} <-> {x.bus1}", axis=1
-    )
+        lambda x: f"lines new {x.bus0} <-> {x.bus1}", axis=1)
 
     #  add new lines to the network
     if line_type_option == "HVDC":
@@ -120,8 +123,8 @@ if __name__ == "__main__":
             p_nom_extendable=True,
             p_nom_min=min_expansion_option,
             length=new_network_lines.length,
-            capital_cost=new_network_lines.length
-            * costs.at["HVDC overhead", "capital_cost"],
+            capital_cost=new_network_lines.length *
+            costs.at["HVDC overhead", "capital_cost"],
             carrier="DC",
             lifetime=costs.at["HVDC overhead", "lifetime"],
         )
@@ -136,8 +139,8 @@ if __name__ == "__main__":
             # TODO: Check if minimum value needs to be set.
             s_nom_min=min_expansion_option,
             length=new_network_lines.length,
-            capital_cost=new_network_lines.length
-            * costs.at["HVAC overhead", "capital_cost"],
+            capital_cost=new_network_lines.length *
+            costs.at["HVAC overhead", "capital_cost"],
             carrier="AC",
             lifetime=costs.at["HVAC overhead", "lifetime"],
         )

--- a/scripts/augmented_line_connections.py
+++ b/scripts/augmented_line_connections.py
@@ -33,17 +33,17 @@ import os
 
 import geopandas as gpd
 import matplotlib.pyplot as plt
-import numpy as np
 import networkx as nx
+import numpy as np
 import pandas as pd
 import pyomo.environ as po
 import pypsa
 import shapely
-
-from add_electricity import load_costs
 from _helpers import configure_logging
-from networkx.algorithms.connectivity.edge_augmentation import k_edge_augmentation
+from add_electricity import load_costs
 from networkx.algorithms import complement
+from networkx.algorithms.connectivity.edge_augmentation import \
+    k_edge_augmentation
 from pypsa.geo import haversine_pts
 
 logger = logging.getLogger(__name__)

--- a/scripts/augmented_line_connections.py
+++ b/scripts/augmented_line_connections.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # coding: utf-8
 """
-Makes a network more meshed
+Guarantees that every bus has at least X-number of connections.
 
 Relevant Settings
 -----------------
@@ -34,16 +34,26 @@ import os
 import geopandas as gpd
 import matplotlib.pyplot as plt
 import numpy as np
+import networkx as nx
 import pandas as pd
 import pyomo.environ as po
 import pypsa
 import shapely
+
+from add_electricity import load_costs
 from _helpers import configure_logging
+from networkx.algorithms.connectivity.edge_augmentation import k_edge_augmentation
+from networkx.algorithms import complement
+from pypsa.geo import haversine_pts
 
 logger = logging.getLogger(__name__)
 
 
 ### Functions
+def haversine(p):
+    coord0 = n.buses.loc[p.bus0, ['x', 'y']].values
+    coord1 = n.buses.loc[p.bus1, ['x', 'y']].values
+    return 1.5 * haversine_pts(coord0, coord1)
 
 
 if __name__ == "__main__":
@@ -57,3 +67,69 @@ if __name__ == "__main__":
     configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input.network)
+    Nyears = n.snapshot_weightings.sum().values[0] / 8760.0
+    costs = load_costs(
+        Nyears,
+        snakemake.input.tech_costs,
+        snakemake.config["costs"],
+        snakemake.config["electricity"],
+    )
+    options = snakemake.config["augmented_line_connection"]
+
+    # Make a copy of the original network
+    n0 = pypsa.Network(snakemake.input.network)
+    n0.export_to_netcdf(snakemake.output.network_unmeshed)
+
+    # k_edge algorithm implementation
+    G = nx.Graph()
+
+    network_buses = n.buses.loc[n.buses.carrier=="AC"].index
+    G.add_nodes_from(np.unique(network_buses.values))
+        
+    # TODO: Currently only AC lines are read in and meshed. One need to combine
+    # AC & DC lines and then move on.
+    network_lines =  n.lines
+    sel = network_lines.s_nom > 100  # TODO: Check, should be all selected or filtered?
+    attrs = ["bus0", "bus1", "length"]
+    G.add_weighted_edges_from(network_lines.loc[:, attrs].values)
+
+    # find all complement edges
+    complement_edges = pd.DataFrame(complement(G).edges, columns=["bus0", "bus1"])
+    complement_edges["length"] = complement_edges.apply(haversine, axis=1)
+
+    # apply k_edge_augmentation weighted by length of complement edges
+    k_edge = options.get("connectivity_upgrade", 3)
+    augmentation = k_edge_augmentation(G, k_edge, avail=complement_edges.values)
+    new_network_lines = pd.DataFrame(augmentation, columns=["bus0", "bus1"])
+    new_network_lines["length"] = new_network_lines.apply(haversine, axis=1)
+    new_network_lines.index = new_network_lines.apply(
+            lambda x: f"lines new {x.bus0} <-> {x.bus1}", axis=1)
+
+    #  add new lines to the network
+    if options.get("new_line_type", "HVDC")=="HVDC":
+        n.madd("Link",
+            new_network_lines.index,
+            bus0=new_network_lines.bus0,
+            bus1=new_network_lines.bus1,
+            p_min_pu=-1, # network is bidirectional
+            p_nom_extendable=True,
+            length=new_network_lines.length,
+            capital_cost=new_network_lines.length * costs.at['HVDC overhead', 'capital_cost'],
+            carrier="DC",
+            lifetime=costs.at['HVDC overhead', 'lifetime']
+        )
+
+    if options.get("new_line_type", "HVAC")=="HVAC":
+        n.madd("Line",
+                new_network_lines.index,
+                bus0=new_network_lines.bus0,
+                bus1=new_network_lines.bus1,
+                s_nom_extendable=True,
+                s_nom_min=1,  #  TODO: Check if minimum value needs to be set.
+                length=new_network_lines.length,
+                capital_cost=new_network_lines.length * costs.at['HVAC overhead', 'capital_cost'],
+                carrier="AC",
+                lifetime=costs.at['HVAC overhead', 'lifetime']
+        )
+
+n.export_to_netcdf(snakemake.output.network)

--- a/scripts/augmented_line_connections.py
+++ b/scripts/augmented_line_connections.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: : 2021 The PyPSA-Africa Authors
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+# coding: utf-8
+"""
+Makes a network more meshed
+
+Relevant Settings
+-----------------
+
+.. code:: yaml
+
+
+.. seealso::
+
+
+Inputs
+------
+
+
+Outputs
+-------
+
+
+
+Description
+-----------
+
+
+"""
+import logging
+import os
+
+import geopandas as gpd
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pyomo.environ as po
+import pypsa
+import shapely
+from _helpers import configure_logging
+
+logger = logging.getLogger(__name__)
+
+
+### Functions
+
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        from _helpers import mock_snakemake
+        os.chdir(os.path.dirname(os.path.abspath(__file__)))
+        snakemake = mock_snakemake("augmented_line_connections",
+                                   network="elec",
+                                   simpl="",
+                                   clusters="60")
+    configure_logging(snakemake)
+
+    n = pypsa.Network(snakemake.input.network)

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -29,7 +29,7 @@ countries: ["NG", "BJ"]
   #["ZA"]  # South Africa
 
 augmented_line_connection:
-  connectivity_upgrade: 3  # https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation.html#networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation
+  connectivity_upgrade: 3  # min. lines connection per node, https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation.html#networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation
   new_line_type: "HVDC"  # or "HVAC"
   min_expansion: 1  # [MW]
 

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -31,6 +31,7 @@ countries: ["NG", "BJ"]
 augmented_line_connection:
   connectivity_upgrade: 3  # https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation.html#networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation
   new_line_type: "HVDC"  # or "HVAC"
+  min_expansion: 1  # [MW]
 
 # if True clusters to GADM shapes, if False Voronoi cells will be clustered
 cluster_options:

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -28,6 +28,10 @@ countries: ["NG", "BJ"]
   #["MA"]  # Morroco
   #["ZA"]  # South Africa
 
+augmented_line_connection:
+  connectivity_upgrade: 3  # https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation.html#networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation
+  new_line_type: "HVDC"  # or "HVAC"
+
 # if True clusters to GADM shapes, if False Voronoi cells will be clustered
 cluster_options:
   alternative_clustering: False


### PR DESCRIPTION
Problem:
The African network is not properly meshed. However, one might be interested to see how a well connected African network might look like.

Solution:
This PR aims to take the clustered network and mesh it according to the k-augmentation algorithm (i.e. make sure that every bus has at least two connections). The `augmented_line_connection.py` should thereby host in future also alternative algorithm to mesh/connect the network. This can include Steiner-tree or minimum spanning tree solutions (see initial discussions [here](https://github.com/pypsa-meets-africa/pypsa-africa/discussions/160))

Examples of k-augementation:
Pointed out by @fneum:
- https://github.com/PyPSA/pypsa-eur-sec/blob/82096f92e883fa508631e34a250249e29ad45a60/scripts/prepare_sector_network.py#L1155-L1157
- https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation.html