### PR TITLE
Revise methodology to calculate databundle outputs

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -13,6 +13,7 @@ from snakemake.remote.HTTP import RemoteProvider as HTTPRemoteProvider
 
 from scripts.download_osm_data import create_country_list
 from scripts.add_electricity import get_load_paths_gegis
+from scripts.retrieve_databundle_light import datafiles_retrivedatabundle
 
 HTTP = HTTPRemoteProvider()
 
@@ -104,39 +105,6 @@ rule plot_all_summaries:
             country=["all"] + config["countries"],
             ext=["png", "pdf"]
         ),
-
-
-def datafiles_retrivedatabundle(config):
-    listoutputs = [
-        dvalue["output"]
-        for (dname, dvalue) in config["databundles"].items()
-        if config.get("tutorial", False) == dvalue.get("tutorial", False)
-    ]
-    unique_outputs = set(
-        (
-            [
-                inneroutput
-                for output in listoutputs
-                for inneroutput in output
-                if "*" not in inneroutput
-                or inneroutput.endswith("/")  # exclude directories
-            ]
-        )
-    )
-
-    # when option build_natura_raster is enabled, remove natura.tiff from the outputs
-    if config["enable"].get("build_natura_raster", False):
-        unique_outputs = [
-            output for output in unique_outputs if "natura.tiff" not in output
-        ]
-
-    # when option build_cutout is enabled, remove cutouts from the outputs
-    if config["enable"].get("build_cutout", False):
-        unique_outputs = [
-            output for output in unique_outputs if "cutouts/" not in output
-        ]
-
-    return unique_outputs
 
 
 if config["enable"].get("retrieve_databundle", True):

--- a/configs/bundle_config.yaml
+++ b/configs/bundle_config.yaml
@@ -36,8 +36,7 @@ databundles:
     category: data
     destination: "data"
     urls:
-      # zenodo: https://sandbox.zenodo.org/record/1016522/files/tutorial_data.zip?download=1
-      gdrive: https://drive.google.com/file/d/1yg1D5o7FN19ypICQKOuKgKbcGqrOmbia/view?usp=share_link
+      gdrive: https://drive.google.com/file/d/1BSxmm3AG5TTOxrLG0ki8IdlL2n3hEviq/view
     output:
     - data/gebco/GEBCO_2021_TID.nc
     - data/copernicus/PROBAV_LC100_global_v3.0.1_2019-nrt_Discrete-Classification-map_EPSG-4326.tif
@@ -49,7 +48,7 @@ databundles:
     category: data
     destination: "data"
     urls:
-      gdrive: https://drive.google.com/file/d/1yJ8JYGFVtMPpsEBeXzDR5Ixa9n8gGu5n/view?usp=share_link
+      gdrive: https://drive.google.com/file/d/1aXqbCxEpe0aNI6EYuCLtFS6CbdXurTn7/view
     output:
     - data/gebco/GEBCO_2021_TID.nc
     - data/copernicus/PROBAV_LC100_global_v3.0.1_2019-nrt_Discrete-Classification-map_EPSG-4326.tif
@@ -61,7 +60,7 @@ databundles:
     category: data
     destination: "data"
     urls:
-      gdrive: https://drive.google.com/file/d/1Qjf0xVBuOSTKTPRD_NANruDDG94CF-Ju/view?usp=share_link
+      gdrive: https://drive.google.com/file/d/1zY3WnKqwBF0derS4ncRIPpdTdNn978xw/view
     output:
     - data/gebco/GEBCO_2021_TID.nc
     - data/copernicus/PROBAV_LC100_global_v3.0.1_2019-nrt_Discrete-Classification-map_EPSG-4326.tif
@@ -73,8 +72,7 @@ databundles:
     category: cutouts
     destination: "cutouts"
     urls:
-      zenodo: https://sandbox.zenodo.org/record/1016015/files/tutorial_cutouts.zip?download=1
-      gdrive: https://drive.google.com/file/d/1No_BNKRO4UODdR5rVtwkfZjfVGUQKJ_K/view?usp=share_link
+      gdrive: https://drive.google.com/file/d/1N6wJb-dBTqWZX1Tlf5y979lEPtqcVEfQ/view
     output: [cutouts/africa-2013-era5-tutorial.nc]
     disable_by_opt:
       build_cutout: [all]
@@ -86,19 +84,19 @@ databundles:
     category: cutouts
     destination: "cutouts"
     urls:
-      gdrive: https://drive.google.com/file/d/19-vq48OKAeJ0C_1S8kx2HVQkCMGKzuTF/view?usp=share_link
+      gdrive: https://drive.google.com/file/d/1vtckYOZeSugDXrE0PGqxFwsVkdHNimhV/view
     output: [cutouts/africa-2013-era5-tutorial.nc]
     disable_by_opt:
       build_cutout: [all]
 
   # tutorial bundle specific for Morocco only
-  bundle_cutouts_tutorial_ma:
+  bundle_cutouts_tutorial_MA:
     countries: [MA]
     tutorial: true
     category: cutouts
     destination: "cutouts"
     urls:
-      gdrive: https://drive.google.com/file/d/14mgef15MSwOTUxDtXcnPBJbC_M7zxalQ/view?usp=share_link
+      gdrive: https://drive.google.com/file/d/1ouIhGQ4e2M2FLzPUZgcKu5GSpRPZotqw/view
     output: [cutouts/africa-2013-era5-tutorial.nc]
     disable_by_opt:
       build_cutout: [all]
@@ -110,7 +108,7 @@ databundles:
     category: common
     destination: "data"
     urls:
-      gdrive: https://drive.google.com/file/d/1yWxR7noWXZP74iRLqQGCatXssRGcuEc2/view?usp=share_link
+      gdrive: https://drive.google.com/file/d/1nRLrs_kP0qVl-IHC4BFLjpoKa3HLk2Py/view
     output:
     - data/costs.csv
     - data/hydro_capacities.csv
@@ -127,7 +125,7 @@ databundles:
     destination: "data"
     urls:
       # zenodo: https://sandbox.zenodo.org/record/1016540/files/common_data.zip?download=1
-      gdrive: https://drive.google.com/file/d/1MdZ4Eb80a2ntsBRBqWMC0Hodvu4e0jSm/view?usp=sharing
+      gdrive: https://drive.google.com/file/d/1jN5iV_iaRa5lc1XOaEtletKPUgPNOVuf/view
     output:
     - data/costs.csv
     - data/hydro_capacities.csv
@@ -145,7 +143,7 @@ databundles:
     destination: "data"
     urls:
       # zenodo: https://sandbox.zenodo.org/record/1016878/files/resources_africa.zip?download=1
-      gdrive: https://drive.google.com/file/d/1WmAAwY0TAcHg8YZyAGof0bPewFacm7my/view?usp=share_link
+      gdrive: https://drive.google.com/file/d/1WmAAwY0TAcHg8YZyAGof0bPewFacm7my/view
     output:
     - data/natura.tiff
 
@@ -156,7 +154,7 @@ databundles:
     destination: "data/landcover"
     urls:
       zenodo: https://sandbox.zenodo.org/record/1016042/files/landcover_africa.zip?download=1
-      gdrive: https://drive.google.com/file/d/1l6Xgr3PXyvgqWaXUbto9zvvMS_OgSjvG/view?usp=sharing
+      gdrive: https://drive.google.com/file/d/1qnJ0HAWZ4z_9q3PtDEUrFmZWBZYg-WNW/view
     output: [data/landcover/*]
 
   # data bundle of the data folder for the african continent
@@ -166,7 +164,7 @@ databundles:
     destination: "data/landcover"
     urls:
       zenodo: https://sandbox.zenodo.org/record/1016042/files/landcover_asiapacific.zip?download=1
-      gdrive: https://drive.google.com/file/d/1HZGpxZdTB2Ai_VN_8SPivCdgt3oz0wkX/view?usp=sharing
+      gdrive: https://drive.google.com/file/d/163Uc9F1DPs2pRgDzkTivnblhXCw4nfd5/view
     output: [data/landcover/*]
 
   # data bundle of the data folder for the african continent
@@ -176,7 +174,7 @@ databundles:
     destination: "data/landcover"
     urls:
       zenodo: https://sandbox.zenodo.org/record/1016042/files/landcover_latinamerica_caribbean.zip?download=1
-      gdrive: https://drive.google.com/file/d/1lmBFPTHyzVmSx9qgrGh8D6uHiSyGaH_F/view?usp=sharing
+      gdrive: https://drive.google.com/file/d/1d3l9qxPnM9XbXODWkP4kWxK_t5cDcEIZ/view
     output: [data/landcover/*]
 
   # data bundle of the data folder for the african continent
@@ -186,7 +184,7 @@ databundles:
     destination: "data/landcover"
     urls:
       zenodo: https://sandbox.zenodo.org/record/1016042/files/landcover_westasia.zip?download=1
-      gdrive: https://drive.google.com/file/d/1s9JRWJaeet4syInGap6FyqDBJIR80UHr/view?usp=sharing
+      gdrive: https://drive.google.com/file/d/1XsZVZDORUFMKyHfAkzqxDVBENiuy4jEM/view
     output: [data/landcover/*]
 
   # data bundle of the data folder for europe
@@ -196,7 +194,7 @@ databundles:
     destination: "data/landcover"
     urls:
       zenodo: https://sandbox.zenodo.org/record/1018640/files/landcover_europe.zip?download=1
-      gdrive: https://drive.google.com/file/d/1zQuKnZFp6ASYD_e-dbWbWXYg330E0occ/view?usp=sharing
+      gdrive: https://drive.google.com/file/d/1MfT3cwHJbNTtTjRLzW2T19f9qBNAxdhw/view
     output: [data/landcover/*]
 
   # data bundle of the data folder for the poles
@@ -206,7 +204,7 @@ databundles:
     destination: "data/landcover"
     urls:
       zenodo: https://sandbox.zenodo.org/record/1018640/files/landcover_northamerica.zip?download=1
-      gdrive: https://drive.google.com/file/d/1gu7PH08ZEpL4cBQa_fMUSq2m6LY1_UJo/view?usp=sharing
+      gdrive: https://drive.google.com/file/d/1Dc11J2BZQQeJWxwCC6GiiPd_GWMCN0uF/view
     output: [data/landcover/*]
 
   # data bundle of the data folder for the poles
@@ -216,7 +214,7 @@ databundles:
     destination: "data/landcover"
     urls:
       zenodo: https://sandbox.zenodo.org/record/1018640/files/landcover_polar.zip?download=1
-      gdrive: https://drive.google.com/file/d/1cUDcE6wpQVZNf3K9ffV6pNXfxq6sA65E/view?usp=sharing
+      gdrive: https://drive.google.com/file/d/18uODyONQZJGoL15P-URPl0lJs7sphQhX/view
     output: [data/landcover/*]
 
   # # data bundle of the data folder for the african continent
@@ -269,7 +267,7 @@ databundles:
     destination: "cutouts"
     urls:
       zenodo: https://sandbox.zenodo.org/record/1016042/files/cutouts_africa.zip?download=1
-      gdrive: https://drive.google.com/file/d/1-Njs7BqG0YE5QwBHj0zgkdicb5IQvQCh/view
+      gdrive: https://drive.google.com/file/d/1uCn7S5EHnPuaZHG5sWEVx2lT6Ve2r5dk/view
     output: [cutouts/africa-2013-era5.nc]
     disable_by_opt:
       build_cutout: [all]

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -35,6 +35,8 @@ Upcoming Release
 
 * Add meta data of config to pypsa network per default. Allows keeping track of the config used to generate the network `PR #526 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/526>`__
 
+* Calculate the outputs of retrieve_databundle dynamically depending on settings `PR #529 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/529>`__
+
 PyPSA-Earth 0.1.0
 =================
 

--- a/scripts/download_osm_data.py
+++ b/scripts/download_osm_data.py
@@ -693,7 +693,7 @@ def create_country_list(input, iso_coding=True):
         full_codes_list.extend(codes_list)
 
     # Removing duplicates and filter outputs by coding
-    full_codes_list = filter_codes(set(full_codes_list), iso_coding=iso_coding)
+    full_codes_list = filter_codes(list(set(full_codes_list)), iso_coding=iso_coding)
 
     return full_codes_list
 

--- a/scripts/retrieve_databundle_light.py
+++ b/scripts/retrieve_databundle_light.py
@@ -642,20 +642,36 @@ if __name__ == "__main__":
         Link: https://pypsa-earth.readthedocs.io/en/latest/introduction.html#licence"
     )
 
+    logger.info(
+        "Bundles to be downloaded:\n\t" + "\n\t".join(bundles_to_download)
+    )
+
     # download the selected bundles
     for b_name in bundles_to_download:
         host_list = config_bundles[b_name]["urls"]
+
+        downloaded_bundle = False
+
         # loop all hosts until data is successfully downloaded
         for host in host_list:
-            # try:
-            download_and_unzip = globals()[f"download_and_unzip_{host}"]
-            if download_and_unzip(
-                config_bundles[b_name], rootpath, disable_progress=disable_progress
-            ):
-                break
-            # except KeyError:
-            #     logger.error(f"Function for {host} has not been defined")
 
+            logger.info(f"Downloading bundle {b_name} - Host {host}")
+
+            try:
+                download_and_unzip = globals()[f"download_and_unzip_{host}"]
+                if download_and_unzip(
+                    config_bundles[b_name], rootpath, disable_progress=disable_progress
+                ):
+                    downloaded_bundle = True
+            except Exception:
+                logger.warning(f"Error in downloading bundle {b_name} - host {host}")
+
+            if downloaded_bundle:
+                break
+        
+        if not downloaded_bundle:
+            logger.error(f"Bundle {b_name} cannot be downloaded")
+    
     logger.info(
         "Bundle successfully loaded and unzipped:\n\t" + "\n\t".join(bundles_to_download)
     )

--- a/scripts/retrieve_databundle_light.py
+++ b/scripts/retrieve_databundle_light.py
@@ -443,7 +443,9 @@ def _check_disabled_by_opt(config_bundle, config_enable):
     return disabled_outs
 
 
-def get_best_bundles_by_category(country_list, category, config_bundles, tutorial, config_enable):
+def get_best_bundles_by_category(
+    country_list, category, config_bundles, tutorial, config_enable
+):
     """
         get_best_bundles_by_category(country_list, category, config_bundles, tutorial)
 
@@ -549,7 +551,7 @@ def get_best_bundles(countries, config_bundles, tutorial, config_enable):
 
     """
 
-        # categories of data to download
+    # categories of data to download
     categories = list(
         set([config_bundles[conf]["category"] for conf in config_bundles])
     )
@@ -579,13 +581,14 @@ def get_best_bundles(countries, config_bundles, tutorial, config_enable):
                     f"Multiple bundle data for category {cat}: "
                     + ", ".join(selection_bundles)
                 )
-    
+
     return bundles_to_download
+
 
 def datafiles_retrivedatabundle(config):
     """
-        Function to get the output files from the bundles,
-        given the target countries, tutorial settings, etc.
+    Function to get the output files from the bundles,
+    given the target countries, tutorial settings, etc.
     """
 
     tutorial = config["tutorial"]
@@ -593,18 +596,23 @@ def datafiles_retrivedatabundle(config):
     config_enable = config["enable"]
 
     config_bundles = load_databundle_config(config["databundles"])
-    
-    bundles_to_download = get_best_bundles(countries, config_bundles, tutorial, config_enable)
 
-    listoutputs = set([
-        inneroutput
-        for bundlename in bundles_to_download
-        for inneroutput in config["databundles"][bundlename]["output"]
-        if "*" not in inneroutput
-        or inneroutput.endswith("/")  # exclude directories
-    ])
+    bundles_to_download = get_best_bundles(
+        countries, config_bundles, tutorial, config_enable
+    )
+
+    listoutputs = set(
+        [
+            inneroutput
+            for bundlename in bundles_to_download
+            for inneroutput in config["databundles"][bundlename]["output"]
+            if "*" not in inneroutput
+            or inneroutput.endswith("/")  # exclude directories
+        ]
+    )
 
     return listoutputs
+
 
 if __name__ == "__main__":
 
@@ -631,8 +639,10 @@ if __name__ == "__main__":
     config_enable = snakemake.config["enable"]
     # load databundle configuration
     config_bundles = load_databundle_config(snakemake.config["databundles"])
-    
-    bundles_to_download = get_best_bundles(countries, config_bundles, tutorial, config_enable)
+
+    bundles_to_download = get_best_bundles(
+        countries, config_bundles, tutorial, config_enable
+    )
 
     logger.warning(
         "DISCLAIMER LICENSES: the use of PyPSA-Earth is conditioned \n \
@@ -642,9 +652,7 @@ if __name__ == "__main__":
         Link: https://pypsa-earth.readthedocs.io/en/latest/introduction.html#licence"
     )
 
-    logger.info(
-        "Bundles to be downloaded:\n\t" + "\n\t".join(bundles_to_download)
-    )
+    logger.info("Bundles to be downloaded:\n\t" + "\n\t".join(bundles_to_download))
 
     # download the selected bundles
     for b_name in bundles_to_download:
@@ -668,10 +676,11 @@ if __name__ == "__main__":
 
             if downloaded_bundle:
                 break
-        
+
         if not downloaded_bundle:
             logger.error(f"Bundle {b_name} cannot be downloaded")
-    
+
     logger.info(
-        "Bundle successfully loaded and unzipped:\n\t" + "\n\t".join(bundles_to_download)
+        "Bundle successfully loaded and unzipped:\n\t"
+        + "\n\t".join(bundles_to_download)
     )

--- a/scripts/retrieve_databundle_light.py
+++ b/scripts/retrieve_databundle_light.py
@@ -443,11 +443,11 @@ def _check_disabled_by_opt(config_bundle, config_enable):
     return disabled_outs
 
 
-def get_best_bundles(country_list, category, config_bundles, tutorial, config_enable):
+def get_best_bundles_by_category(country_list, category, config_bundles, tutorial, config_enable):
     """
-        get_best_bundles(country_list, category, config_bundles, tutorial)
+        get_best_bundles_by_category(country_list, category, config_bundles, tutorial)
 
-    Function to get the best bundles that download the datafor selected countries,
+    Function to get the best bundles that download the data for selected countries,
     given category and tutorial characteristics.
 
     The selected bundles shall adhere to the following criteria:
@@ -514,7 +514,100 @@ def get_best_bundles(country_list, category, config_bundles, tutorial, config_en
     return returned_bundles
 
 
+def get_best_bundles(countries, config_bundles, tutorial, config_enable):
+    """
+        get_best_bundles(countries, category, config_bundles, tutorial)
+
+    Function to get the best bundles that download the data for selected countries,
+    given tutorial characteristics.
+
+    First, the categories of data to download are identified in agreement to
+    the bundles that match the list of countries and tutorial configuration.
+
+    Then, the bundles to be downloaded shall adhere to the following criteria:
+    - The bundles' tutorial parameter shall match the tutorial argument
+    - The bundles' category shall match the category of data to download
+    - When multiple bundles are identified for the same set of users,
+      the bundles matching more countries are first selected and more bundles
+      are added until all countries are matched or no more bundles are available
+
+    Inputs
+    ------
+    countries : list
+        List of country codes for the countries to download
+    config_bundles : Dict
+        Dictionary of configurations for all available bundles
+    tutorial : Bool
+        Whether data for tutorial shall be downloaded
+    config_enable : dict
+        Dictionary of the enabled/disabled scripts
+
+    Outputs
+    -------
+    returned_bundles : list
+        List of bundles to download
+
+    """
+
+        # categories of data to download
+    categories = list(
+        set([config_bundles[conf]["category"] for conf in config_bundles])
+    )
+
+    # idenfify matched countries for every bundle
+    for bname in config_bundles:
+        config_bundles[bname]["matched_countries"] = [
+            c for c in config_bundles[bname]["countries"] if c in countries
+        ]
+        n_matched = len(config_bundles[bname]["matched_countries"])
+        config_bundles[bname]["n_matched"] = n_matched
+
+    # bundles to download
+    bundles_to_download = []
+
+    for cat in categories:
+        selection_bundles = get_best_bundles_by_category(
+            countries, cat, config_bundles, tutorial, config_enable
+        )
+
+        # check if non-empty dictionary
+        if selection_bundles:
+            bundles_to_download.extend(selection_bundles)
+
+            if len(selection_bundles) > 1:
+                logger.warning(
+                    f"Multiple bundle data for category {cat}: "
+                    + ", ".join(selection_bundles)
+                )
+    
+    return bundles_to_download
+
+def datafiles_retrivedatabundle(config):
+    """
+        Function to get the output files from the bundles,
+        given the target countries, tutorial settings, etc.
+    """
+
+    tutorial = config["tutorial"]
+    countries = config["countries"]
+    config_enable = config["enable"]
+
+    config_bundles = load_databundle_config(config["databundles"])
+    
+    bundles_to_download = get_best_bundles(countries, config_bundles, tutorial, config_enable)
+
+    listoutputs = set([
+        inneroutput
+        for bundlename in bundles_to_download
+        for inneroutput in config["databundles"][bundlename]["output"]
+        if "*" not in inneroutput
+        or inneroutput.endswith("/")  # exclude directories
+    ])
+
+    return listoutputs
+
 if __name__ == "__main__":
+
     if "snakemake" not in globals():
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
         from _helpers import mock_snakemake
@@ -538,40 +631,11 @@ if __name__ == "__main__":
     config_enable = snakemake.config["enable"]
     # load databundle configuration
     config_bundles = load_databundle_config(snakemake.config["databundles"])
-
-    # categories of data to download
-    categories = list(
-        set([config_bundles[conf]["category"] for conf in config_bundles])
-    )
-
-    # idenfify matched countries for every bundle
-    for bname in config_bundles:
-        config_bundles[bname]["matched_countries"] = [
-            c for c in config_bundles[bname]["countries"] if c in countries
-        ]
-        n_matched = len(config_bundles[bname]["matched_countries"])
-        config_bundles[bname]["n_matched"] = n_matched
-
-    # bundles to download
-    bundle_to_download = []
-
-    for cat in categories:
-        selection_bundles = get_best_bundles(
-            countries, cat, config_bundles, tutorial, config_enable
-        )
-
-        # check if non-empty dictionary
-        if selection_bundles:
-            bundle_to_download.extend(selection_bundles)
-
-            if len(selection_bundles) > 1:
-                logger.warning(
-                    f"Multiple bundle data for category {cat}: "
-                    + ", ".join(selection_bundles)
-                )
+    
+    bundles_to_download = get_best_bundles(countries, config_bundles, tutorial, config_enable)
 
     logger.warning(
-        "DISCLAIMER LICENSES: the use of PyPSA-Earth is conditioned \
+        "DISCLAIMER LICENSES: the use of PyPSA-Earth is conditioned \n \
         to the acceptance of its multiple licenses.\n \
         The use of the code automatically implies that you accept all the licenses.\n \
         See our documentation for more information. \n \
@@ -579,7 +643,7 @@ if __name__ == "__main__":
     )
 
     # download the selected bundles
-    for b_name in bundle_to_download:
+    for b_name in bundles_to_download:
         host_list = config_bundles[b_name]["urls"]
         # loop all hosts until data is successfully downloaded
         for host in host_list:
@@ -593,7 +657,5 @@ if __name__ == "__main__":
             #     logger.error(f"Function for {host} has not been defined")
 
     logger.info(
-        "Bundle successfully loaded and unzipped:\n\t" + "\n\t".join(bundle_to_download)
+        "Bundle successfully loaded and unzipped:\n\t" + "\n\t".join(bundles_to_download)
     )
-    # print("Bundle successfully loaded and unzipped:\n\t" +
-    #       "\n\t".join(bundle_to_download))

--- a/scripts/retrieve_databundle_light.py
+++ b/scripts/retrieve_databundle_light.py
@@ -601,7 +601,7 @@ def datafiles_retrivedatabundle(config):
         countries, config_bundles, tutorial, config_enable
     )
 
-    listoutputs = set(
+    listoutputs = list(set(
         [
             inneroutput
             for bundlename in bundles_to_download
@@ -609,7 +609,7 @@ def datafiles_retrivedatabundle(config):
             if "*" not in inneroutput
             or inneroutput.endswith("/")  # exclude directories
         ]
-    )
+    ))
 
     return listoutputs
 

--- a/scripts/retrieve_databundle_light.py
+++ b/scripts/retrieve_databundle_light.py
@@ -601,15 +601,17 @@ def datafiles_retrivedatabundle(config):
         countries, config_bundles, tutorial, config_enable
     )
 
-    listoutputs = list(set(
-        [
-            inneroutput
-            for bundlename in bundles_to_download
-            for inneroutput in config["databundles"][bundlename]["output"]
-            if "*" not in inneroutput
-            or inneroutput.endswith("/")  # exclude directories
-        ]
-    ))
+    listoutputs = list(
+        set(
+            [
+                inneroutput
+                for bundlename in bundles_to_download
+                for inneroutput in config["databundles"][bundlename]["output"]
+                if "*" not in inneroutput
+                or inneroutput.endswith("/")  # exclude directories
+            ]
+        )
+    )
 
     return listoutputs
 


### PR DESCRIPTION
# Closes #519 

## Changes proposed in this Pull Request
This is a fix to identify the outputs of the retrieve_databundle depending on the bundles that are being downloaded given the set of countries that has been specified

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [x] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
