### PR TITLE
Enable the use of a float value for the scale in load_options

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -77,6 +77,8 @@ Upcoming Release
 
 * Add transformer components which connect different voltage level lines `PR #389 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/389>`
 
+* Enable the use of a float value for the scale in load_options `PR #397 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/397>`
+
 PyPSA-Africa 0.0.2 (6th April 2022)
 =====================================
 

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -305,7 +305,7 @@ def attach_load(
     # filter load for analysed countries
     gegis_load = gegis_load.loc[gegis_load.region_code.isin(countries)]
     logger.info(f"Load data scaled with scalling factor {scale}.")
-    gegis_load['Electricity demand'] *= scale
+    gegis_load["Electricity demand"] *= scale
     shapes = gpd.read_file(admin_shapes).set_index("GADM_ID")
     shapes.loc[:, "geometry"] = shapes["geometry"].apply(lambda x: make_valid(x))
 

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -305,7 +305,7 @@ def attach_load(
     # filter load for analysed countries
     gegis_load = gegis_load.loc[gegis_load.region_code.isin(countries)]
     logger.info(f"Load data scaled with scalling factor {scale}.")
-    gegis_load *= scale
+    gegis_load['Electricity demand'] *= scale
     shapes = gpd.read_file(admin_shapes).set_index("GADM_ID")
     shapes.loc[:, "geometry"] = shapes["geometry"].apply(lambda x: make_valid(x))
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
The aim of the PR is to enable the use of a float value for the scale in load_options in the config file.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
