### PR TITLE
Add observed wind farm power densities to validation script

### DIFF
--- a/notebooks/validation/renewable_potential_validation.ipynb
+++ b/notebooks/validation/renewable_potential_validation.ipynb
@@ -662,8 +662,8 @@
     "df1[\"MW/km2\"] = df1[\"p_nom\"] / df1[\"area\"]\n",
     "print(\"Average installed power density\", df1[\"MW/km2\"].mean())\n",
     "print(\"Stats [MW/km2]:\", df1[\"MW/km2\"].describe())\n",
-    "#print(\"Stats [Year:\", df1[\"Year\"].astype(\"int\").describe())\n",
-    "#df1"
+    "# print(\"Stats [Year:\", df1[\"Year\"].astype(\"int\").describe())\n",
+    "# df1"
    ]
   },
   {
@@ -707,19 +707,35 @@
    ],
    "source": [
     "data = {\n",
-    "    'name': ['Fowler Ridge Wind Farm', 'Horse Hollow Wind Energy Center', \"Alta Wind Energy Center\", \"Hornsea 1\", \"Borssele 3n4\", \"Ganhekou Project\", \"Dawood Wind Power Project\"],\n",
-    "    'capacity MW':[750, 735, 1550, 1200, 732, 200, 49.5],\n",
-    "    'area km2':[202, 190, 129, 407, 146, 43, 7],\n",
-    "    'type':[\"onshore\", \"onshore\", \"onshore\", \"offshore\", \"offshore\", \"onshore\", \"onshore\"],\n",
-    "    'year':[2009, 2006, 2013, 2020, 2022, 2012, 2016],\n",
+    "    \"name\": [\n",
+    "        \"Fowler Ridge Wind Farm\",\n",
+    "        \"Horse Hollow Wind Energy Center\",\n",
+    "        \"Alta Wind Energy Center\",\n",
+    "        \"Hornsea 1\",\n",
+    "        \"Borssele 3n4\",\n",
+    "        \"Ganhekou Project\",\n",
+    "        \"Dawood Wind Power Project\",\n",
+    "    ],\n",
+    "    \"capacity MW\": [750, 735, 1550, 1200, 732, 200, 49.5],\n",
+    "    \"area km2\": [202, 190, 129, 407, 146, 43, 7],\n",
+    "    \"type\": [\n",
+    "        \"onshore\",\n",
+    "        \"onshore\",\n",
+    "        \"onshore\",\n",
+    "        \"offshore\",\n",
+    "        \"offshore\",\n",
+    "        \"onshore\",\n",
+    "        \"onshore\",\n",
+    "    ],\n",
+    "    \"year\": [2009, 2006, 2013, 2020, 2022, 2012, 2016],\n",
     "}\n",
     "\n",
     "df = pd.DataFrame(data=data)\n",
-    "df[\"MW/km2\"] = df[\"capacity MW\"]/df[\"area km2\"]\n",
+    "df[\"MW/km2\"] = df[\"capacity MW\"] / df[\"area km2\"]\n",
     "print(\"onshore stats:\")\n",
-    "print(df.loc[df.type==\"onshore\", :].describe())\n",
+    "print(df.loc[df.type == \"onshore\", :].describe())\n",
     "print(\"offshore stats:\")\n",
-    "print(df.loc[df.type==\"offshore\", :].describe())"
+    "print(df.loc[df.type == \"offshore\", :].describe())"
    ]
   },
   {

--- a/notebooks/validation/renewable_potential_validation.ipynb
+++ b/notebooks/validation/renewable_potential_validation.ipynb
@@ -488,18 +488,18 @@
        "    weight            (bus) float64 3.422e+03 2.421e+03 ... 485.6 73.52\n",
        "    p_nom_max         (bus) float64 1.55e+04 2.835e+04 ... 1.662e+04 3.323e+03\n",
        "    potential         (y, x) float64 0.0 0.0 0.0 0.0 0.0 ... 0.0 0.0 0.0 0.0 0.0\n",
-       "    average_distance  (bus) float64 44.99 53.31 23.5 13.49 ... 52.68 29.37 10.77</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-81d8acc5-1a53-4503-8ec1-56a4d65475c1' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-81d8acc5-1a53-4503-8ec1-56a4d65475c1' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 8760</li><li><span class='xr-has-index'>bus</span>: 2848</li><li><span class='xr-has-index'>y</span>: 257</li><li><span class='xr-has-index'>x</span>: 291</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-fb02a4e0-69b9-4f82-aeac-5b83f9dc5f74' class='xr-section-summary-in' type='checkbox'  checked><label for='section-fb02a4e0-69b9-4f82-aeac-5b83f9dc5f74' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2013-01-01 ... 2013-12-31T23:00:00</div><input id='attrs-7d78dd3c-8d05-40a2-9814-290781c3ba56' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-7d78dd3c-8d05-40a2-9814-290781c3ba56' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e731ffd3-3713-4ab9-9b0c-4dbdf72784f3' class='xr-var-data-in' type='checkbox'><label for='data-e731ffd3-3713-4ab9-9b0c-4dbdf72784f3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;2013-01-01T00:00:00.000000000&#x27;, &#x27;2013-01-01T01:00:00.000000000&#x27;,\n",
+       "    average_distance  (bus) float64 44.99 53.31 23.5 13.49 ... 52.68 29.37 10.77</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-a0d9bd6d-c7f8-4be5-a5ee-538ba8e8e230' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-a0d9bd6d-c7f8-4be5-a5ee-538ba8e8e230' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 8760</li><li><span class='xr-has-index'>bus</span>: 2848</li><li><span class='xr-has-index'>y</span>: 257</li><li><span class='xr-has-index'>x</span>: 291</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-df8dd727-dabc-4b9a-acc5-aa6407669370' class='xr-section-summary-in' type='checkbox'  checked><label for='section-df8dd727-dabc-4b9a-acc5-aa6407669370' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2013-01-01 ... 2013-12-31T23:00:00</div><input id='attrs-2f33537b-ac4e-4489-b955-38d54f0ee3be' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-2f33537b-ac4e-4489-b955-38d54f0ee3be' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3f9e530d-081a-4efc-aedc-1754f23f02bb' class='xr-var-data-in' type='checkbox'><label for='data-3f9e530d-081a-4efc-aedc-1754f23f02bb' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;2013-01-01T00:00:00.000000000&#x27;, &#x27;2013-01-01T01:00:00.000000000&#x27;,\n",
        "       &#x27;2013-01-01T02:00:00.000000000&#x27;, ..., &#x27;2013-12-31T21:00:00.000000000&#x27;,\n",
        "       &#x27;2013-12-31T22:00:00.000000000&#x27;, &#x27;2013-12-31T23:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>bus</span></div><div class='xr-var-dims'>(bus)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>&#x27;29&#x27; &#x27;707&#x27; &#x27;708&#x27; ... &#x27;7038&#x27; &#x27;7039&#x27;</div><input id='attrs-7c352989-c464-4499-b972-c501e862a2d4' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-7c352989-c464-4499-b972-c501e862a2d4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-300c1629-113b-4762-a423-4ba3c6a5cfab' class='xr-var-data-in' type='checkbox'><label for='data-300c1629-113b-4762-a423-4ba3c6a5cfab' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;29&#x27;, &#x27;707&#x27;, &#x27;708&#x27;, ..., &#x27;7036&#x27;, &#x27;7038&#x27;, &#x27;7039&#x27;], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-37.5 -37.2 -36.9 ... 39.0 39.3</div><input id='attrs-0d45dbff-275a-4876-8478-5d7b4f440838' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-0d45dbff-275a-4876-8478-5d7b4f440838' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0de86a25-b93b-4323-ba21-c3371668fa6c' class='xr-var-data-in' type='checkbox'><label for='data-0de86a25-b93b-4323-ba21-c3371668fa6c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-37.5, -37.2, -36.9, ...,  38.7,  39. ,  39.3])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-19.5 -19.2 -18.9 ... 67.2 67.5</div><input id='attrs-1b08c2f4-9f0f-4105-b7ed-c3dba54948ab' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-1b08c2f4-9f0f-4105-b7ed-c3dba54948ab' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1e98c44c-325d-471c-8040-c55a8ac6d685' class='xr-var-data-in' type='checkbox'><label for='data-1e98c44c-325d-471c-8040-c55a8ac6d685' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-19.5, -19.2, -18.9, ...,  66.9,  67.2,  67.5])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-297310c2-8f5c-41fd-a26c-fffaa037770c' class='xr-section-summary-in' type='checkbox'  checked><label for='section-297310c2-8f5c-41fd-a26c-fffaa037770c' class='xr-section-summary' >Data variables: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>profile</span></div><div class='xr-var-dims'>(time, bus)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-9526afb7-8596-4539-93a1-2e96ea2327c9' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-9526afb7-8596-4539-93a1-2e96ea2327c9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8e5e165a-0f9c-454f-995d-d5539244ea0b' class='xr-var-data-in' type='checkbox'><label for='data-8e5e165a-0f9c-454f-995d-d5539244ea0b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>[24948480 values with dtype=float64]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>weight</span></div><div class='xr-var-dims'>(bus)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-1b1bf4e7-82d4-4eb3-8e75-85523f5cb4ee' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-1b1bf4e7-82d4-4eb3-8e75-85523f5cb4ee' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a89ef448-c108-4cc7-bd56-472bffd4c0ed' class='xr-var-data-in' type='checkbox'><label for='data-a89ef448-c108-4cc7-bd56-472bffd4c0ed' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>MW</dd></dl></div><div class='xr-var-data'><pre>array([3421.96942 , 2421.207638, 1087.25839 , ...,  112.384566,  485.571345,\n",
-       "         73.524517])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>p_nom_max</span></div><div class='xr-var-dims'>(bus)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-60b4d41a-b603-48e0-bcde-00ae6015487b' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-60b4d41a-b603-48e0-bcde-00ae6015487b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-118401ec-90f9-44f2-96f2-c4e291809778' class='xr-var-data-in' type='checkbox'><label for='data-118401ec-90f9-44f2-96f2-c4e291809778' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([15503.188947, 28354.281446,  6280.623981, ...,  3319.848996,\n",
-       "       16616.890334,  3323.39577 ])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>potential</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-72b0b51d-f548-441c-b31c-667a02d9aa40' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-72b0b51d-f548-441c-b31c-667a02d9aa40' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-be44640e-f626-4bac-b79e-7ac2bb9aa363' class='xr-var-data-in' type='checkbox'><label for='data-be44640e-f626-4bac-b79e-7ac2bb9aa363' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[0., 0., 0., ..., 0., 0., 0.],\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>bus</span></div><div class='xr-var-dims'>(bus)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>&#x27;29&#x27; &#x27;707&#x27; &#x27;708&#x27; ... &#x27;7038&#x27; &#x27;7039&#x27;</div><input id='attrs-09efc166-1409-40ef-828c-486305a07d52' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-09efc166-1409-40ef-828c-486305a07d52' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-373070cc-da86-42c5-b17f-69bf86806ea1' class='xr-var-data-in' type='checkbox'><label for='data-373070cc-da86-42c5-b17f-69bf86806ea1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;29&#x27;, &#x27;707&#x27;, &#x27;708&#x27;, ..., &#x27;7036&#x27;, &#x27;7038&#x27;, &#x27;7039&#x27;], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-37.5 -37.2 -36.9 ... 39.0 39.3</div><input id='attrs-4c446f17-4910-408f-859e-2486ae151338' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-4c446f17-4910-408f-859e-2486ae151338' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fa8c1e03-7921-4a36-a9d1-8c1a4a3ef5f9' class='xr-var-data-in' type='checkbox'><label for='data-fa8c1e03-7921-4a36-a9d1-8c1a4a3ef5f9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-37.5, -37.2, -36.9, ...,  38.7,  39. ,  39.3])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-19.5 -19.2 -18.9 ... 67.2 67.5</div><input id='attrs-fc228f46-06c9-4f9b-83fb-185018c863b8' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-fc228f46-06c9-4f9b-83fb-185018c863b8' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9dfc4f74-a76b-4276-8228-9b1ea77d1dc4' class='xr-var-data-in' type='checkbox'><label for='data-9dfc4f74-a76b-4276-8228-9b1ea77d1dc4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-19.5, -19.2, -18.9, ...,  66.9,  67.2,  67.5])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-37d2134c-1e72-4786-bb18-723060d1b77b' class='xr-section-summary-in' type='checkbox'  checked><label for='section-37d2134c-1e72-4786-bb18-723060d1b77b' class='xr-section-summary' >Data variables: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>profile</span></div><div class='xr-var-dims'>(time, bus)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-877a6658-23fb-44ad-a861-6936c2325c61' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-877a6658-23fb-44ad-a861-6936c2325c61' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5d69c38f-a660-4e98-bc3c-815d4cfd7ead' class='xr-var-data-in' type='checkbox'><label for='data-5d69c38f-a660-4e98-bc3c-815d4cfd7ead' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>[24948480 values with dtype=float64]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>weight</span></div><div class='xr-var-dims'>(bus)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-eba4ec00-251b-4c2b-b6eb-f0ab0247db03' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-eba4ec00-251b-4c2b-b6eb-f0ab0247db03' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-cff9168a-e982-47fc-adc7-7d61c74767d0' class='xr-var-data-in' type='checkbox'><label for='data-cff9168a-e982-47fc-adc7-7d61c74767d0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>MW</dd></dl></div><div class='xr-var-data'><pre>array([3421.96942 , 2421.207638, 1087.25839 , ...,  112.384566,  485.571345,\n",
+       "         73.524517])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>p_nom_max</span></div><div class='xr-var-dims'>(bus)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-0ce8c939-271b-4fb4-8b89-c2203f7e56c7' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-0ce8c939-271b-4fb4-8b89-c2203f7e56c7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-57c33b78-04ad-4947-a584-3d4ce988f548' class='xr-var-data-in' type='checkbox'><label for='data-57c33b78-04ad-4947-a584-3d4ce988f548' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([15503.188947, 28354.281446,  6280.623981, ...,  3319.848996,\n",
+       "       16616.890334,  3323.39577 ])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>potential</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-e91c3f47-8821-40f3-aa94-84a32ae83fc4' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-e91c3f47-8821-40f3-aa94-84a32ae83fc4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bdc3beb9-bbbd-4be8-831a-f1e6e7004987' class='xr-var-data-in' type='checkbox'><label for='data-bdc3beb9-bbbd-4be8-831a-f1e6e7004987' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[0., 0., 0., ..., 0., 0., 0.],\n",
        "       [0., 0., 0., ..., 0., 0., 0.],\n",
        "       [0., 0., 0., ..., 0., 0., 0.],\n",
        "       ...,\n",
        "       [0., 0., 0., ..., 0., 0., 0.],\n",
        "       [0., 0., 0., ..., 0., 0., 0.],\n",
-       "       [0., 0., 0., ..., 0., 0., 0.]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>average_distance</span></div><div class='xr-var-dims'>(bus)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-ab3c85ee-a847-4562-9f04-50e7bb391202' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-ab3c85ee-a847-4562-9f04-50e7bb391202' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a3aba400-bb17-4972-8a34-074880f79581' class='xr-var-data-in' type='checkbox'><label for='data-a3aba400-bb17-4972-8a34-074880f79581' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([44.989078, 53.306378, 23.5013  , ..., 52.68125 , 29.366412, 10.772618])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-458cf5b6-2643-46cf-9303-5ff2e69bdee3' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-458cf5b6-2643-46cf-9303-5ff2e69bdee3' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
+       "       [0., 0., 0., ..., 0., 0., 0.]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>average_distance</span></div><div class='xr-var-dims'>(bus)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-835e2b72-e9ce-4ca2-af03-92dd25de3370' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-835e2b72-e9ce-4ca2-af03-92dd25de3370' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bc4966eb-56e4-405b-b9d9-4520ed8e5643' class='xr-var-data-in' type='checkbox'><label for='data-bc4966eb-56e4-405b-b9d9-4520ed8e5643' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([44.989078, 53.306378, 23.5013  , ..., 52.68125 , 29.366412, 10.772618])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-cd04cf05-c414-477f-9ed8-999d24446ab3' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-cd04cf05-c414-477f-9ed8-999d24446ab3' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -604,7 +604,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3. Wikipedia list of largest PV plant\n",
+    "## 3a. Wikipedia list of largest PV plant\n",
     "\n",
     "In case the above data is off, we might want to look at the \"installable power density\" [MW/km2]. The installable power density describes how much of the technology can be build in a specific area while being maintainable and techno-economic efficient (reduce shaddow losses and alike). This parameter is an input in too energy system models that finally lead to the technical potential [TW]."
    ]
@@ -630,25 +630,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Average installed power density 45.62385307011756\n",
+      "Average installed power density 46.46813074366352\n",
       "Stats [MW/km2]: count     41.000000\n",
-      "mean      45.623853\n",
-      "std       30.368618\n",
+      "mean      46.468131\n",
+      "std       32.744736\n",
       "min       10.416667\n",
       "25%       28.947368\n",
       "50%       38.679245\n",
       "75%       49.400000\n",
-      "max      147.125000\n",
-      "Name: MW/km2, dtype: float64\n",
-      "Stats [Year: count      41.000000\n",
-      "mean     2017.390244\n",
-      "std         2.322478\n",
-      "min      2012.000000\n",
-      "25%      2016.000000\n",
-      "50%      2018.000000\n",
-      "75%      2019.000000\n",
-      "max      2021.000000\n",
-      "Name: Year, dtype: float64\n"
+      "max      150.000000\n",
+      "Name: MW/km2, dtype: float64\n"
      ]
     }
    ],
@@ -671,14 +662,15 @@
     "df1[\"MW/km2\"] = df1[\"p_nom\"] / df1[\"area\"]\n",
     "print(\"Average installed power density\", df1[\"MW/km2\"].mean())\n",
     "print(\"Stats [MW/km2]:\", df1[\"MW/km2\"].describe())\n",
-    "print(\"Stats [Year:\", df1[\"Year\"].astype(\"int\").describe())"
+    "#print(\"Stats [Year:\", df1[\"Year\"].astype(\"int\").describe())\n",
+    "#df1"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 4. Comparison to other sources"
+    "## 3b. Collected list of on and offshore wind farms"
    ]
   },
   {
@@ -690,7 +682,63 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Investigating config.yaml input for PyPSA-Africa:\n",
+      "onshore stats:\n",
+      "       capacity MW    area km2         year     MW/km2\n",
+      "count     5.000000    5.000000     5.000000   5.000000\n",
+      "mean    656.900000  114.200000  2011.200000   6.263878\n",
+      "std     589.509796   86.940784     3.834058   3.484969\n",
+      "min      49.500000    7.000000  2006.000000   3.712871\n",
+      "25%     200.000000   43.000000  2009.000000   3.868421\n",
+      "50%     735.000000  129.000000  2012.000000   4.651163\n",
+      "75%     750.000000  190.000000  2013.000000   7.071429\n",
+      "max    1550.000000  202.000000  2016.000000  12.015504\n",
+      "offshore stats:\n",
+      "       capacity MW   area km2         year    MW/km2\n",
+      "count     2.000000    2.00000     2.000000  2.000000\n",
+      "mean    966.000000  276.50000  2021.000000  3.981051\n",
+      "std     330.925974  184.55487     1.414214  1.460385\n",
+      "min     732.000000  146.00000  2020.000000  2.948403\n",
+      "25%     849.000000  211.25000  2020.500000  3.464727\n",
+      "50%     966.000000  276.50000  2021.000000  3.981051\n",
+      "75%    1083.000000  341.75000  2021.500000  4.497375\n",
+      "max    1200.000000  407.00000  2022.000000  5.013699\n"
+     ]
+    }
+   ],
+   "source": [
+    "data = {\n",
+    "    'name': ['Fowler Ridge Wind Farm', 'Horse Hollow Wind Energy Center', \"Alta Wind Energy Center\", \"Hornsea 1\", \"Borssele 3n4\", \"Ganhekou Project\", \"Dawood Wind Power Project\"],\n",
+    "    'capacity MW':[750, 735, 1550, 1200, 732, 200, 49.5],\n",
+    "    'area km2':[202, 190, 129, 407, 146, 43, 7],\n",
+    "    'type':[\"onshore\", \"onshore\", \"onshore\", \"offshore\", \"offshore\", \"onshore\", \"onshore\"],\n",
+    "    'year':[2009, 2006, 2013, 2020, 2022, 2012, 2016],\n",
+    "}\n",
+    "\n",
+    "df = pd.DataFrame(data=data)\n",
+    "df[\"MW/km2\"] = df[\"capacity MW\"]/df[\"area km2\"]\n",
+    "print(\"onshore stats:\")\n",
+    "print(df.loc[df.type==\"onshore\", :].describe())\n",
+    "print(\"offshore stats:\")\n",
+    "print(df.loc[df.type==\"offshore\", :].describe())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Comparison to other sources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Investigating config.yaml solar power density input for PyPSA-Africa:\n",
       "Installed power density, Benban plant Egypt: 44.59 MW/km2\n",
       "Installable power density, IRENA: 46 MW/km2\n",
       "Installable power density, Fraunhofer 2022: 1 MW/ha which equals 100.0 MW/km2\n",
@@ -782,7 +830,7 @@
     "\n",
     "\n",
     "# Specific Technical potential [MW/km2]\n",
-    "print(\"Investigating config.yaml input for PyPSA-Africa:\")\n",
+    "print(\"Investigating config.yaml solar power density input for PyPSA-Africa:\")\n",
     "print(\n",
     "    \"Installed power density, Benban plant Egypt:\",\n",
     "    round(specific_power_benban, 2),\n",


### PR DESCRIPTION
## Changes proposed in this Pull Request
Add observed wind farm power densities to validation script.

We use as socio-technical wind farm power densities 2MW/km2 for onshore and 3 MW/km2 for offshore.
Looking at the stats this seems ok. Accessing a database for wind farms would be great. Now only a selection of powerplants were used.

![image](https://user-images.githubusercontent.com/61968949/172048701-3d6fe464-11db-49be-92c7-fb7a7f993288.png)


