### PR TITLE
Comment out cutout time in config

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -120,7 +120,11 @@ atlite:
       module: era5
       dx: 0.3  # cutout resolution
       dy: 0.3  # cutout resolution
-      time: ["2013", "2013"]  # cutout weather year (~40 years available)
+      # Below customization options are dealt in an automated way depending on
+      # the snapshots and the selected countries. See 'build_cutout.py'
+      # time: ["2013-01-01", "2014-01-01"]  # specify different weather year (~40 years available)
+      # x: [-12., 35.]  # manual set cutout range
+      # y: [33., 72]    # manual set cutout range
 
 
 renewable:

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -75,13 +75,10 @@ enable:
   # prepare_links_p_nom: false
   retrieve_databundle: true
   download_osm_data: true
-  # retrieve_cutout: true
-  # retrieve_natura_raster: true
   # If "build_cutout" : true # requires cds API key https://cds.climate.copernicus.eu/api-how-to
   # More information https://atlite.readthedocs.io/en/latest/introduction.html#datasets
   build_cutout: false
   build_natura_raster: true  # If True, then build_natura_raster can be run
-  # custom_busmap: false
 
 electricity:
   voltages: [220., 300., 380.]
@@ -132,26 +129,13 @@ atlite:
     # module: era5
     africa-2013-era5-tutorial:
       module: era5
-      dx: 0.3
-      dy: 0.3
-      time: ["2013-03", "2013-03"]
-    # europe-2013-era5:
-    #   module: era5 # in priority order
-    #   x: [-12., 35.]
-    #   y: [33., 72]
-    #   dx: 0.3
-    #   dy: 0.3
-    #   time: ["2013", "2013"]
-    # europe-2013-sarah:
-    #   module: [sarah, era5] # in priority order
-    #   x: [-12., 45.]
-    #   y: [33., 65]
-    #   dx: 0.2
-    #   dy: 0.2
-    #   time: ["2013", "2013"]
-    #   sarah_interpolate: false
-    #   sarah_dir:
-    #   features: [influx, temperature]
+      dx: 0.3  # cutout resolution
+      dy: 0.3  # cutout resolution
+      # Below customization options are dealt in an automated way depending on
+      # the snapshots and the selected countries. See 'build_cutout.py'
+      # time: ["2013-01-01", "2014-01-01"]  # specify different weather year (~40 years available)
+      # x: [-12., 35.]  # manual set cutout range
+      # y: [33., 72]    # manual set cutout range
 
 renewable:
   onwind:

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -35,6 +35,8 @@ Upcoming Release
 
 * Add CI caching and windows CI: `Commit CI windows <https://github.com/pypsa-meets-africa/pypsa-africa/commit/c98cb30e828cfda17692b8f5e1dd8e39d33766ad>`__,  `PR #277 <https://github.com/PyPSA/pypsa-eur/pull/277>`__.
 
+* Change config to allow weather year extraction from snapshots as default: `PR #301 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/301>`__. 
+
 
 PyPSA-Africa 0.0.1 (24th December 2021)
 =====================================


### PR DESCRIPTION
When the user specifies a snapshot range and tries to download a
cutout for the range, they often doesn't know that the time range
is taken with priority from the "time" in the atlite part of
the config. By default comment this atlite time specification out,
meaning the snapshot range will be used as cutout range.

Comments are added to the config to help the user understanding
some extra atlite functionalities that can be parsed.

# Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
