### PR TITLE
Harmonize CRS in the workflow

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -37,8 +37,9 @@ enable:
 
 # definition of the Coordinate Reference Systems
 crs:
-  default_crs: EPSG:4326  # general geographic projection, not used for metric measures. "EPSG:4326" is the standard used by OSM and google maps
-  metric_crs: EPSG:3857  # projection for metric measures only. Possible recommended values are "EPSG:3857" (used by OSM and Google Maps) or also Global Mollweide "ESRI:54009"
+  geo_crs: EPSG:4326  # general geographic projection, not used for metric measures. "EPSG:4326" is the standard used by OSM and google maps
+  distance_crs: EPSG:3857  # projection for distance measurements only. Possible recommended values are "EPSG:3857" (used by OSM and Google Maps)
+  area_crs: ESRI:54009  # projection for area measurements only. Possible recommended values are Global Mollweide "ESRI:54009"
 
 # download_osm_data_nprocesses: 10  # (optional) number of threads used to download osm data
 

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -24,7 +24,7 @@ summary_dir: results
 snapshots:
   start: "2013-01-01"
   end: "2014-01-01"
-  closed: "left" # end is not inclusive
+  inclusive: "left" # end is not inclusive
 
 enable:
   retrieve_databundle: true  #  Recommended 'true', for the first run. Otherwise data might be missing.

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -35,6 +35,11 @@ enable:
   # requires cds API key https://cds.climate.copernicus.eu/api-how-to
   # More information https://atlite.readthedocs.io/en/latest/introduction.html#datasets
 
+# definition of the Coordinate Reference Systems
+crs:
+  default_crs: EPSG:4326  # general geographic projection, not used for metric measures
+  metric_crs: EPSG:3085  # projection for metric measures only
+
 # download_osm_data_nprocesses: 10  # (optional) number of threads used to download osm data
 
 augmented_line_connection:

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -37,8 +37,8 @@ enable:
 
 # definition of the Coordinate Reference Systems
 crs:
-  default_crs: EPSG:4326  # general geographic projection, not used for metric measures
-  metric_crs: EPSG:3085  # projection for metric measures only
+  default_crs: EPSG:4326  # general geographic projection, not used for metric measures. "EPSG:4326" is the standard used by OSM and google maps
+  metric_crs: EPSG:3857  # projection for metric measures only. Possible recommended values are "EPSG:3857" (used by OSM and Google Maps) or also Global Mollweide "ESRI:54009"
 
 # download_osm_data_nprocesses: 10  # (optional) number of threads used to download osm data
 

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -93,8 +93,9 @@ enable:
 
 # definition of the Coordinate Reference Systems
 crs:
-  default_crs: EPSG:4326  # general geographic projection, not used for metric measures. "EPSG:4326" is the standard used by OSM and google maps
-  metric_crs: EPSG:3857  # projection for metric measures only. Possible recommended values are "EPSG:3857" (used by OSM and Google Maps) or also Global Mollweide "ESRI:54009"
+  geo_crs: EPSG:4326  # general geographic projection, not used for metric measures. "EPSG:4326" is the standard used by OSM and google maps
+  distance_crs: EPSG:3857  # projection for distance measurements only. Possible recommended values are "EPSG:3857" (used by OSM and Google Maps)
+  area_crs: ESRI:54009  # projection for area measurements only. Possible recommended values are Global Mollweide "ESRI:54009"
 
 electricity:
   voltages: [220., 300., 380.]

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -93,8 +93,8 @@ enable:
 
 # definition of the Coordinate Reference Systems
 crs:
-  default_crs: EPSG:4326  # general geographic projection, not used for metric measures
-  metric_crs: EPSG:3085  # projection for metric measures only
+  default_crs: EPSG:4326  # general geographic projection, not used for metric measures. "EPSG:4326" is the standard used by OSM and google maps
+  metric_crs: EPSG:3857  # projection for metric measures only. Possible recommended values are "EPSG:3857" (used by OSM and Google Maps) or also Global Mollweide "ESRI:54009"
 
 electricity:
   voltages: [220., 300., 380.]

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -91,6 +91,11 @@ enable:
   build_cutout: false
   build_natura_raster: true  # If True, then build_natura_raster can be run
 
+# definition of the Coordinate Reference Systems
+crs:
+  default_crs: EPSG:4326  # general geographic projection, not used for metric measures
+  metric_crs: EPSG:3085  # projection for metric measures only
+
 electricity:
   voltages: [220., 300., 380.]
   co2limit: 7.75e+7 # 0.05 * 3.1e9*0.5

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -80,7 +80,7 @@ summary_dir: results
 snapshots:
   start: "2013-03-1"
   end: "2013-03-14"
-  closed: "left" # end is not inclusive
+  inclusive: "left" # end is not inclusive
 
 enable:
   # prepare_links_p_nom: false

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -43,6 +43,8 @@ Upcoming Release
 
 * Add option to run workflow without pop and gdp raster `PR #353 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/353>`_
 
+* Harmonize CRSs by options `PR #356 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/356>`_
+
 
 PyPSA-Africa 0.0.2 (6th April 2022)
 =====================================

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -223,7 +223,9 @@ def _set_countries_and_substations(n):
 
     bus_locations = buses
     bus_locations = gpd.GeoDataFrame(
-        bus_locations, geometry=gpd.points_from_xy(bus_locations.x, bus_locations.y)
+        bus_locations,
+        geometry=gpd.points_from_xy(bus_locations.x, bus_locations.y),
+        crs=buses.crs,
     )
     # Check if bus is in shape
     offshore_b = bus_locations.within(offshore_shapes)

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -214,20 +214,16 @@ def _set_countries_and_substations(n):
     buses = n.buses
 
     countries = snakemake.config["countries"]
-    country_shapes = (
-        gpd.read_file(snakemake.input.country_shapes)
-        .set_index("name")["geometry"]
-        .set_crs(4326)
-    )
+    country_shapes = gpd.read_file(snakemake.input.country_shapes).set_index("name")[
+        "geometry"
+    ]
     offshore_shapes = unary_union(
-        gpd.read_file(snakemake.input.offshore_shapes)["geometry"].set_crs(4326)
+        gpd.read_file(snakemake.input.offshore_shapes)["geometry"]
     )
 
     bus_locations = buses
     bus_locations = gpd.GeoDataFrame(
-        bus_locations,
-        geometry=gpd.points_from_xy(bus_locations.x, bus_locations.y),
-        crs=4326,
+        bus_locations, geometry=gpd.points_from_xy(bus_locations.x, bus_locations.y)
     )
     # Check if bus is in shape
     offshore_b = bus_locations.within(offshore_shapes)

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -225,7 +225,7 @@ def _set_countries_and_substations(n):
     bus_locations = gpd.GeoDataFrame(
         bus_locations,
         geometry=gpd.points_from_xy(bus_locations.x, bus_locations.y),
-        crs=buses.crs,
+        crs=country_shapes.crs,  # the workflow sets the the same crs for buses and shapes
     )
     # Check if bus is in shape
     offshore_b = bus_locations.within(offshore_shapes)

--- a/scripts/build_natura_raster.py
+++ b/scripts/build_natura_raster.py
@@ -201,7 +201,7 @@ if __name__ == "__main__":
         dtype=rio.uint8,
         count=1,
         transform=transform,
-        crs=3035,
+        crs=metric_crs,
         compress="lzw",
         width=raster.shape[1],
         height=raster.shape[0],

--- a/scripts/build_natura_raster.py
+++ b/scripts/build_natura_raster.py
@@ -90,7 +90,7 @@ def determine_cutout_xXyY(cutout_name, out_logging):
     if out_logging:
         _logger.info("Stage 1/5: Determine cutout boundaries")
     cutout = atlite.Cutout(cutout_name)
-    assert cutout.crs.to_epsg() == CUTOUT_CRS
+    assert cutout.crs == CUTOUT_CRS
     x, X, y, Y = cutout.extent
     dx, dy = cutout.dx, cutout.dy
     return [x - dx / 2.0, X + dx / 2.0, y - dy / 2.0, Y + dy / 2.0]

--- a/scripts/build_natura_raster.py
+++ b/scripts/build_natura_raster.py
@@ -106,7 +106,7 @@ def get_transform_and_shape(bounds, res, out_logging):
     return transform, shape
 
 
-def unify_protected_shape_areas(inputs, crs, out_logging):
+def unify_protected_shape_areas(inputs, area_crs, out_logging):
     """
     Iterates thorugh all snakemake rule inputs and unifies shapefiles (.shp) only.
 
@@ -135,13 +135,13 @@ def unify_protected_shape_areas(inputs, crs, out_logging):
     for i in shp_files:
         shape = gpd.GeoDataFrame(
             pd.concat([gpd.read_file(i) for i in shp_files])
-        ).to_crs(crs)
+        ).to_crs(area_crs)
 
     # Removes shapely geometry with null values. Returns geoseries.
     shape = shape["geometry"][shape["geometry"].is_valid]
 
     # Create Geodataframe with crs
-    shape = gpd.GeoDataFrame(shape, crs=crs)
+    shape = gpd.GeoDataFrame(shape, crs=area_crs)
     shape = shape.rename(columns={0: "geometry"}).set_geometry("geometry")
 
     # Unary_union makes out of i.e. 1000 shapes -> 1 unified shape
@@ -152,7 +152,7 @@ def unify_protected_shape_areas(inputs, crs, out_logging):
         _logger.info(
             "Stage 3/5: Unify protected shape area. Step 3: Set geometry of unified shape"
         )
-    unified_shape = gpd.GeoDataFrame(geometry=[unified_shape_file], crs=crs)
+    unified_shape = gpd.GeoDataFrame(geometry=[unified_shape_file], crs=area_crs)
 
     return unified_shape
 

--- a/scripts/build_natura_raster.py
+++ b/scripts/build_natura_raster.py
@@ -166,8 +166,7 @@ if __name__ == "__main__":
     configure_logging(snakemake)
 
     # get crs
-    default_crs = snakemake.config["crs"]["default_crs"]
-    metric_crs = snakemake.config["crs"]["metric_crs"]
+    area_crs = snakemake.config["crs"]["area_crs"]
 
     out_logging = True
     inputs = snakemake.input
@@ -176,16 +175,12 @@ if __name__ == "__main__":
     xs, Xs, ys, Ys = zip(
         *(determine_cutout_xXyY(cutout, out_logging=out_logging) for cutout in cutouts)
     )
-    bounds = transform_bounds(
-        CUTOUT_CRS, metric_crs, min(xs), min(ys), max(Xs), max(Ys)
-    )
+    bounds = transform_bounds(CUTOUT_CRS, area_crs, min(xs), min(ys), max(Xs), max(Ys))
     transform, out_shape = get_transform_and_shape(
         bounds, res=100, out_logging=out_logging
     )
     # adjusted boundaries
-    shapes = unify_protected_shape_areas(
-        shapefiles, metric_crs, out_logging=out_logging
-    )
+    shapes = unify_protected_shape_areas(shapefiles, area_crs, out_logging=out_logging)
 
     if out_logging:
         _logger.info("Stage 4/5: Mask geometry")
@@ -201,7 +196,7 @@ if __name__ == "__main__":
         dtype=rio.uint8,
         count=1,
         transform=transform,
-        crs=metric_crs,
+        crs=area_crs,
         compress="lzw",
         width=raster.shape[1],
         height=raster.shape[0],

--- a/scripts/build_natura_raster.py
+++ b/scripts/build_natura_raster.py
@@ -62,6 +62,8 @@ from rasterio.warp import transform_bounds
 _logger = logging.getLogger(__name__)
 _logger.setLevel(logging.INFO)
 
+CUTOUT_CRS = "EPSG:4326"
+
 
 def get_fileshapes(list_paths, accepted_formats=(".shp",)):
     "Function to parse the list of paths to include shapes included in folders, if any"
@@ -88,7 +90,7 @@ def determine_cutout_xXyY(cutout_name, out_logging):
     if out_logging:
         _logger.info("Stage 1/5: Determine cutout boundaries")
     cutout = atlite.Cutout(cutout_name)
-    assert cutout.crs.to_epsg() == 4326
+    assert cutout.crs.to_epsg() == CUTOUT_CRS
     x, X, y, Y = cutout.extent
     dx, dy = cutout.dx, cutout.dy
     return [x - dx / 2.0, X + dx / 2.0, y - dy / 2.0, Y + dy / 2.0]
@@ -104,7 +106,7 @@ def get_transform_and_shape(bounds, res, out_logging):
     return transform, shape
 
 
-def unify_protected_shape_areas(inputs, out_logging):
+def unify_protected_shape_areas(inputs, crs, out_logging):
     """
     Iterates thorugh all snakemake rule inputs and unifies shapefiles (.shp) only.
 
@@ -113,7 +115,7 @@ def unify_protected_shape_areas(inputs, out_logging):
 
     Returns
     -------
-    unified_shape : GeoDataFrame with a unified "multishape" (crs=3035)
+    unified_shape : GeoDataFrame with a unified "multishape"
 
     """
     import pandas as pd
@@ -133,16 +135,14 @@ def unify_protected_shape_areas(inputs, out_logging):
     for i in shp_files:
         shape = gpd.GeoDataFrame(
             pd.concat([gpd.read_file(i) for i in shp_files])
-        ).to_crs(3035)
+        ).to_crs(crs)
 
     # Removes shapely geometry with null values. Returns geoseries.
     shape = shape["geometry"][shape["geometry"].is_valid]
 
-    # Create Geodataframe with crs(3035)
-    shape = gpd.GeoDataFrame(shape)
-    shape = shape.rename(columns={0: "geometry"}).set_geometry(
-        "geometry"
-    )  # .set_crs(3035)
+    # Create Geodataframe with crs
+    shape = gpd.GeoDataFrame(shape, crs=crs)
+    shape = shape.rename(columns={0: "geometry"}).set_geometry("geometry")
 
     # Unary_union makes out of i.e. 1000 shapes -> 1 unified shape
     if out_logging:
@@ -152,7 +152,7 @@ def unify_protected_shape_areas(inputs, out_logging):
         _logger.info(
             "Stage 3/5: Unify protected shape area. Step 3: Set geometry of unified shape"
         )
-    unified_shape = gpd.GeoDataFrame(geometry=[unified_shape_file]).set_crs(3035)
+    unified_shape = gpd.GeoDataFrame(geometry=[unified_shape_file], crs=crs)
 
     return unified_shape
 
@@ -165,6 +165,10 @@ if __name__ == "__main__":
         snakemake = mock_snakemake("build_natura_raster")
     configure_logging(snakemake)
 
+    # get crs
+    default_crs = snakemake.config["crs"]["default_crs"]
+    metric_crs = snakemake.config["crs"]["metric_crs"]
+
     out_logging = True
     inputs = snakemake.input
     cutouts = inputs.cutouts
@@ -172,12 +176,16 @@ if __name__ == "__main__":
     xs, Xs, ys, Ys = zip(
         *(determine_cutout_xXyY(cutout, out_logging=out_logging) for cutout in cutouts)
     )
-    bounds = transform_bounds(4326, 3035, min(xs), min(ys), max(Xs), max(Ys))
+    bounds = transform_bounds(
+        CUTOUT_CRS, metric_crs, min(xs), min(ys), max(Xs), max(Ys)
+    )
     transform, out_shape = get_transform_and_shape(
         bounds, res=100, out_logging=out_logging
     )
     # adjusted boundaries
-    shapes = unify_protected_shape_areas(shapefiles, out_logging=out_logging)
+    shapes = unify_protected_shape_areas(
+        shapefiles, metric_crs, out_logging=out_logging
+    )
 
     if out_logging:
         _logger.info("Stage 4/5: Mask geometry")

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -213,7 +213,7 @@ if __name__ == "__main__":
         from _helpers import mock_snakemake
 
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
-        snakemake = mock_snakemake("build_renewable_profiles", technology="hydro")
+        snakemake = mock_snakemake("build_renewable_profiles", technology="onwind")
         sets_path_to_root("pypsa-africa")
     configure_logging(snakemake)
 
@@ -226,7 +226,7 @@ if __name__ == "__main__":
     correction_factor = config.get("correction_factor", 1.0)
     p_nom_max_meth = config.get("potential", "conservative")
     default_crs = snakemake.config["crs"]["default_crs"]
-    metric_crs = snakemake.config["crs"]["metric_crs"]
+    metric_crs = "EPSG:3035"  # snakemake.config["crs"]["metric_crs"]  # BUG when 3857 is selected!!!
 
     if isinstance(config.get("copernicus", {}), list):
         config["copernicus"] = {"grid_codes": config["copernicus"]}

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -225,8 +225,8 @@ if __name__ == "__main__":
     resource = config["resource"]
     correction_factor = config.get("correction_factor", 1.0)
     p_nom_max_meth = config.get("potential", "conservative")
-    default_crs = snakemake.config["crs"]["default_crs"]
-    metric_crs = snakemake.config["crs"]["metric_crs"]
+    geo_crs = snakemake.config["crs"]["geo_crs"]
+    area_crs = snakemake.config["crs"]["area_crs"]
 
     if isinstance(config.get("copernicus", {}), list):
         config["copernicus"] = {"grid_codes": config["copernicus"]}
@@ -297,7 +297,7 @@ if __name__ == "__main__":
 
         capacity_per_sqkm = config["capacity_per_sqkm"]
 
-        excluder = atlite.ExclusionContainer(crs=metric_crs, res=100)
+        excluder = atlite.ExclusionContainer(crs=area_crs, res=100)
 
         if "natura" in config and config["natura"]:
             excluder.add_raster(paths.natura, nodata=0, allow_no_overlap=True)
@@ -345,7 +345,7 @@ if __name__ == "__main__":
         else:
             availability = cutout.availabilitymatrix(regions, excluder, **kwargs)
 
-        area = cutout.grid.to_crs(metric_crs).area / 1e6
+        area = cutout.grid.to_crs(area_crs).area / 1e6
         area = xr.DataArray(
             area.values.reshape(cutout.shape), [cutout.coords["y"], cutout.coords["x"]]
         )

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -226,7 +226,7 @@ if __name__ == "__main__":
     correction_factor = config.get("correction_factor", 1.0)
     p_nom_max_meth = config.get("potential", "conservative")
     default_crs = snakemake.config["crs"]["default_crs"]
-    metric_crs = "EPSG:3035"  # snakemake.config["crs"]["metric_crs"]  # BUG when 3857 is selected!!!
+    metric_crs = snakemake.config["crs"]["metric_crs"]
 
     if isinstance(config.get("copernicus", {}), list):
         config["copernicus"] = {"grid_codes": config["copernicus"]}

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -37,6 +37,8 @@ _logger.setLevel(logging.INFO)
 
 sets_path_to_root("pypsa-africa")
 
+EEZ_CRS = "EPSG:4326"
+
 
 def download_GADM(country_code, update=False, out_logging=False):
     """
@@ -94,7 +96,7 @@ def download_GADM(country_code, update=False, out_logging=False):
     return GADM_inputfile_gpkg, GADM_filename
 
 
-def get_GADM_layer(country_list, layer_id, update=False, outlogging=False):
+def get_GADM_layer(country_list, layer_id, crs, update=False, outlogging=False):
     """
     Function to retrive a specific layer id of a geopackage for a selection of countries
 
@@ -128,7 +130,7 @@ def get_GADM_layer(country_list, layer_id, update=False, outlogging=False):
         )
 
         # read gpkg file
-        geodf_temp = gpd.read_file(file_gpkg, layer=layer_name)
+        geodf_temp = gpd.read_file(file_gpkg, layer=layer_name).to_crs(crs)
 
         # convert country name representation of the main country (GID_0 column)
         geodf_temp["GID_0"] = [
@@ -143,7 +145,7 @@ def get_GADM_layer(country_list, layer_id, update=False, outlogging=False):
         geodf_list.append(geodf_temp)
 
     geodf_GADM = gpd.GeoDataFrame(pd.concat(geodf_list, ignore_index=True))
-    geodf_GADM.set_crs(geodf_list[0].crs, inplace=True)
+    geodf_GADM.set_crs(crs)
 
     return geodf_GADM
 
@@ -167,14 +169,14 @@ def _simplify_polys(polys, minarea=0.0001, tolerance=0.008, filterremote=False):
     return polys.simplify(tolerance=tolerance)
 
 
-def countries(countries, update=False, out_logging=False):
+def countries(countries, crs, update=False, out_logging=False):
     "Create country shapes"
 
     if out_logging:
         _logger.info("Stage 1 of 4: Create country shapes")
 
     # download data if needed and get the layer id 0, corresponding to the countries
-    df_countries = get_GADM_layer(countries, 0, update, out_logging)
+    df_countries = get_GADM_layer(countries, 0, crs, update, out_logging)
 
     # select and rename columns
     df_countries = df_countries[["GID_0", "geometry"]].copy()
@@ -218,7 +220,7 @@ def save_to_geojson(df, fn):
             pass
 
 
-def load_EEZ(countries_codes, EEZ_gpkg="./data/raw/eez/eez_v11.gpkg"):
+def load_EEZ(countries_codes, crs, EEZ_gpkg="./data/eez/eez_v11.gpkg"):
     """
     Function to load the database of the Exclusive Economic Zones.
     The dataset shall be downloaded independently by the user (see guide) or
@@ -229,7 +231,7 @@ def load_EEZ(countries_codes, EEZ_gpkg="./data/raw/eez/eez_v11.gpkg"):
             f"File EEZ {EEZ_gpkg} not found, please download it from https://www.marineregions.org/download_file.php?name=World_EEZ_v11_20191118_gpkg.zip and copy it in {os.path.dirname(EEZ_gpkg)}"
         )
 
-    geodf_EEZ = gpd.read_file(EEZ_gpkg)
+    geodf_EEZ = gpd.read_file(EEZ_gpkg).to_crs(crs)
     geodf_EEZ.dropna(axis=0, how="any", subset=["ISO_TER1"], inplace=True)
     # [["ISO_TER1", "TERRITORY1", "ISO_SOV1", "ISO_SOV2", "ISO_SOV3", "geometry"]]
     geodf_EEZ = geodf_EEZ[["ISO_TER1", "geometry"]]
@@ -249,7 +251,7 @@ def load_EEZ(countries_codes, EEZ_gpkg="./data/raw/eez/eez_v11.gpkg"):
     return geodf_EEZ
 
 
-def eez(countries, country_shapes, EEZ_gpkg, out_logging=False, distance=0.01):
+def eez(countries, crs, country_shapes, EEZ_gpkg, out_logging=False, distance=0.01):
     """
     Creates offshore shapes by
     - buffer smooth countryshape (=offset country shape)
@@ -262,7 +264,7 @@ def eez(countries, country_shapes, EEZ_gpkg, out_logging=False, distance=0.01):
         _logger.info("Stage 2 of 4: Create offshore shapes")
 
     # load data
-    df_eez = load_EEZ(countries, EEZ_gpkg)
+    df_eez = load_EEZ(countries, crs, EEZ_gpkg)
 
     ret_df = df_eez[["name", "geometry"]]
     # create unique shape if country is described by multiple shapes
@@ -742,6 +744,7 @@ def gadm(
     worldpop_method,
     gdp_method,
     countries,
+    crs,
     layer_id=2,
     update=False,
     out_logging=False,
@@ -753,7 +756,7 @@ def gadm(
         _logger.info("Stage 4/4: Creation GADM GeoDataFrame")
 
     # download data if needed and get the desired layer_id
-    df_gadm = get_GADM_layer(countries, layer_id, update)
+    df_gadm = get_GADM_layer(countries, layer_id, crs, update)
 
     # select and rename columns
     df_gadm.rename(columns={"GID_0": "country"}, inplace=True)
@@ -814,11 +817,15 @@ if __name__ == "__main__":
     EEZ_gpkg = snakemake.input["eez"]
     worldpop_method = snakemake.config["build_shape_options"]["worldpop_method"]
     gdp_method = snakemake.config["build_shape_options"]["gdp_method"]
+    default_crs = snakemake.config["crs"]["default_crs"]
+    metric_crs = snakemake.config["crs"]["metric_crs"]
 
-    country_shapes = countries(countries_list, update, out_logging)
+    country_shapes = countries(countries_list, default_crs, update, out_logging)
     save_to_geojson(country_shapes, out.country_shapes)
 
-    offshore_shapes = eez(countries_list, country_shapes, EEZ_gpkg, out_logging)
+    offshore_shapes = eez(
+        countries_list, default_crs, country_shapes, EEZ_gpkg, out_logging
+    )
     save_to_geojson(offshore_shapes, out.offshore_shapes)
 
     africa_shape = country_cover(country_shapes, offshore_shapes, out_logging)
@@ -828,6 +835,7 @@ if __name__ == "__main__":
         worldpop_method,
         gdp_method,
         countries_list,
+        default_crs,
         layer_id,
         update,
         out_logging,

--- a/scripts/clean_osm_data.py
+++ b/scripts/clean_osm_data.py
@@ -447,7 +447,7 @@ def integrate_lines_df(df_all_lines, metric_crs):
                 }
             )
 
-            # transfrom to EPSG:4326 from EPSG:3857 to obtain length in m from coordinates
+            # transfrom to metric crs to obtain length in m from coordinates
             df_one_third_circuits_m = df_one_third_circuits.to_crs(metric_crs)
 
             length_from_crs = df_one_third_circuits_m.length

--- a/scripts/clean_osm_data.py
+++ b/scripts/clean_osm_data.py
@@ -352,7 +352,7 @@ dropped_circuits_tags = [
 ]
 
 
-def integrate_lines_df(df_all_lines, metric_crs):
+def integrate_lines_df(df_all_lines, distance_crs):
     """
     Function to add underground, under_construction, frequency and circuits
     """
@@ -448,7 +448,7 @@ def integrate_lines_df(df_all_lines, metric_crs):
             )
 
             # transfrom to metric crs to obtain length in m from coordinates
-            df_one_third_circuits_m = df_one_third_circuits.to_crs(metric_crs)
+            df_one_third_circuits_m = df_one_third_circuits.to_crs(distance_crs)
 
             length_from_crs = df_one_third_circuits_m.length
             df_one_third_circuits["length_crs"] = length_from_crs
@@ -624,14 +624,14 @@ def clean_data(
     input_files,
     output_files,
     africa_shape,
+    geo_crs,
+    distance_crs,
     ext_country_shapes=None,
     names_by_shapes=True,
     tag_substation="transmission",
     threshold_voltage=35000,
     add_line_endings=True,
     generator_name_method="OSM",
-    crs="EPSG:4326",
-    metric_crs="EPSG:3857",
 ):
     # Load raw data lines
     df_lines = gpd.read_file(input_files["lines"])
@@ -657,7 +657,7 @@ def clean_data(
 
     # Add underground, under_construction, frequency and circuits columns to the dataframe
     # and drop corresponding unused columns
-    df_all_lines = integrate_lines_df(df_all_lines, metric_crs)
+    df_all_lines = integrate_lines_df(df_all_lines, distance_crs)
 
     # filter lines by voltage
     df_all_lines = filter_voltage(df_all_lines, threshold_voltage)
@@ -765,8 +765,8 @@ if __name__ == "__main__":
     )
     offshore_shape_path = snakemake.input.offshore_shapes
     onshore_shape_path = snakemake.input.country_shapes
-    default_crs = snakemake.config["crs"]["default_crs"]
-    metric_crs = snakemake.config["crs"]["metric_crs"]
+    geo_crs = snakemake.config["crs"]["geo_crs"]
+    distance_crs = snakemake.config["crs"]["distance_crs"]
 
     input_files = snakemake.input
     output_files = snakemake.output
@@ -794,12 +794,12 @@ if __name__ == "__main__":
         input_files,
         output_files,
         africa_shape,
+        geo_crs,
+        distance_crs,
         ext_country_shapes=ext_country_shapes,
         names_by_shapes=names_by_shapes,
         tag_substation=tag_substation,
         threshold_voltage=threshold_voltage,
         add_line_endings=add_line_endings,
         generator_name_method=generator_name_method,
-        crs=default_crs,
-        metric_crs=metric_crs,
     )

--- a/scripts/download_osm_data.py
+++ b/scripts/download_osm_data.py
@@ -323,7 +323,7 @@ def lonlat_lookup(df_way, Data):
     return lonlat_list
 
 
-def convert_ways_points(df_way, Data, metric_crs="EPSG:3857"):
+def convert_ways_points(df_way, Data, crs, metric_crs):
     """Convert Ways to Point Coordinates"""
     lonlat_list = lonlat_lookup(df_way, Data)
     way_polygon = list(
@@ -336,7 +336,7 @@ def convert_ways_points(df_way, Data, metric_crs="EPSG:3857"):
         map(
             int,
             round(
-                gpd.GeoSeries(way_polygon).set_crs(OSM_CRS).to_crs(metric_crs).area,
+                gpd.GeoSeries(way_polygon).set_crs(crs).to_crs(metric_crs).area,
                 -1,
             ),
         )
@@ -355,30 +355,28 @@ def convert_ways_points(df_way, Data, metric_crs="EPSG:3857"):
     df_way.insert(0, "lonlat", lonlat_column)
 
 
-def convert_ways_lines(df_way, Data, metric_crs="EPSG:3857"):
+def convert_ways_lines(df_way, Data, crs, metric_crs):
     """Convert Ways to Line Coordinates"""
     lonlat_list = lonlat_lookup(df_way, Data)
     lonlat_column = lonlat_list
     df_way.insert(0, "lonlat", lonlat_column)
 
     way_linestring = map(lambda lonlats: LineString(lonlats), lonlat_list)
-    length_column = (
-        gpd.GeoSeries(way_linestring).set_crs(OSM_CRS).to_crs(metric_crs).length
-    )
+    length_column = gpd.GeoSeries(way_linestring).set_crs(crs).to_crs(metric_crs).length
 
     df_way.insert(0, "Length", length_column)
 
 
-def convert_pd_to_gdf_nodes(df_way):
+def convert_pd_to_gdf_nodes(df_way, crs):
     """Convert Points Pandas Dataframe to GeoPandas Dataframe"""
     gdf = gpd.GeoDataFrame(
         df_way, geometry=[Point(x, y) for x, y in df_way.lonlat], crs=OSM_CRS
-    )
+    ).to_crs(crs)
     gdf.drop(columns=["lonlat"], inplace=True)
     return gdf
 
 
-def convert_pd_to_gdf_lines(df_way, simplified=False, crs="EPSG:4326"):
+def convert_pd_to_gdf_lines(df_way, crs, simplified=False):
     """Convert Lines Pandas Dataframe to GeoPandas Dataframe"""
     if simplified is True:
         df_way["geometry"] = df_way["geometry"].apply(
@@ -421,9 +419,7 @@ def convert_iso_to_geofk(iso_code, iso_coding=True, convert_dict=iso_to_geofk_di
         return iso_code
 
 
-def output_csv_geojson(
-    output_files, df_all_feature, columns_feature, feature, crs="EPSG:4326"
-):
+def output_csv_geojson(output_files, df_all_feature, columns_feature, feature, crs):
     """Function to save the feature as csv and geojson"""
 
     # get path from snakemake; expected geojson
@@ -449,7 +445,7 @@ def output_csv_geojson(
         # TODO: is it possible to have "geometry" without "lonlat"?
         else:
             # TODO: is it possible that nodes dataframe will also be empty?
-            gdf_feature = convert_pd_to_gdf_lines(df_all_feature, crs=crs)
+            gdf_feature = convert_pd_to_gdf_lines(df_all_feature, crs)
             gdf_feature.to_file(path_file_geojson, driver="GeoJSON")  # Generate GeoJson
             return None
 
@@ -480,9 +476,9 @@ def output_csv_geojson(
         return None
 
     if feature_category[feature] == "way":
-        gdf_feature = convert_pd_to_gdf_lines(df_all_feature)
+        gdf_feature = convert_pd_to_gdf_lines(df_all_feature, crs)
     else:
-        gdf_feature = convert_pd_to_gdf_nodes(df_all_feature)
+        gdf_feature = convert_pd_to_gdf_nodes(df_all_feature, crs)
 
     _logger.info("Writing GeoJSON file")
     gdf_feature.to_file(path_file_geojson, driver="GeoJSON")  # Generate GeoJson
@@ -538,12 +534,12 @@ def process_data(
     feature_list,
     country_list,
     output_files,
+    default_crs,
+    metric_crs,
     iso_coding=True,
     update=False,
     verify=False,
     nprocesses=1,
-    default_crs="EPSG:4326",
-    metric_crs="EPSG:3857",
 ):
     """
     Download the features in feature_list for each country of the country_list
@@ -574,7 +570,7 @@ def process_data(
 
             if feature_category[feature] == "way":
                 convert_ways_lines(
-                    df_way, Data, metric_crs=metric_crs
+                    df_way, Data, OSM_CRS, metric_crs
                 ) if not df_way.empty else _logger.warning(
                     f"Empty Way Dataframe for {feature} in {country_code}"
                 )
@@ -585,7 +581,7 @@ def process_data(
 
             if feature_category[feature] == "node":
                 convert_ways_points(
-                    df_way, Data, metric_crs=metric_crs
+                    df_way, Data, OSM_CRS, metric_crs
                 ) if not df_way.empty else None
 
             # Add Type Column
@@ -743,10 +739,10 @@ if __name__ == "__main__":
         feature_list,
         country_list,
         output_files,
+        default_crs,
+        metric_crs,
         iso_coding=True,
         update=False,
         verify=False,
         nprocesses=nprocesses,
-        default_crs=default_crs,
-        metric_crs=metric_crs,
     )

--- a/scripts/download_osm_data.py
+++ b/scripts/download_osm_data.py
@@ -51,6 +51,8 @@ _logger.setLevel(logging.INFO)
 
 # logger.setLevel(logging.WARNING)
 
+OSM_CRS = "EPSG:4326"
+
 
 def getContinentCountry(code):
     """
@@ -321,7 +323,7 @@ def lonlat_lookup(df_way, Data):
     return lonlat_list
 
 
-def convert_ways_points(df_way, Data):
+def convert_ways_points(df_way, Data, metric_crs="EPSG:3857"):
     """Convert Ways to Point Coordinates"""
     lonlat_list = lonlat_lookup(df_way, Data)
     way_polygon = list(
@@ -334,10 +336,7 @@ def convert_ways_points(df_way, Data):
         map(
             int,
             round(
-                gpd.GeoSeries(way_polygon)
-                .set_crs("EPSG:4326")
-                .to_crs("EPSG:3857")
-                .area,
+                gpd.GeoSeries(way_polygon).set_crs(OSM_CRS).to_crs(metric_crs).area,
                 -1,
             ),
         )
@@ -356,7 +355,7 @@ def convert_ways_points(df_way, Data):
     df_way.insert(0, "lonlat", lonlat_column)
 
 
-def convert_ways_lines(df_way, Data):
+def convert_ways_lines(df_way, Data, metric_crs="EPSG:3857"):
     """Convert Ways to Line Coordinates"""
     lonlat_list = lonlat_lookup(df_way, Data)
     lonlat_column = lonlat_list
@@ -364,7 +363,7 @@ def convert_ways_lines(df_way, Data):
 
     way_linestring = map(lambda lonlats: LineString(lonlats), lonlat_list)
     length_column = (
-        gpd.GeoSeries(way_linestring).set_crs("EPSG:4326").to_crs("EPSG:3857").length
+        gpd.GeoSeries(way_linestring).set_crs(OSM_CRS).to_crs(metric_crs).length
     )
 
     df_way.insert(0, "Length", length_column)
@@ -373,13 +372,13 @@ def convert_ways_lines(df_way, Data):
 def convert_pd_to_gdf_nodes(df_way):
     """Convert Points Pandas Dataframe to GeoPandas Dataframe"""
     gdf = gpd.GeoDataFrame(
-        df_way, geometry=[Point(x, y) for x, y in df_way.lonlat], crs="EPSG:4326"
+        df_way, geometry=[Point(x, y) for x, y in df_way.lonlat], crs=OSM_CRS
     )
     gdf.drop(columns=["lonlat"], inplace=True)
     return gdf
 
 
-def convert_pd_to_gdf_lines(df_way, simplified=False):
+def convert_pd_to_gdf_lines(df_way, simplified=False, crs="EPSG:4326"):
     """Convert Lines Pandas Dataframe to GeoPandas Dataframe"""
     if simplified is True:
         df_way["geometry"] = df_way["geometry"].apply(
@@ -387,8 +386,8 @@ def convert_pd_to_gdf_lines(df_way, simplified=False):
         )
 
     gdf = gpd.GeoDataFrame(
-        df_way, geometry=[LineString(x) for x in df_way.lonlat], crs="EPSG:4326"
-    )
+        df_way, geometry=[LineString(x) for x in df_way.lonlat], crs=OSM_CRS
+    ).to_crs(crs)
     gdf.drop(columns=["lonlat"], inplace=True)
 
     return gdf
@@ -423,10 +422,9 @@ def convert_iso_to_geofk(iso_code, iso_coding=True, convert_dict=iso_to_geofk_di
 
 
 def output_csv_geojson(
-    output_files, country_code, df_all_feature, columns_feature, feature
+    output_files, df_all_feature, columns_feature, feature, crs="EPSG:4326"
 ):
     """Function to save the feature as csv and geojson"""
-    continent, country_name = getContinentCountry(country_code)
 
     # get path from snakemake; expected geojson
     path_file_geojson = output_files[feature + "s"]
@@ -451,7 +449,7 @@ def output_csv_geojson(
         # TODO: is it possible to have "geometry" without "lonlat"?
         else:
             # TODO: is it possible that nodes dataframe will also be empty?
-            gdf_feature = convert_pd_to_gdf_lines(df_all_feature)
+            gdf_feature = convert_pd_to_gdf_lines(df_all_feature, crs=crs)
             gdf_feature.to_file(path_file_geojson, driver="GeoJSON")  # Generate GeoJson
             return None
 
@@ -544,6 +542,8 @@ def process_data(
     update=False,
     verify=False,
     nprocesses=1,
+    default_crs="EPSG:4326",
+    metric_crs="EPSG:3857",
 ):
     """
     Download the features in feature_list for each country of the country_list
@@ -574,7 +574,7 @@ def process_data(
 
             if feature_category[feature] == "way":
                 convert_ways_lines(
-                    df_way, Data
+                    df_way, Data, metric_crs=metric_crs
                 ) if not df_way.empty else _logger.warning(
                     f"Empty Way Dataframe for {feature} in {country_code}"
                 )
@@ -584,7 +584,9 @@ def process_data(
                     )
 
             if feature_category[feature] == "node":
-                convert_ways_points(df_way, Data) if not df_way.empty else None
+                convert_ways_points(
+                    df_way, Data, metric_crs=metric_crs
+                ) if not df_way.empty else None
 
             # Add Type Column
             df_node["Type"] = "Node"
@@ -602,10 +604,10 @@ def process_data(
 
         output_csv_geojson(
             output_files,
-            country_code,
             df_all_feature,
             feature_columns[feature],
             feature,
+            crs=default_crs,
         )
 
 
@@ -732,6 +734,10 @@ if __name__ == "__main__":
         "download_osm_data_nprocesses", 1
     )  # number of threads
 
+    # get the default and metric crs of the workflow
+    default_crs = snakemake.config["crs"]["default_crs"]
+    metric_crs = snakemake.config["crs"]["metric_crs"]
+
     # Set update # Verify = True checks local md5s and pre-filters data again
     process_data(
         feature_list,
@@ -741,4 +747,6 @@ if __name__ == "__main__":
         update=False,
         verify=False,
         nprocesses=nprocesses,
+        default_crs=default_crs,
+        metric_crs=metric_crs,
     )

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -99,6 +99,11 @@ enable:
   build_natura_raster: true  # If True, then build_natura_raster can be run
   # custom_busmap: false
 
+# definition of the Coordinate Reference Systems
+crs:
+  default_crs: EPSG:4326  # general geographic projection, not used for metric measures
+  metric_crs: EPSG:3085  # projection for metric measures only
+
 download_osm_data_nprocesses: 4  # (optional) number of threads used to download osm data
 
 electricity:

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -101,8 +101,8 @@ enable:
 
 # definition of the Coordinate Reference Systems
 crs:
-  default_crs: EPSG:4326  # general geographic projection, not used for metric measures
-  metric_crs: EPSG:3085  # projection for metric measures only
+  default_crs: EPSG:4326  # general geographic projection, not used for metric measures. "EPSG:4326" is the standard used by OSM and google maps
+  metric_crs: EPSG:3857  # projection for metric measures only. Possible recommended values are "EPSG:3857" (used by OSM and Google Maps) or also Global Mollweide "ESRI:54009"
 
 download_osm_data_nprocesses: 4  # (optional) number of threads used to download osm data
 

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -85,7 +85,7 @@ summary_dir: results
 snapshots:
   start: "2013-03-1"
   end: "2013-03-8"
-  closed: "left" # end is not inclusive
+  inclusive: "left" # end is not inclusive
 
 enable:
   # prepare_links_p_nom: false

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -101,8 +101,9 @@ enable:
 
 # definition of the Coordinate Reference Systems
 crs:
-  default_crs: EPSG:4326  # general geographic projection, not used for metric measures. "EPSG:4326" is the standard used by OSM and google maps
-  metric_crs: EPSG:3857  # projection for metric measures only. Possible recommended values are "EPSG:3857" (used by OSM and Google Maps) or also Global Mollweide "ESRI:54009"
+  geo_crs: EPSG:4326  # general geographic projection, not used for metric measures. "EPSG:4326" is the standard used by OSM and google maps
+  distance_crs: EPSG:3857  # projection for distance measurements only. Possible recommended values are "EPSG:3857" (used by OSM and Google Maps)
+  area_crs: ESRI:54009  # projection for area measurements only. Possible recommended values are Global Mollweide "ESRI:54009"
 
 download_osm_data_nprocesses: 4  # (optional) number of threads used to download osm data
 


### PR DESCRIPTION
# Closes #297 

## Changes proposed in this Pull Request

This PR aims at harmonizing the CRSs used in the workflow as follows:
- Avoid having "magic" epsg specifications along the text: constant values are used in the scripts according to the file that are downloaded
- In the config files default and metric crs is proposed

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
