### PR TITLE
Test environment to solve CI

### DIFF
--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -28,7 +28,7 @@ dependencies:
   - pytables
   - lxml
   - numpy
-  - pandas
+  - pandas <= 1.3.4
   - geopandas
   # - xarray # till the main is not in conda
   - netcdf4


### PR DESCRIPTION
## Changes proposed in this Pull Request

Verify why CI fails and fix the issue.

The recent update of pandas to version 1.4 leads to errors across the workflow.
Limiting it to version 1.3.4 can provide a temporary fix to this problem till the next week, yet we need to adjust in the future.

The main problem arising in simplifying network is due to the line below of function aggregateoneport in [pypsa package](https://github.com/PyPSA/PyPSA):
```new_df = old_df.groupby(grouper).agg(strategies)```
https://github.com/PyPSA/PyPSA/blob/bd6cefb2cd30eec1f9fd44e2d2000fc688069f7a/pypsa/networkclustering.py#L118

In particular, grouper has empty values and that creates problem. This issue has been notified to PyPSA: https://github.com/PyPSA/PyPSA/issues/346

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
