### PR TITLE
Speed up availabilitymatrix calculation by factor 4-5 by progress bar deactivation

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -67,6 +67,7 @@ Upcoming Release
 
 * Fix bug in GADM clustering. Missing crs input. `PR #379 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/379>`_
 
+* Optimise `availabilitymatrix` speed by factor 4-5. `PR #380 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/380>`
 
 PyPSA-Africa 0.0.2 (6th April 2022)
 =====================================

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -220,7 +220,7 @@ if __name__ == "__main__":
     pgb.streams.wrap_stderr()
     paths = snakemake.input
     nprocesses = snakemake.config["atlite"].get("nprocesses")
-    noprogress = not snakemake.config["atlite"].get("show_progress", True)
+    noprogress = not snakemake.config["atlite"].get("show_progress", False)
     config = snakemake.config["renewable"][snakemake.wildcards.technology]
     resource = config["resource"]
     correction_factor = config.get("correction_factor", 1.0)


### PR DESCRIPTION
## Changes proposed in this Pull Request
Turning off the progress bar for a short process saves time.
Colleagues in PyPSA-Eur observed a speed-up from 5min to 1min. 
Upgrading the Atlite tqdm progressbar with dynamic_miniters might solve such overhead issues.

See more discussions at the PyPSA-Eur issue: https://github.com/PyPSA/pypsa-eur/pull/376

## Checklist

- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
