### PR TITLE
add false as option for pop and gdp

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -54,7 +54,8 @@ build_shape_options:
   out_logging: true    # When true, logging is printed to console
   year: 2020    # reference year used to derive shapes, info on population and info on GDP
   nprocesses: 5    # number of processes to be used in build_shapes
-  worldpop_method: "standard" # "api" pulls from API 100mx100m raster."standard" pulls from web 1kmx1km raster.
+  worldpop_method: "standard"  # "standard" pulls from web 1kmx1km raster, "api" pulls from API 100mx100m raster, false (not "false") no pop addition to shape which is useful when generating only cutout
+  gdp_method: "standard"  # "standard" pulls from web 1x1km raster, false (not "false") no gdp addition to shape which useful when generating only cutout
 
 
 clean_osm_data_options:  # osm = OpenStreetMap

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -47,7 +47,8 @@ build_shape_options:
   out_logging: true    # When true, logging is printed to console
   year: 2020    # reference year used to derive shapes, info on population and info on GDP
   nprocesses: 5    # number of processes to be used in build_shapes
-  worldpop_method: "standard" # "api" pulls from API 100mx100m raster."standard" pulls from web 1kmx1km raster.
+  worldpop_method: "standard"  # "standard" pulls from web 1kmx1km raster, "api" pulls from API 100mx100m raster, false (not "false") no pop addition to shape which is useful when generating only cutout
+  gdp_method: "standard"  # "standard" pulls from web 1x1km raster, false (not "false") no gdp addition to shape which useful when generating only cutout
 
 clean_osm_data_options:
   names_by_shapes: true  # Set the country name based on the extended country shapes

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -35,11 +35,13 @@ Upcoming Release
 
 * Add new countries and update iso code: `PR #330 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/330>`_
 
-* Fix solar pv slope and add correction factor for wake losses `PR #335 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/350>`
+* Fix solar pv slope and add correction factor for wake losses `PR #335 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/350>`_
 
-* Add renewable potential notebook `PR #351 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/351>`
+* Add renewable potential notebook `PR #351 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/351>`_
 
-* Make cutout workflow simpler `PR #352 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/352>`
+* Make cutout workflow simpler `PR #352 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/352>`_
+
+* Add option to run workflow without pop and gdp raster `PR #353 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/353>`_
 
 
 PyPSA-Africa 0.0.2 (6th April 2022)

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -740,6 +740,7 @@ def add_population_data(
 
 def gadm(
     worldpop_method,
+    gdp_method,
     countries,
     layer_id=2,
     update=False,
@@ -764,25 +765,27 @@ def gadm(
         inplace=True,
     )
 
-    # add the population data to the dataset
-    add_population_data(
-        df_gadm,
-        countries,
-        worldpop_method,
-        year,
-        update,
-        out_logging,
-        nprocesses=nprocesses,
-    )
+    if worldpop_method != False:
+        # add the population data to the dataset
+        add_population_data(
+            df_gadm,
+            countries,
+            worldpop_method,
+            year,
+            update,
+            out_logging,
+            nprocesses=nprocesses,
+        )
 
-    # add the gdp data to the dataset
-    add_gdp_data(
-        df_gadm,
-        year,
-        update,
-        out_logging,
-        name_file_nc="GDP_PPP_1990_2015_5arcmin_v2.nc",
-    )
+    if gdp_method != False:
+        # add the gdp data to the dataset
+        add_gdp_data(
+            df_gadm,
+            year,
+            update,
+            out_logging,
+            name_file_nc="GDP_PPP_1990_2015_5arcmin_v2.nc",
+        )
 
     # set index and simplify polygons
     df_gadm.set_index("GADM_ID", inplace=True)
@@ -810,6 +813,7 @@ if __name__ == "__main__":
     nprocesses = snakemake.config["build_shape_options"]["nprocesses"]
     EEZ_gpkg = snakemake.input["eez"]
     worldpop_method = snakemake.config["build_shape_options"]["worldpop_method"]
+    gdp_method = snakemake.config["build_shape_options"]["gdp_method"]
 
     country_shapes = countries(countries_list, update, out_logging)
     save_to_geojson(country_shapes, out.country_shapes)
@@ -822,6 +826,7 @@ if __name__ == "__main__":
 
     gadm_shapes = gadm(
         worldpop_method,
+        gdp_method,
         countries_list,
         layer_id,
         update,

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -51,7 +51,8 @@ build_shape_options:
   out_logging: true    # When true, logging is printed to console
   year: 2020    # reference year used to derive shapes, info on population and info on GDP
   nprocesses: 5    # number of processes to be used in build_shapes
-  worldpop_method: "standard" # "api" pulls from API 100mx100m raster."standard" pulls from web 1kmx1km raster.
+  worldpop_method: "standard"  # "standard" pulls from web 1kmx1km raster, "api" pulls from API 100mx100m raster, false (not "false") no pop addition to shape which is useful when generating only cutout
+  gdp_method: "standard"  # "standard" pulls from web 1x1km raster, false (not "false") no gdp addition to shape which useful when generating only cutout
 
 
 clean_osm_data_options:


### PR DESCRIPTION
## Problem
Running only the cutout is sometimes desirable. However, to build the shapes, gdp and population raster were always added which can take hours to compute e.g. for Africa. 

## Changes proposed in this Pull Request
This PR adds another option to build_shapes called **false** which does not add the given raster to the shape.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
