### PR TITLE
Env fix and renaming to pypsa-earth.readthedocs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Status Linux](https://github.com/pypsa-meets-earth/pypsa-earth/actions/workflows/ci-linux.yaml/badge.svg?branch=main&event=push)](https://github.com/pypsa-meets-earth/pypsa-earth/actions/workflows/ci-linux.yaml)
 [![Status Mac](https://github.com/pypsa-meets-earth/pypsa-earth/actions/workflows/ci-mac.yaml/badge.svg?branch=main&event=push)](https://github.com/pypsa-meets-earth/pypsa-earth/actions/workflows/ci-mac.yaml)
 [![Status Windows](https://github.com/pypsa-meets-earth/pypsa-earth/actions/workflows/ci-windows.yaml/badge.svg?branch=main&event=push)](https://github.com/pypsa-meets-earth/pypsa-earth/actions/workflows/ci-windows.yaml)
-[![Documentation Status](https://readthedocs.org/projects/pypsa-meets-earth/badge/?version=latest)](https://pypsa-meets-earth.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/pypsa-meets-earth/badge/?version=latest)](https://pypsa-earth.readthedocs.io/en/latest/?badge=latest)
 ![Size](https://img.shields.io/github/repo-size/pypsa-meets-earth/pypsa-earth)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
@@ -16,7 +16,7 @@
 
 **PyPSA-Earth is the first open-source global energy system model with data in high spatial and temporal resolution.** It enables large-scale collaboration by providing a tool that can model the world energy system or any subset of it. This work is derived from the European [PyPSA-Eur](https://pypsa-eur.readthedocs.io/en/latest/) model using new data and functions. It is suitable for operational as well as combined generation, storage and transmission expansion studies. The model provides two main features: (1) customizable data extraction and preparation scripts with global coverage and (2) a [PyPSA](https://pypsa.readthedocs.io/en/latest/) energy modelling framework integration. The data includes electricity demand, generation and medium to high-voltage networks from open sources, yet additional data can be further integrated. A broad range of clustering and grid meshing strategies help adapt the model to computational and practical needs.
 
-The model is described in the preprint "PyPSA-Earth. A New Global Open Energy System Optimization Model Demonstrated in Africa", 2022, https://arxiv.org/abs/2209.04663. The [documentation](https://pypsa-meets-earth.readthedocs.io/en/latest/index.html) provides additional information. 
+The model is described in the preprint "PyPSA-Earth. A New Global Open Energy System Optimization Model Demonstrated in Africa", 2022, https://arxiv.org/abs/2209.04663. The [documentation](https://pypsa-earth.readthedocs.io/en/latest/index.html) provides additional information. 
 
 PyPSA meets Earth is a free and open source software initiative aiming to develop a powerful energy system model for Earth. We work on open data, open source modelling, open source solver support and open communities. Stay tuned and join our mission - We look for users, co-developers and leaders! Check out our [website for results and our projects](https://pypsa-meets-earth.github.io/projects.html). Happy coding!
 
@@ -129,7 +129,7 @@ There are multiple ways to get involved and learn more about our work. That's ho
 
 ## Documentation
 
-The documentation is available here: [documentation](https://pypsa-meets-earth.readthedocs.io/en/latest/index.html).
+The documentation is available here: [documentation](https://pypsa-earth.readthedocs.io/en/latest/index.html).
 
 ## Collaborators
 

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -17,7 +17,7 @@ scenario:
   opts: [Co2L-3H]
 
 countries: ["Africa"]
-# Can be replaced by country ["NG", "BJ"] or user specific region, more at https://pypsa-meets-earth.readthedocs.io/en/latest/configuration.html#top-level-configuration
+# Can be replaced by country ["NG", "BJ"] or user specific region, more at https://pypsa-earth.readthedocs.io/en/latest/configuration.html#top-level-configuration
 
 snapshots:
   start: "2013-01-01"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -55,7 +55,7 @@ print(
 
 # -- Project information -----------------------------------------------------
 
-project = "PyPSA Earth"
+project = "PyPSA-Earth"
 author = "Max Parzen"
 copyright = f"{datetime.datetime.today().year}, {author}"
 
@@ -148,9 +148,7 @@ texinfo_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, "pypsa_earth", "pypsa_earth Documentation", [author], 1)
-]
+man_pages = [(master_doc, "pypsa_earth", "pypsa_earth Documentation", [author], 1)]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -20,7 +20,7 @@ Welcome to the PyPSA-Earth documentation!
     :target: https://github.com/pypsa-meets-earth/pypsa-earth/actions
 
 .. image:: https://readthedocs.org/projects/pypsa-meets-earth/badge/?version=latest
-    :target: https://pypsa-meets-earth.readthedocs.io/en/latest/?badge=latest
+    :target: https://pypsa-earth.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
 .. image:: https://img.shields.io/github/repo-size/pypsa-meets-earth/pypsa-earth

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -54,7 +54,7 @@ The complete list of software needed before installing PyPSA Earth is listed bel
 .. note::
   Be aware that the list of software listed above is only the prerequisite elements needed to successfully install the PyPSA Earth model.
   The complete list of recommended software and prerequisite needed to enjoy the full PyPSA Earth experience is listed in the 
-  `Tutorial section <https://pypsa-meets-earth.readthedocs.io/en/latest/tutorial.html#prerequisites-and-learning-material>`_.
+  `Tutorial section <https://pypsa-earth.readthedocs.io/en/latest/tutorial.html#prerequisites-and-learning-material>`_.
   Most of the dependencies needed will be automatically installed using the conda environments listed below
 
 Clone the repository

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -138,7 +138,7 @@ Manual test of specific scripts
 The python scripts in the ``scripts`` folder are build so that they can be easily run and tested
 even without the snakemake procedure. This assumes you have all inputs of the rule 
 available (see Snakefile). For instance, let us run the ``build_shapes.py``.
-Looking at the Snakefile or the `workflow <https://pypsa-meets-earth.readthedocs.io/en/latest/introduction.html#workflow>`_
+Looking at the Snakefile or the `workflow <https://pypsa-earth.readthedocs.io/en/latest/introduction.html#workflow>`_
 we need to run the ``retrieve_databundle_light.py`` manually or by snakemake:
 
    .. code:: bash

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -30,7 +30,7 @@ dependencies:
 - numpy
 - pandas
 - geopandas
-- fiona
+- fiona!=1.8.22
 - xarray
 - netcdf4
 - networkx
@@ -51,7 +51,7 @@ dependencies:
   # GIS dependencies:
 - cartopy
 - descartes
-- rasterio>1.2.10
+- rasterio!=1.2.10
 - rioxarray
 
  # Plotting

--- a/scripts/retrieve_databundle_light.py
+++ b/scripts/retrieve_databundle_light.py
@@ -575,7 +575,7 @@ if __name__ == "__main__":
         to the acceptance of its multiple licenses.\n \
         The use of the code automatically implies that you accept all the licenses.\n \
         See our documentation for more information. \n \
-        Link: https://pypsa-meets-earth.readthedocs.io/en/latest/introduction.html#licence"
+        Link: https://pypsa-earth.readthedocs.io/en/latest/introduction.html#licence"
     )
 
     # download the selected bundles


### PR DESCRIPTION
## Changes proposed in this Pull Request

- Avoid recent fiona 1.8.22 version conflict
- Loose rasterio restriction
- Rename pypsa-meets-earth.readthedocs to pypsa-earh.readthedocs

## Checklist

- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
