### PR TITLE
Fix ci

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -39,6 +39,12 @@ wildcard_constraints:
     opts="[-+a-zA-Z0-9\.]*",
 
 
+rule run_test:
+    run:
+        shell("cp test/config.test1.yaml config.yaml")
+        shell("snakemake --cores all solve_all_networks --forceall")
+
+
 rule solve_all_networks:
     input:
         expand(

--- a/configs/bundle_config.yaml
+++ b/configs/bundle_config.yaml
@@ -57,7 +57,6 @@ databundles:
       gdrive: https://drive.google.com/file/d/1WWVyXHA2E7aGcg_OC1lN8Pb2tA8DgfU0/view?usp=sharing
     output:
     - resources/ssp2-2.6/2030/era5_2013/Africa.nc
-    - resources/natura.tiff
 
   # tutorial bundle specific for Nigeria and Benin only
   bundle_cutouts_tutorial:

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -13,7 +13,7 @@ Upcoming Release
 
 **New Features and major Changes**
 
-
+* Bug fixing (script retrieve_databundle) and rule run_test to ease testing `PR #322 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/322>`__
 
 PyPSA-Africa 0.0.2 (6th April 2022)
 =====================================

--- a/scripts/retrieve_databundle_light.py
+++ b/scripts/retrieve_databundle_light.py
@@ -220,7 +220,7 @@ def download_and_unzip_gdrive(config, rootpath, hot_run=True, disable_progress=F
         with ZipFile(file_path, "r") as zipObj:
             # Extract all the contents of zip file in current directory
             zipObj.extractall(path=config["destination"])
-        
+
         logger.info(f"Download resource '{resource}' from cloud '{url}'.")
 
         return True


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR aims at improving the retrieve_databundle and possibly re-enable the CI in the case sandbox downloader fails.
For easy debugging, the snakemake rule "run_test" is also provided

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
