### PR TITLE
Fix powerplantmatching problem for DRC

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -35,17 +35,19 @@ Upcoming Release
 
 * Add new countries and update iso code: `PR #330 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/330>`_
 
-* Fix solar pv slope and add correction factor for wake losses `PR #335 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/350>`_
+* Fix solar pv slope and add correction factor for wake losses: `PR #335 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/350>`_
 
-* Add renewable potential notebook `PR #351 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/351>`_
+* Add renewable potential notebook: `PR #351 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/351>`_
 
-* Make cutout workflow simpler `PR #352 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/352>`_
+* Make cutout workflow simpler: `PR #352 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/352>`_
 
-* Add option to run workflow without pop and gdp raster `PR #353 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/353>`_
+* Add option to run workflow without pop and gdp raster: `PR #353 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/353>`_
 
-* Add latitude_optimal to get optimal solar orientation by default `Commit 1b2466b <https://github.com/pypsa-meets-africa/pypsa-africa/commit/de7d32be8807e4fc42486a60184f45680612fd46>`_
+* Add latitude_optimal to get optimal solar orientation by default: `Commit 1b2466b <https://github.com/pypsa-meets-africa/pypsa-africa/commit/de7d32be8807e4fc42486a60184f45680612fd46>`_
 
-* Harmonize CRSs by options `PR #356 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/356>`_
+* Harmonize CRSs by options: `PR #356 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/356>`_
+
+* Fix powerplantmatching problem for DRC and countries with multi-word name: `PR #359 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/359>`_
 
 
 PyPSA-Africa 0.0.2 (6th April 2022)

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -509,7 +509,7 @@ def three_2_two_digits_country(three_code_country):
     return two_code_country
 
 
-def two_digits_2_name_country(two_code_country):
+def two_digits_2_name_country(two_code_country, nocomma=False, remove_start_words=[]):
     """
     Convert 2-digit country code to full name country:
 
@@ -517,6 +517,12 @@ def two_digits_2_name_country(two_code_country):
     ----------
     two_code_country: str
         2-digit country name
+    nocomma: bool (optional, default False)
+        When true, country names with comma are extended to remove the comma.
+        Example CD -> Congo, The Democratic Republic of -> The Democratic Republic of Congo
+    remove_start_words: list (optional, default empty)
+        When a sentence starts with any of the provided words, the beginning is removed.
+        e.g. The Democratic Republic of Congo -> Democratic Republic of Congo (remove_start_words=["The"])
 
     Returns
     ----------
@@ -527,6 +533,25 @@ def two_digits_2_name_country(two_code_country):
         return f"{two_digits_2_name_country('SN')}-{two_digits_2_name_country('GM')}"
 
     full_name = get_country("name", alpha_2=two_code_country)
+
+    if nocomma:
+        # separate list by delim
+        splits = full_name.split(", ")
+
+        # reverse the order
+        splits.reverse()
+
+        # return the merged string
+        full_name = " ".join(splits)
+
+    # when list is non empty
+    if remove_start_words:
+        # loop over every provided word
+        for word in remove_start_words:
+            # when the full_name starts with the desired word, then remove it
+            if full_name.startswith(word):
+                full_name = full_name.replace(word, "", 1)
+
     return full_name
 
 


### PR DESCRIPTION
# Closes #349 

## Changes proposed in this Pull Request

This fix aims at addressing the issue discussed in #349.
The country name standard in pycountry sometimes is conflicting to the value used in other datasets, such as GEO and GPD.
In the specific case of 349, DRC is named "Congo, The Democratic Republic of" (pycountry), while in GEO and GPD is "Democratic Republic of Congo".
That lead to conflicts that are now fixed, yet to be verified at Africa and Earth scale.
It is worth mentioning on pycountry as well.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
