### PR TITLE
Move ppl dependency back to pypsa

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -35,6 +35,8 @@ Upcoming Release
 
 * Add meta data of config to pypsa network per default. Allows keeping track of the config used to generate the network `PR #526 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/526>`__
 
+* Adapt dependencies of powerplantmatching to the PyPSA main branch `PR #527 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/527>`__
+
 PyPSA-Earth 0.1.0
 =================
 

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -77,7 +77,7 @@ dependencies:
 
 - pip:
   # - git+https://github.com/pypsa/pypsa.git#egg=pypsa
-  - git+https://github.com/davide-f/powerplantmatching.git@new_pypsa_africa#egg=powerplantmatching
+  - git+https://github.com/PyPSA/powerplantmatching.git@master
   - git+https://github.com/davide-f/google-drive-downloader@master  # google drive with fix for virus scan
   - git+https://github.com/davide-f/atlite.git@master
   - git+https://github.com/ekatef/PyPSA.git@master

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -265,8 +265,15 @@ if __name__ == "__main__":
             os.getcwd(), filepath_osm2pm_ppl
         )
 
+    # specify the main query for filtering powerplants
+    ppl_query = snakemake.config["electricity"]["powerplants_filter"]
+    if isinstance(ppl_query, str):
+        config["main_query"] = ppl_query
+    else:
+        config["main_query"] = ""
+
     ppl = (
-        pm.powerplants(from_url=False, update=True, config=config)
+        pm.powerplants(from_url=False, update=True, config_update=config)
         .powerplant.fill_missing_decommissioning_years()
         .query('Fueltype not in ["Solar", "Wind"] and Country in @countries_names')
         .replace({"Technology": {"Steam Turbine": "OCGT", "Combustion Engine": "OCGT"}})
@@ -276,10 +283,6 @@ if __name__ == "__main__":
             Country=lambda df: df.Country.map(lambda x: country_mapping[x]),
         )
     )
-
-    ppl_query = snakemake.config["electricity"]["powerplants_filter"]
-    if isinstance(ppl_query, str):
-        ppl.query(ppl_query, inplace=True)
 
     ppl = add_custom_powerplants(ppl)  # add carriers from own powerplant files
 


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request
Change powerplantmatching dependency back to the PyPSA organization

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [x] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
