### PR TITLE
Make clean_osm_data script run with landlocked country

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,63 +116,6 @@ The documentation is available here: [documentation](https://pypsa-meets-africa.
 <table>
 <tr>
     <td align="center">
-        <a href="https://github.com/hazemakhalek">
-            <img src="https://avatars.githubusercontent.com/u/26235356?v=4" width="100;" alt="hazemakhalek"/>
-            <br />
-            <sub><b>hazemakhalek</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/jarry7">
-            <img src="https://avatars.githubusercontent.com/u/27745389?v=4" width="100;" alt="jarry7"/>
-            <br />
-            <sub><b>Jarrad Wright</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/fneum">
-            <img src="https://avatars.githubusercontent.com/u/29101152?v=4" width="100;" alt="fneum"/>
-            <br />
-            <sub><b>Fabian Neumann</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/euronion">
-            <img src="https://avatars.githubusercontent.com/u/42553970?v=4" width="100;" alt="euronion"/>
-            <br />
-            <sub><b>Euronion</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/Justus-coded">
-            <img src="https://avatars.githubusercontent.com/u/44394641?v=4" width="100;" alt="Justus-coded"/>
-            <br />
-            <sub><b>Justus Ilemobayo</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/mnm-matin">
-            <img src="https://avatars.githubusercontent.com/u/45293386?v=4" width="100;" alt="mnm-matin"/>
-            <br />
-            <sub><b>Mnm-matin</b></sub>
-        </a>
-    </td></tr>
-<tr>
-    <td align="center">
-        <a href="https://github.com/desenk">
-            <img src="https://avatars.githubusercontent.com/u/48335263?v=4" width="100;" alt="desenk"/>
-            <br />
-            <sub><b>Desen Kirli</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/LukasFrankenQ">
-            <img src="https://avatars.githubusercontent.com/u/55196140?v=4" width="100;" alt="LukasFrankenQ"/>
-            <br />
-            <sub><b>Lukas Franken</b></sub>
-        </a>
-    </td>
-    <td align="center">
         <a href="https://github.com/pz-max">
             <img src="https://avatars.githubusercontent.com/u/61968949?v=4" width="100;" alt="pz-max"/>
             <br />
@@ -180,53 +123,10 @@ The documentation is available here: [documentation](https://pypsa-meets-africa.
         </a>
     </td>
     <td align="center">
-        <a href="https://github.com/Cesare-Caputo">
-            <img src="https://avatars.githubusercontent.com/u/62548290?v=4" width="100;" alt="Cesare-Caputo"/>
-            <br />
-            <sub><b>Cesare-Caputo</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/Nayara2020">
-            <img src="https://avatars.githubusercontent.com/u/64689686?v=4" width="100;" alt="Nayara2020"/>
-            <br />
-            <sub><b>Nayara2020</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/Ay-Khi">
-            <img src="https://avatars.githubusercontent.com/u/65019030?v=4" width="100;" alt="Ay-Khi"/>
-            <br />
-            <sub><b>Ayman Alkhirbash</b></sub>
-        </a>
-    </td></tr>
-<tr>
-    <td align="center">
         <a href="https://github.com/davide-f">
             <img src="https://avatars.githubusercontent.com/u/67809479?v=4" width="100;" alt="davide-f"/>
             <br />
             <sub><b>Davide-f</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/koen-vg">
-            <img src="https://avatars.githubusercontent.com/u/74298901?v=4" width="100;" alt="koen-vg"/>
-            <br />
-            <sub><b>Koen Van Greevenbroek</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/Hazem-IEG">
-            <img src="https://avatars.githubusercontent.com/u/87850910?v=4" width="100;" alt="Hazem-IEG"/>
-            <br />
-            <sub><b>Hazem-IEG</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/energyLS">
-            <img src="https://avatars.githubusercontent.com/u/89515385?v=4" width="100;" alt="energyLS"/>
-            <br />
-            <sub><b>energyLS</b></sub>
         </a>
     </td>
     <td align="center">
@@ -242,13 +142,41 @@ The documentation is available here: [documentation](https://pypsa-meets-africa.
             <br />
             <sub><b>Ekaterina</b></sub>
         </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/mnm-matin">
+            <img src="https://avatars.githubusercontent.com/u/45293386?v=4" width="100;" alt="mnm-matin"/>
+            <br />
+            <sub><b>Mnm-matin</b></sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/Hazem-IEG">
+            <img src="https://avatars.githubusercontent.com/u/87850910?v=4" width="100;" alt="Hazem-IEG"/>
+            <br />
+            <sub><b>Hazem-IEG</b></sub>
+        </a>
     </td></tr>
 <tr>
+    <td align="center">
+        <a href="https://github.com/euronion">
+            <img src="https://avatars.githubusercontent.com/u/42553970?v=4" width="100;" alt="euronion"/>
+            <br />
+            <sub><b>Euronion</b></sub>
+        </a>
+    </td>
     <td align="center">
         <a href="https://github.com/giacfalk">
             <img src="https://avatars.githubusercontent.com/u/36954873?v=4" width="100;" alt="giacfalk"/>
             <br />
             <sub><b>Giacomo Falchetta</b></sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/LukasFrankenQ">
+            <img src="https://avatars.githubusercontent.com/u/55196140?v=4" width="100;" alt="LukasFrankenQ"/>
+            <br />
+            <sub><b>Lukas Franken</b></sub>
         </a>
     </td>
     <td align="center">
@@ -258,6 +186,21 @@ The documentation is available here: [documentation](https://pypsa-meets-africa.
             <sub><b>Jarrad Wright</b></sub>
         </a>
     </td>
+    <td align="center">
+        <a href="https://github.com/koen-vg">
+            <img src="https://avatars.githubusercontent.com/u/74298901?v=4" width="100;" alt="koen-vg"/>
+            <br />
+            <sub><b>Koen Van Greevenbroek</b></sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/jarry7">
+            <img src="https://avatars.githubusercontent.com/u/27745389?v=4" width="100;" alt="jarry7"/>
+            <br />
+            <sub><b>Jarrad Wright</b></sub>
+        </a>
+    </td></tr>
+<tr>
     <td align="center">
         <a href="https://github.com/EmreYorat">
             <img src="https://avatars.githubusercontent.com/u/93644024?v=4" width="100;" alt="EmreYorat"/>

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -19,7 +19,9 @@ Upcoming Release
 
 * General user experience improvements: `PR #326 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/326>`__
 
-* Fix minor validation notebook inaccuracy:  `PR #332 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/332>`__ 
+* Fix minor validation notebook inaccuracy:  `PR #332 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/332>`__
+
+* Make clean_osm_data script work with land-locked country: `PR #341 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/341>`_
 
 
 PyPSA-Africa 0.0.2 (6th April 2022)

--- a/scripts/clean_osm_data.py
+++ b/scripts/clean_osm_data.py
@@ -288,7 +288,7 @@ def split_cells_multiple(df, list_col=["cables", "circuits", "voltage"]):
                 df.loc[i, list_col[1]] = d[1][0]
                 r[list_col[0]] = d[0][1]  # second split [1]
                 r[list_col[1]] = d[1][1]
-                df = pd.concat([df,r])
+                df = pd.concat([df, r])
 
     # if some columns still contain ";" then sum the values
     for cl_name in list_col:
@@ -759,7 +759,7 @@ if __name__ == "__main__":
             gpd.read_file(onshore_shape_path)
             .set_index("name")["geometry"]
             .set_crs(4326)
-        )   
+        )
 
     if os.stat(offshore_shape_path).st_size == 0:
         logger.info("No offshore file exist. Passing only onshore shape")

--- a/scripts/clean_osm_data.py
+++ b/scripts/clean_osm_data.py
@@ -97,7 +97,7 @@ def add_line_endings_tosubstations(substations, lines):
     bus_e["lat"] = bus_e["geometry"].map(lambda p: p.y if p != None else None)
     bus_e["bus_id"] = bus_s["bus_id"].max() + 1 + bus_e.index
 
-    bus_all = bus_s.append(bus_e).reset_index(drop=True)
+    bus_all = pd.concat([bus_s, bus_e], ignore_index=True)
 
     # Add NaN as default
     bus_all["station_id"] = np.nan
@@ -109,7 +109,7 @@ def add_line_endings_tosubstations(substations, lines):
     # TODO: this tag may be improved, maybe depending on voltage levels
     bus_all["tag_substation"] = "transmission"
 
-    buses = substations.append(bus_all).reset_index(drop=True)
+    buses = pd.concat([substations, bus_all], ignore_index=True)
 
     # Assign index to bus_id
     buses.loc[:, "bus_id"] = buses.index
@@ -288,7 +288,7 @@ def split_cells_multiple(df, list_col=["cables", "circuits", "voltage"]):
                 df.loc[i, list_col[1]] = d[1][0]
                 r[list_col[0]] = d[0][1]  # second split [1]
                 r[list_col[1]] = d[1][1]
-                df = df.append(r)
+                df = pd.concat([df,r])
 
     # if some columns still contain ";" then sum the values
     for cl_name in list_col:

--- a/scripts/clean_osm_data.py
+++ b/scripts/clean_osm_data.py
@@ -743,6 +743,8 @@ if __name__ == "__main__":
     threshold_voltage = snakemake.config["clean_osm_data_options"]["threshold_voltage"]
     names_by_shapes = snakemake.config["clean_osm_data_options"]["names_by_shapes"]
     add_line_endings = snakemake.config["clean_osm_data_options"]["add_line_endings"]
+    offshore_shape_path = snakemake.input.offshore_shapes
+    onshore_shape_path = snakemake.input.country_shapes
 
     input_files = snakemake.input
     output_files = snakemake.output
@@ -754,20 +756,25 @@ if __name__ == "__main__":
     # only when country names are defined by shapes, load the info
     if names_by_shapes:
         country_shapes = (
-            gpd.read_file(snakemake.input.country_shapes)
+            gpd.read_file(onshore_shape_path)
             .set_index("name")["geometry"]
             .set_crs(4326)
-        )
+        )   
+
+    if os.stat(offshore_shape_path).st_size == 0:
+        logger.info("No offshore file exist. Passing only onshore shape")
+        ext_country_shapes = country_shapes
+
+    else:
+        logger.info("Combining on- and offshore shape")
         offshore_shapes = (
-            gpd.read_file(snakemake.input.offshore_shapes)
+            gpd.read_file(offshore_shape_path)
             .set_index("name")["geometry"]
             .set_crs(4326)
         )
         ext_country_shapes = create_extended_country_shapes(
             country_shapes, offshore_shapes
         )
-    else:
-        ext_country_shapes = None
 
     clean_data(
         input_files,


### PR DESCRIPTION
# Closes #340

## Changes proposed in this Pull Request
- Pass only onshore shape if the offshore shape does not exist. Note. Landlock countries might cause later scripts issues, hence, this fix is only valid for the `clean_osm_data` script.
- Change append to concat functions
- Read snakemake input at the beginning of script execution

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
