### PR TITLE
adapt env rasterio version and add plot dependencies

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -53,6 +53,8 @@ Upcoming Release
 
 * Add renewable potential validation notebook and update others `PR #363 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/363>`_
 
+* Constrain rasterio version and add plotting dependencies `PR #365 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/365>`_
+
 
 PyPSA-Africa 0.0.2 (6th April 2022)
 =====================================

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -49,7 +49,7 @@ dependencies:
   # GIS dependencies:
 - cartopy
 - descartes
-- rasterio<=1.2.8
+- rasterio<=1.2.8  # until atlite is up to date https://github.com/PyPSA/atlite/issues/238
 - rioxarray
 
  # Plotting

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -29,7 +29,7 @@ dependencies:
 - numpy
 - pandas
 - geopandas
-- fiona <= 1.8.20  # Till issue https://github.com/Toblerity/Fiona/issues/1085 is not solved
+- fiona<=1.8.20  # Till issue https://github.com/Toblerity/Fiona/issues/1085 is not solved
 - xarray
 - netcdf4
 - networkx
@@ -49,10 +49,15 @@ dependencies:
   # GIS dependencies:
 - cartopy
 - descartes
-- rasterio
+- rasterio<=1.2.8
 - rioxarray
+
+ # Plotting
 - geoviews
 - hvplot
+- graphviz
+- contextily
+- graphviz
 
   # PyPSA-Eur-Sec Dependencies
 - geopy


### PR DESCRIPTION
## Changes proposed in this Pull Request
We need to constrain rasterio to avoid an bug.
**The fix is not required in the new atlite version but we need to wait for it.** 
Issue: https://github.com/PyPSA/atlite/issues/238
Solution PR is linked to the issue.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
