### PR TITLE
fix p_nom aggregation, and model line as link per default

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -53,8 +53,9 @@ cluster_options:
   distribute_cluster: ['load'] # Distributes cluster nodes per country according to ['load'],['pop'] or ['gdp']
   out_logging: true  # When "True", logging is printed to console
   aggregation_strategies:
-    generators:
-      p_nom_max: sum # use "min" for more conservative assumptions
+    generators:  # use "min" for more conservative assumptions
+      p_nom: sum
+      p_nom_max: sum
       p_nom_min: sum
       p_min_pu: mean
       marginal_cost: mean
@@ -100,7 +101,7 @@ electricity:
   co2limit: 7.75e+7  # European default, 0.05 * 3.1e9*0.5, needs to be adjusted for Africa
   co2base: 1.487e+9  # European default, adjustment to Africa necessary
   agg_p_nom_limits: data/agg_p_nom_minmax.csv
-  hvdc_as_lines: true # should HVDC lines be modeled as `Line` or as `Link` component?
+  hvdc_as_lines: false  # should HVDC lines be modeled as `Line` or as `Link` component?
 
   operational_reserve: # like https://genxproject.github.io/GenX/dev/core/#Reserves
     activate: false

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -65,8 +65,9 @@ cluster_options:
   distribute_cluster: ['load'] # ['load'],['pop'] or ['gdp']
   out_logging: true  # When true, logging is printed to console
   aggregation_strategies:
-    generators:
-      p_nom_max: sum # use "min" for more conservative assumptions
+    generators:  # use "min" for more conservative assumptions
+      p_nom: sum
+      p_nom_max: sum
       p_nom_min: sum
       p_min_pu: mean
       marginal_cost: mean
@@ -113,7 +114,7 @@ electricity:
   co2limit: 7.75e+7 # 0.05 * 3.1e9*0.5
   co2base: 1.487e+9
   agg_p_nom_limits: data/agg_p_nom_minmax.csv
-  hvdc_as_lines: true # should HVDC lines be modeled as `Line` or as `Link` component?
+  hvdc_as_lines: false  # should HVDC lines be modeled as `Line` or as `Link` component?
 
   operational_reserve: # like https://genxproject.github.io/GenX/dev/core/#Reserves
     activate: false

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -101,7 +101,9 @@ Upcoming Release
 
 * Improve line augmentation for network expansion explorations. Use k-edge augmenation for AC lines and random sampling for long HVDC lines: `PR #427 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/427>`_
 
-* Fix minor bug in clustering about missing prefix assignment `PR #434 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/434>`
+* Fix minor bug in clustering about missing prefix assignment `PR #434 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/434>`_
+
+* Fix major aggregation bug and adjust config: `PR #435 <https://github.com/pypsa-meets-africa/pypsa-africa/pull/435>`_
 
 PyPSA-Africa 0.0.2 (6th April 2022)
 =====================================

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -69,8 +69,9 @@ cluster_options:
   distribute_cluster: ['load'] # ['load'],['pop'] or ['gdp']
   out_logging: true  # When true, logging is printed to console
   aggregation_strategies:
-    generators:
-      p_nom_max: sum # use "min" for more conservative assumptions
+    generators:  # use "min" for more conservative assumptions
+      p_nom: sum
+      p_nom_max: sum
       p_nom_min: sum
       p_min_pu: mean
       marginal_cost: mean
@@ -117,7 +118,7 @@ electricity:
   co2limit: 7.75e+7 # 0.05 * 3.1e9*0.5
   co2base: 1.487e+9
   agg_p_nom_limits: data/agg_p_nom_minmax.csv
-  hvdc_as_lines: true # should HVDC lines be modeled as `Line` or as `Link` component?
+  hvdc_as_lines: true  # should HVDC lines be modeled as `Line` or as `Link` component?
 
   operational_reserve: # like https://genxproject.github.io/GenX/dev/core/#Reserves
     activate: false


### PR DESCRIPTION
# Closes #431

## Changes proposed in this Pull Request
- Change `p_nom: min` to `p_nom: sum`. This guarantees that no capacity will be lost by the aggregation/clustering process.
- tutorial and default config use `hvdc_as_line: false`, the config.test as `true` 

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
