### PR TITLE
change default build_natura option

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -29,7 +29,7 @@ snapshots:
 enable:
   retrieve_databundle: true  #  Recommended 'true', for the first run. Otherwise data might be missing.
   download_osm_data: true  # If 'true', OpenStreetMap data will be downloaded for the above given countries
-  build_natura_raster: true  # If True, than an exclusion raster will be build
+  build_natura_raster: false  # If True, than an exclusion raster will be build
   build_cutout: false
   # If "build_cutout" : true, then environmental data is extracted according to `snapshots` date range and `countries`
   # requires cds API key https://cds.climate.copernicus.eu/api-how-to

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -89,7 +89,7 @@ enable:
   # If "build_cutout" : true # requires cds API key https://cds.climate.copernicus.eu/api-how-to
   # More information https://atlite.readthedocs.io/en/latest/introduction.html#datasets
   build_cutout: false
-  build_natura_raster: true  # If True, then build_natura_raster can be run
+  build_natura_raster: false  # If True, then build_natura_raster can be run
 
 # definition of the Coordinate Reference Systems
 crs:

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -89,7 +89,7 @@ enable:
   # If "build_cutout" : true # requires cds API key https://cds.climate.copernicus.eu/api-how-to
   # More information https://atlite.readthedocs.io/en/latest/introduction.html#datasets
   build_cutout: false
-  build_natura_raster: false  # If True, then build_natura_raster can be run
+  build_natura_raster: true  # If True, then build_natura_raster can be run
 
 # definition of the Coordinate Reference Systems
 crs:

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -47,6 +47,8 @@ Upcoming Release
 
 * Harmonize CRSs by options `PR #356 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/356>`_
 
+* Change default option for build_natura `PR #360 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/360>`_
+
 
 PyPSA-Africa 0.0.2 (6th April 2022)
 =====================================

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -88,16 +88,13 @@ snapshots:
   inclusive: "left" # end is not inclusive
 
 enable:
-  # prepare_links_p_nom: false
-  retrieve_databundle: true
-  download_osm_data: true
-  # retrieve_cutout: true
-  # retrieve_natura_raster: true
-  # If "build_cutout" : true # requires cds API key https://cds.climate.copernicus.eu/api-how-to
-  # More information https://atlite.readthedocs.io/en/latest/introduction.html#datasets
+  retrieve_databundle: true  #  Recommended 'true', for the first run. Otherwise data might be missing.
+  download_osm_data: true  # If 'true', OpenStreetMap data will be downloaded for the above given countries
+  build_natura_raster: false  # If True, than an exclusion raster will be build
   build_cutout: false
-  build_natura_raster: true  # If True, then build_natura_raster can be run
-  # custom_busmap: false
+  # If "build_cutout" : true, then environmental data is extracted according to `snapshots` date range and `countries`
+  # requires cds API key https://cds.climate.copernicus.eu/api-how-to
+  # More information https://atlite.readthedocs.io/en/latest/introduction.html#datasets
 
 # definition of the Coordinate Reference Systems
 crs:

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -90,7 +90,7 @@ snapshots:
 enable:
   retrieve_databundle: true  #  Recommended 'true', for the first run. Otherwise data might be missing.
   download_osm_data: true  # If 'true', OpenStreetMap data will be downloaded for the above given countries
-  build_natura_raster: false  # If True, than an exclusion raster will be build
+  build_natura_raster: true  # If True, than an exclusion raster will be build
   build_cutout: false
   # If "build_cutout" : true, then environmental data is extracted according to `snapshots` date range and `countries`
   # requires cds API key https://cds.climate.copernicus.eu/api-how-to


### PR DESCRIPTION
## Changes proposed in this Pull Request
If the `natura raster: true`, it can take ages to compute.
Setting it the default false will lead to a download from zenodo which is much faster.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
