### PR TITLE
fix: add gadm_shape variable to cluster rule

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -477,6 +477,11 @@ if config["augmented_line_connection"].get("add_to_snakefile", False) == False:
             country_shapes="resources/shapes/country_shapes.geojson",
             regions_onshore="resources/bus_regions/regions_onshore_elec_s{simpl}.geojson",
             regions_offshore="resources/bus_regions/regions_offshore_elec_s{simpl}.geojson",
+            #gadm_shapes="resources/shapes/MAR2.geojson",
+            #using this line instead of the following will test updated gadm shapes for MA.
+            #To use: downlaod file from the google drive and place it in resources/shapes/
+            #Link: https://drive.google.com/drive/u/1/folders/1dkW1wKBWvSY4i-XEuQFFBj242p0VdUlM
+            gadm_shapes="resources/shapes/gadm_shapes.geojson",
             # busmap=ancient('resources/busmap_elec_s{simpl}.csv'),
             # custom_busmap=("data/custom_busmap_elec_s{simpl}_{clusters}.csv"
             #                if config["enable"].get("custom_busmap", False) else []),


### PR DESCRIPTION
## Changes proposed in this Pull Request
In the snakemake workflow the rule `cluster_networks` was missing the input parameter `gadm_shapes` when running without
`augmented_line_connection`

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
