### PR TITLE
Fix clustering due to PyPSA v0.20.0

### DIFF
--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -143,7 +143,6 @@ from build_shapes import add_gdp_data, add_population_data, get_GADM_layer
 from pypsa.networkclustering import (
     _make_consense,
     busmap_by_kmeans,
-    busmap_by_spectral_clustering,
     get_clustering_from_busmap,
 )
 from shapely.geometry import Point
@@ -384,14 +383,10 @@ def busmap_for_n_clusters(
             return prefix + busmap_by_kmeans(
                 n, weight, n_cluster_c, buses_i=x.index, **algorithm_kwds
             )
-        elif algorithm == "spectral":
-            return prefix + busmap_by_spectral_clustering(
-                reduce_network(n, x), n_cluster_c, **algorithm_kwds
-            )
 
         else:
             raise ValueError(
-                f"`algorithm` must be one of 'kmeans', 'spectral' or 'louvain'. Is {algorithm}."
+                f"`algorithm` must be one of 'kmeans' or 'louvain'. Is {algorithm}."
             )
 
     return (


### PR DESCRIPTION
## Changes proposed in this Pull Request
The clustering option "spectral_clustering" is removed the latest PyPSA release v0.20.0. Hence the option in the script cluster_network.py must be removed too.

For details refer to:
[compare](https://github.com/PyPSA/PyPSA/compare/v0.19.3...v0.20.0#diff-65d8f27b01202f45ea84acb3587c27e43357f86dda641d3d1b0f9d71bb1c1630L521)
the function `def busmap_by_spectral_clustering(network, n_clusters, **kwds)` is removed



## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
