### PR TITLE
Make cutout workflow simpler

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -253,8 +253,8 @@ if config["enable"].get("build_cutout", False):
 
     rule build_cutout:
         input:
-            regions_onshore="resources/regions_onshore.geojson",
-            regions_offshore="resources/regions_offshore.geojson",
+            onshore_shapes="resources/country_shapes.geojson",
+            offshore_shapes="resources/offshore_shapes.geojson",
         output:
             "cutouts/{cutout}.nc",
         log:

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -39,6 +39,8 @@ Upcoming Release
 
 * Add renewable potential notebook `PR #351 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/351>`
 
+* Make cutout workflow simpler `PR #352 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/352>`
+
 
 PyPSA-Africa 0.0.2 (6th April 2022)
 =====================================

--- a/scripts/build_cutout.py
+++ b/scripts/build_cutout.py
@@ -116,7 +116,6 @@ if __name__ == "__main__":
     onshore_shapes = snakemake.input.onshore_shapes
     offshore_shapes = snakemake.input.offshore_shapes
 
-
     # If one of the parameters is there
     if {"x", "y", "bounds"}.isdisjoint(cutout_params):
         # Determine the bounds from bus regions with a buffer of two grid cells

--- a/scripts/build_cutout.py
+++ b/scripts/build_cutout.py
@@ -110,16 +110,18 @@ if __name__ == "__main__":
     configure_logging(snakemake)
 
     cutout_params = snakemake.config["atlite"]["cutouts"][snakemake.wildcards.cutout]
-
     snapshots = pd.date_range(freq="h", **snakemake.config["snapshots"])
     time = [snapshots[0], snapshots[-1]]
     cutout_params["time"] = slice(*cutout_params.get("time", time))
+    onshore_shapes = snakemake.input.onshore_shapes
+    offshore_shapes = snakemake.input.offshore_shapes
+
 
     # If one of the parameters is there
     if {"x", "y", "bounds"}.isdisjoint(cutout_params):
         # Determine the bounds from bus regions with a buffer of two grid cells
-        onshore = gpd.read_file(snakemake.input.regions_onshore)
-        offshore = gpd.read_file(snakemake.input.regions_offshore)
+        onshore = gpd.read_file(onshore_shapes)
+        offshore = gpd.read_file(offshore_shapes)
         regions = onshore.append(offshore)
         d = max(cutout_params.get("dx", 0.25), cutout_params.get("dy", 0.25)) * 2
         cutout_params["bounds"] = regions.total_bounds + [-d, -d, d, d]


### PR DESCRIPTION
## Changes proposed in this Pull Request

We are building at the moment the cutout with `resources/regions_onshore.geojson` and the `resources/regions_offshore.geojson`. Producing these shapes can be cumbersome since they are built from the network infrastructure. 
![image](https://user-images.githubusercontent.com/61968949/170873058-6887d0f7-2a65-43c8-8e04-a7445725f148.png)


This PR suggest using simply the country and offshore shapes. This helps to produce the cutouts much faster without any error potential in between.
![image](https://user-images.githubusercontent.com/61968949/170873020-24eb282a-1f98-4ff3-a25d-2976b42a72a7.png)

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.