### PR TITLE
Fix geometry issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,27 +148,6 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
 <table>
 <tr>
     <td align="center">
-        <a href="https://github.com/hazemakhalek">
-            <img src="https://avatars.githubusercontent.com/u/26235356?v=4" width="100;" alt="hazemakhalek"/>
-            <br />
-            <sub><b>Null</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/jarry7">
-            <img src="https://avatars.githubusercontent.com/u/27745389?v=4" width="100;" alt="jarry7"/>
-            <br />
-            <sub><b>Jarrad Wright</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/fneum">
-            <img src="https://avatars.githubusercontent.com/u/29101152?v=4" width="100;" alt="fneum"/>
-            <br />
-            <sub><b>Fabian Neumann</b></sub>
-        </a>
-    </td>
-    <td align="center">
         <a href="https://github.com/ekatef">
             <img src="https://avatars.githubusercontent.com/u/30229437?v=4" width="100;" alt="ekatef"/>
             <br />
@@ -176,39 +155,10 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
         </a>
     </td>
     <td align="center">
-        <a href="https://github.com/euronion">
-            <img src="https://avatars.githubusercontent.com/u/42553970?v=4" width="100;" alt="euronion"/>
+        <a href="https://github.com/davide-f">
+            <img src="https://avatars.githubusercontent.com/u/67809479?v=4" width="100;" alt="davide-f"/>
             <br />
-            <sub><b>Euronion</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/Justus-coded">
-            <img src="https://avatars.githubusercontent.com/u/44394641?v=4" width="100;" alt="Justus-coded"/>
-            <br />
-            <sub><b>Justus Ilemobayo</b></sub>
-        </a>
-    </td></tr>
-<tr>
-    <td align="center">
-        <a href="https://github.com/mnm-matin">
-            <img src="https://avatars.githubusercontent.com/u/45293386?v=4" width="100;" alt="mnm-matin"/>
-            <br />
-            <sub><b>Mnm-matin</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/desenk">
-            <img src="https://avatars.githubusercontent.com/u/48335263?v=4" width="100;" alt="desenk"/>
-            <br />
-            <sub><b>Desen Kirli</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/LukasFrankenQ">
-            <img src="https://avatars.githubusercontent.com/u/55196140?v=4" width="100;" alt="LukasFrankenQ"/>
-            <br />
-            <sub><b>Lukas Franken</b></sub>
+            <sub><b>Davide-f</b></sub>
         </a>
     </td>
     <td align="center">
@@ -219,27 +169,27 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
         </a>
     </td>
     <td align="center">
-        <a href="https://github.com/Cesare-Caputo">
-            <img src="https://avatars.githubusercontent.com/u/62548290?v=4" width="100;" alt="Cesare-Caputo"/>
+        <a href="https://github.com/restyled-commits">
+            <img src="https://avatars.githubusercontent.com/u/65077583?v=4" width="100;" alt="restyled-commits"/>
+            <br />
+            <sub><b>Restyled Commits</b></sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/mnm-matin">
+            <img src="https://avatars.githubusercontent.com/u/45293386?v=4" width="100;" alt="mnm-matin"/>
+            <br />
+            <sub><b>Mnm-matin</b></sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/DeniseGiub">
+            <img src="https://avatars.githubusercontent.com/u/113139589?v=4" width="100;" alt="DeniseGiub"/>
             <br />
             <sub><b>Null</b></sub>
         </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/davide-f">
-            <img src="https://avatars.githubusercontent.com/u/67809479?v=4" width="100;" alt="davide-f"/>
-            <br />
-            <sub><b>Davide-f</b></sub>
-        </a>
     </td></tr>
 <tr>
-    <td align="center">
-        <a href="https://github.com/koen-vg">
-            <img src="https://avatars.githubusercontent.com/u/74298901?v=4" width="100;" alt="koen-vg"/>
-            <br />
-            <sub><b>Koen Van Greevenbroek</b></sub>
-        </a>
-    </td>
     <td align="center">
         <a href="https://github.com/Hazem-IEG">
             <img src="https://avatars.githubusercontent.com/u/87850910?v=4" width="100;" alt="Hazem-IEG"/>
@@ -254,28 +204,6 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
             <sub><b>EnergyLS</b></sub>
         </a>
     </td>
-    <td align="center">
-        <a href="https://github.com/AnasAlgarei">
-            <img src="https://avatars.githubusercontent.com/u/101210563?v=4" width="100;" alt="AnasAlgarei"/>
-            <br />
-            <sub><b>AnasAlgarei</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/restyled-commits">
-            <img src="https://avatars.githubusercontent.com/u/65077583?v=4" width="100;" alt="restyled-commits"/>
-            <br />
-            <sub><b>Restyled Commits</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/DeniseGiub">
-            <img src="https://avatars.githubusercontent.com/u/113139589?v=4" width="100;" alt="DeniseGiub"/>
-            <br />
-            <sub><b>Null</b></sub>
-        </a>
-    </td></tr>
-<tr>
     <td align="center">
         <a href="https://github.com/Tomkourou">
             <img src="https://avatars.githubusercontent.com/u/5240283?v=4" width="100;" alt="Tomkourou"/>
@@ -298,10 +226,39 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
         </a>
     </td>
     <td align="center">
+        <a href="https://github.com/euronion">
+            <img src="https://avatars.githubusercontent.com/u/42553970?v=4" width="100;" alt="euronion"/>
+            <br />
+            <sub><b>Euronion</b></sub>
+        </a>
+    </td></tr>
+<tr>
+    <td align="center">
+        <a href="https://github.com/AnasAlgarei">
+            <img src="https://avatars.githubusercontent.com/u/101210563?v=4" width="100;" alt="AnasAlgarei"/>
+            <br />
+            <sub><b>AnasAlgarei</b></sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/LukasFrankenQ">
+            <img src="https://avatars.githubusercontent.com/u/55196140?v=4" width="100;" alt="LukasFrankenQ"/>
+            <br />
+            <sub><b>Lukas Franken</b></sub>
+        </a>
+    </td>
+    <td align="center">
         <a href="https://github.com/Tooblippe">
             <img src="https://avatars.githubusercontent.com/u/805313?v=4" width="100;" alt="Tooblippe"/>
             <br />
             <sub><b>Jarrad Wright</b></sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/koen-vg">
+            <img src="https://avatars.githubusercontent.com/u/74298901?v=4" width="100;" alt="koen-vg"/>
+            <br />
+            <sub><b>Koen Van Greevenbroek</b></sub>
         </a>
     </td>
     <td align="center">
@@ -319,6 +276,13 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
         </a>
     </td></tr>
 <tr>
+    <td align="center">
+        <a href="https://github.com/jarry7">
+            <img src="https://avatars.githubusercontent.com/u/27745389?v=4" width="100;" alt="jarry7"/>
+            <br />
+            <sub><b>Jarrad Wright</b></sub>
+        </a>
+    </td>
     <td align="center">
         <a href="https://github.com/squoilin">
             <img src="https://avatars.githubusercontent.com/u/4547840?v=4" width="100;" alt="squoilin"/>

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -41,6 +41,8 @@ Upcoming Release
 
 * Calculate the outputs of retrieve_databundle dynamically depending on settings `PR #529 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/529>`__
 
+* Fix geo-shapes geometry issues found for some world regions `PR #532 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/532>`__
+
 PyPSA-Earth 0.1.0
 =================
 

--- a/scripts/build_bus_regions.py
+++ b/scripts/build_bus_regions.py
@@ -262,6 +262,7 @@ if __name__ == "__main__":
         crs=country_shapes.crs,
     ).dropna(axis="index", subset=["geometry"])
 
+    # sometimes Voronoi partition may give empty polygons
     onshore_regions = pd.concat([onshore_regions[~onshore_regions.is_empty]], ignore_index=True).to_file(
         snakemake.output.regions_onshore
     )

--- a/scripts/build_bus_regions.py
+++ b/scripts/build_bus_regions.py
@@ -76,6 +76,9 @@ def custom_voronoi_partition_pts(points, outline, add_bounds_shape=True, multipl
     import numpy as np
     from scipy.spatial import Voronoi
     from shapely.geometry import Point, Polygon
+    from shapely.ops import unary_union
+
+    outline = unary_union(outline)
 
     points = np.asarray(points)
 

--- a/scripts/build_bus_regions.py
+++ b/scripts/build_bus_regions.py
@@ -263,9 +263,9 @@ if __name__ == "__main__":
     ).dropna(axis="index", subset=["geometry"])
 
     # sometimes Voronoi partition may give empty polygons
-    onshore_regions = pd.concat([onshore_regions[~onshore_regions.is_empty]], ignore_index=True).to_file(
-        snakemake.output.regions_onshore
-    )
+    onshore_regions = pd.concat(
+        [onshore_regions[~onshore_regions.is_empty]], ignore_index=True
+    ).to_file(snakemake.output.regions_onshore)
 
     if offshore_regions:
         # if a offshore_regions exists excute below

--- a/scripts/build_bus_regions.py
+++ b/scripts/build_bus_regions.py
@@ -262,7 +262,7 @@ if __name__ == "__main__":
         crs=country_shapes.crs,
     ).dropna(axis="index", subset=["geometry"])
 
-    onshore_regions = pd.concat([onshore_regions], ignore_index=True).to_file(
+    onshore_regions = pd.concat([onshore_regions[~onshore_regions.is_empty]], ignore_index=True).to_file(
         snakemake.output.regions_onshore
     )
 

--- a/scripts/build_bus_regions.py
+++ b/scripts/build_bus_regions.py
@@ -270,12 +270,14 @@ if __name__ == "__main__":
             offshore_regions.append(offshore_regions_c)
 
     # create geodataframe and remove nan shapes
-    onshore_regions = gpd.GeoDataFrame(
-        pd.concat(onshore_regions, ignore_index=True),
-        crs=country_shapes.crs,
-    ).dropna(
-    axis="index", subset=["geometry"]
-    ).to_file(snakemake.output.regions_onshore)
+    onshore_regions = (
+        gpd.GeoDataFrame(
+            pd.concat(onshore_regions, ignore_index=True),
+            crs=country_shapes.crs,
+        )
+        .dropna(axis="index", subset=["geometry"])
+        .to_file(snakemake.output.regions_onshore)
+    )
 
     if offshore_regions:
         # if a offshore_regions exists excute below

--- a/scripts/build_bus_regions.py
+++ b/scripts/build_bus_regions.py
@@ -273,11 +273,8 @@ if __name__ == "__main__":
     onshore_regions = gpd.GeoDataFrame(
         pd.concat(onshore_regions, ignore_index=True),
         crs=country_shapes.crs,
-    ).dropna(axis="index", subset=["geometry"])
-
-    # sometimes Voronoi partition may give empty polygons
-    onshore_regions = pd.concat(
-        [onshore_regions[~onshore_regions.is_empty]], ignore_index=True
+    ).dropna(
+    axis="index", subset=["geometry"]
     ).to_file(snakemake.output.regions_onshore)
 
     if offshore_regions:

--- a/scripts/build_osm_network.py
+++ b/scripts/build_osm_network.py
@@ -831,8 +831,12 @@ def built_network(inputs, outputs, geo_crs, distance_crs):
     country_list = input
     bus_country_list = buses["country"].unique().tolist()
 
-    if len(bus_country_list) != len(country_list):
-        no_data_countries = set(country_list).difference(set(bus_country_list))
+    # it may happen that bus_country_list contains entries not relevant as a country name (e.g. "not found")
+    # difference can't give negative values; the following will return only releant country names
+    no_data_countries = set(country_list).difference(set(bus_country_list))
+    
+    if len(no_data_countries) > 0:
+        
         no_data_countries_shape = country_shapes[
             country_shapes.index.isin(no_data_countries) == True
         ].reset_index()

--- a/scripts/build_osm_network.py
+++ b/scripts/build_osm_network.py
@@ -834,9 +834,9 @@ def built_network(inputs, outputs, geo_crs, distance_crs):
     # it may happen that bus_country_list contains entries not relevant as a country name (e.g. "not found")
     # difference can't give negative values; the following will return only releant country names
     no_data_countries = set(country_list).difference(set(bus_country_list))
-    
+
     if len(no_data_countries) > 0:
-        
+
         no_data_countries_shape = country_shapes[
             country_shapes.index.isin(no_data_countries) == True
         ].reset_index()

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -24,6 +24,7 @@ from _helpers import (
     three_2_two_digits_country,
     two_2_three_digits_country,
     two_digits_2_name_country,
+    country_name_2_two_digits,
 )
 from rasterio.mask import mask
 from shapely.geometry import LineString, MultiPolygon, Point, Polygon

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -126,6 +126,12 @@ def get_GADM_layer(country_list, layer_id, geo_crs, update=False, outlogging=Fal
             three_2_two_digits_country(twoD_c) for twoD_c in geodf_temp["GID_0"]
         ]
 
+        # GID_0 may have some exotic values, "COUNTRY" column may be used instead
+        geodf_temp["GID_0"] = geodf_temp.apply(
+            lambda x: restore_country_code_by_name(x, country_code=country_code), 
+            axis=1
+        )          
+        
         # create a subindex column that is useful
         # in the GADM processing of sub-national zones
         geodf_temp["GADM_ID"] = geodf_temp[f"GID_{layer_id}"]

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -846,5 +846,5 @@ if __name__ == "__main__":
         if not row.geometry.is_valid
         else row.geometry,
         axis=1,
-    )    
+    )
     save_to_geojson(gadm_shapes, out.gadm_shapes)

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -868,8 +868,7 @@ if __name__ == "__main__":
     # e.g. that is the case for enclaves like Dahagram–Angarpota for IN/BD
     country_shapes_valid = country_shapes.apply(
         lambda x: make_valid(x) if not x.is_valid else x
-    )
-    country_shapes_valid.reset_index().to_file(snakemake.output.country_shapes)
+    ).reset_index().to_file(snakemake.output.country_shapes)
 
     offshore_shapes = eez(
         countries_list, geo_crs, country_shapes, EEZ_gpkg, out_logging

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -286,7 +286,9 @@ def eez(countries, geo_crs, country_shapes, EEZ_gpkg, out_logging=False, distanc
     )
 
     ret_df = ret_df.apply(lambda x: make_valid(x))
-    country_shapes = country_shapes.apply(lambda x: make_valid(x))
+
+    # country_shapes may consist of different geometries which need to be united
+    country_shapes = country_shapes.apply(lambda x: make_valid(x)).unary_union
 
     country_shapes_with_buffer = country_shapes.buffer(distance)
     ret_df_new = ret_df.difference(country_shapes_with_buffer)

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -20,11 +20,11 @@ import rioxarray as rx
 import xarray as xr
 from _helpers import (
     configure_logging,
+    country_name_2_two_digits,
     sets_path_to_root,
     three_2_two_digits_country,
     two_2_three_digits_country,
     two_digits_2_name_country,
-    country_name_2_two_digits,
 )
 from rasterio.mask import mask
 from shapely.geometry import LineString, MultiPolygon, Point, Polygon
@@ -81,11 +81,13 @@ def download_GADM(country_code, update=False, out_logging=False):
 
     return GADM_inputfile_gpkg, GADM_filename
 
+
 def restore_country_code_by_name(row, country_code):
     if row["GID_0"] != country_code:
-         return country_name_2_two_digits(row["COUNTRY"])
+        return country_name_2_two_digits(row["COUNTRY"])
     else:
-        return row["GID_0"]   
+        return row["GID_0"]
+
 
 def get_GADM_layer(country_list, layer_id, geo_crs, update=False, outlogging=False):
     """
@@ -128,12 +130,13 @@ def get_GADM_layer(country_list, layer_id, geo_crs, update=False, outlogging=Fal
 
         # GID_0 may have some exotic values, "COUNTRY" column may be used instead
         geodf_temp["GID_0"] = geodf_temp.apply(
-            lambda x: restore_country_code_by_name(x, country_code=country_code), 
-            axis=1
-        )          
-        
+            lambda x: restore_country_code_by_name(x, country_code=country_code), axis=1
+        )
+
         # "not found" hardcoded according to country_converter conventions
-        geodf_temp.drop(geodf_temp[geodf_temp["GID_0"] == "not found"].index, inplace=True)
+        geodf_temp.drop(
+            geodf_temp[geodf_temp["GID_0"] == "not found"].index, inplace=True
+        )
 
         # create a subindex column that is useful
         # in the GADM processing of sub-national zones

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -87,17 +87,14 @@ def restore_country_code_by_name(row, country_code):
     else:
         return row["GID_0"]
 
-#  file=file_gpkg, layer=layer_id, cc=country_code 
-def build_gadm_df(file, layer, cc): 
+
+#  file=file_gpkg, layer=layer_id, cc=country_code
+def build_gadm_df(file, layer, cc):
     # read gpkg file
-    geodf = gpd.read_file(file, layer="ADM_ADM_" + str(layer)).to_crs(
-        geo_crs
-    )
+    geodf = gpd.read_file(file, layer="ADM_ADM_" + str(layer)).to_crs(geo_crs)
 
     # convert country name representation of the main country (GID_0 column)
-    geodf["GID_0"] = [
-        three_2_two_digits_country(twoD_c) for twoD_c in geodf["GID_0"]
-    ]
+    geodf["GID_0"] = [three_2_two_digits_country(twoD_c) for twoD_c in geodf["GID_0"]]
 
     # GID_0 may have some exotic values, "COUNTRY" column may be used instead
     geodf["GID_0"] = geodf.apply(
@@ -105,14 +102,12 @@ def build_gadm_df(file, layer, cc):
     )
 
     # "not found" hardcoded according to country_converter conventions
-    geodf.drop(
-        geodf[geodf["GID_0"] == "not found"].index, inplace=True
-    )
+    geodf.drop(geodf[geodf["GID_0"] == "not found"].index, inplace=True)
 
     # create a subindex column that is useful
     # in the GADM processing of sub-national zones
     geodf["GADM_ID"] = geodf[f"GID_{layer}"]
-    
+
     if layer >= 1:
         available_gadm_codes = geodf["GADM_ID"].unique()
         code_three_digits = two_2_three_digits_country(cc)
@@ -124,9 +119,7 @@ def build_gadm_df(file, layer, cc):
 
         if len(non_std_gadm_codes) > 0:
             df_filtered = geodf[geodf["GADM_ID"].isin(non_std_gadm_codes)]
-            df_filtered.to_csv(
-                "non_standard_gadm_" + cc + "_raw.csv", index=False
-            )
+            df_filtered.to_csv("non_standard_gadm_" + cc + "_raw.csv", index=False)
 
     return geodf
 
@@ -161,7 +154,7 @@ def get_GADM_layer(country_list, layer_id, geo_crs, update=False, outlogging=Fal
             layer_id = len(list_layers) - 1
 
         geodf_temp = build_gadm_df(file=file_gpkg, layer=layer_id, cc=country_code)
-                    
+
         # append geodataframes
         geodf_list.append(geodf_temp)
 
@@ -867,9 +860,11 @@ if __name__ == "__main__":
 
     # there may be "holes" in the countries geometry which cause troubles along the workflow
     # e.g. that is the case for enclaves like Dahagram–Angarpota for IN/BD
-    country_shapes_valid = country_shapes.apply(
-        lambda x: make_valid(x) if not x.is_valid else x
-    ).reset_index().to_file(snakemake.output.country_shapes)
+    country_shapes_valid = (
+        country_shapes.apply(lambda x: make_valid(x) if not x.is_valid else x)
+        .reset_index()
+        .to_file(snakemake.output.country_shapes)
+    )
 
     offshore_shapes = eez(
         countries_list, geo_crs, country_shapes, EEZ_gpkg, out_logging

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -824,9 +824,17 @@ def gadm(
     # set index and simplify polygons
     df_gadm.set_index("GADM_ID", inplace=True)
     df_gadm["geometry"] = df_gadm["geometry"].map(_simplify_polys)
+    # df_gadm = df_gadm[df_gadm.geometry.is_valid & ~df_gadm.geometry.is_empty]
     df_gadm = df_gadm[~df_gadm.geometry.is_empty].geometry.apply(
         lambda r: make_valid(r) if not r.is_valid else r
     )
+
+    # gadm_shapes.geometry = gadm_shapes.apply(
+    #     lambda row: make_valid(row.geometry)
+    #     if not row.geometry.is_valid
+    #     else row.geometry,
+    #     axis=1,
+    # )
 
     return df_gadm
 
@@ -884,4 +892,10 @@ if __name__ == "__main__":
         year,
         nprocesses=nprocesses,
     )
+    # gadm_shapes.geometry = gadm_shapes.apply(
+    #     lambda row: make_valid(row.geometry)
+    #     if not row.geometry.is_valid
+    #     else row.geometry,
+    #     axis=1,
+    # )
     save_to_geojson(gadm_shapes, out.gadm_shapes)

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -825,9 +825,10 @@ def gadm(
     df_gadm.set_index("GADM_ID", inplace=True)
     df_gadm["geometry"] = df_gadm["geometry"].map(_simplify_polys)
     # df_gadm = df_gadm[df_gadm.geometry.is_valid & ~df_gadm.geometry.is_empty]
-    df_gadm = df_gadm[~df_gadm.geometry.is_empty].geometry.apply(
+    df_gadm.geometry = df_gadm.geometry.apply(
         lambda r: make_valid(r) if not r.is_valid else r
     )
+    df_gadm = df_gadm[df_gadm.geometry.is_valid & ~df_gadm.geometry.is_empty]
 
     # gadm_shapes.geometry = gadm_shapes.apply(
     #     lambda row: make_valid(row.geometry)

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -142,6 +142,28 @@ def get_GADM_layer(country_list, layer_id, geo_crs, update=False, outlogging=Fal
         # in the GADM processing of sub-national zones
         geodf_temp["GADM_ID"] = geodf_temp[f"GID_{layer_id}"]
 
+        if layer_id >= 1:
+            available_gadm_codes = geodf_temp["GADM_ID"].unique()
+            code_three_digits = two_2_three_digits_country(country_code)
+
+            # normally the GADM code starts the ISO3 
+            non_std_gadm_codes = [w for w in available_gadm_codes if not w.startswith(code_three_digits)]
+
+            if len(non_std_gadm_codes) > 0:
+
+                # a "minimalistic" approach outputs a single file (~200kb for CN + IN)
+                d = {"country_code": country_code, "non_standard_gadm_codes": non_std_gadm_codes}
+                df = pd.DataFrame(data = d)
+                output_path = "non_standard_gadm_codes.csv"
+                df.to_csv(output_path, mode = "a", header = not os.path.exists(output_path), 
+                    index = False)
+
+                # a (more useful) approach outputs a file for each of the country (~200kb each for CN and IN)
+                df_filtered = geodf_temp[geodf_temp["GADM_ID"].isin(non_std_gadm_codes)]
+                print(df_filtered)
+                df_filtered.to_csv("non_standard_gadm_" + country_code +  "_raw.csv", index = False)
+
+
         # append geodataframes
         geodf_list.append(geodf_temp)
 

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -128,7 +128,7 @@ def build_gadm_df(file, layer, cc):
                 "non_standard_gadm_" + cc + "_raw.csv", index=False
             )
 
-        return geodf
+    return geodf
 
 
 def get_GADM_layer(country_list, layer_id, geo_crs, update=False, outlogging=False):

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -160,7 +160,6 @@ def get_GADM_layer(country_list, layer_id, geo_crs, update=False, outlogging=Fal
 
                 # a (more useful) approach outputs a file for each of the country (~200kb each for CN and IN)
                 df_filtered = geodf_temp[geodf_temp["GADM_ID"].isin(non_std_gadm_codes)]
-                print(df_filtered)
                 df_filtered.to_csv("non_standard_gadm_" + country_code +  "_raw.csv", index = False)
 
 

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -88,7 +88,7 @@ def restore_country_code_by_name(row, country_code):
         return row["GID_0"]
 
 #  file=file_gpkg, layer=layer_id, cc=country_code 
-def build_gadm_df(file=file_gpkg, layer=layer_id, cc=country_code): 
+def build_gadm_df(file, layer, cc): 
     # read gpkg file
     geodf = gpd.read_file(file, layer="ADM_ADM_" + str(layer)).to_crs(
         geo_crs
@@ -160,7 +160,7 @@ def get_GADM_layer(country_list, layer_id, geo_crs, update=False, outlogging=Fal
             # when layer id is negative or larger than the number of layers, select the last layer
             layer_id = len(list_layers) - 1
 
-        geodf_temp = build_gadm_df()
+        geodf_temp = build_gadm_df(file=file_gpkg, layer=layer_id, cc=country_code)
                     
         # append geodataframes
         geodf_list.append(geodf_temp)

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -812,7 +812,8 @@ if __name__ == "__main__":
 
     country_shapes = countries(countries_list, geo_crs, update, out_logging)
 
-    # there may be holes in geometry which cause a lot of troubles along the workflow
+    # there may be "holes" in the countries geometry which cause troubles along the workflow
+    # e.g. that is the case for enclaves like Dahagram–Angarpota for IN/BD
     country_shapes_valid = country_shapes.apply(
         lambda x: make_valid(x) if not x.is_valid else x
     )

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -169,8 +169,9 @@ def get_GADM_layer(country_list, layer_id, geo_crs, update=False, outlogging=Fal
 
                 # a (more useful) approach outputs a file for each of the country (~200kb each for CN and IN)
                 df_filtered = geodf_temp[geodf_temp["GADM_ID"].isin(non_std_gadm_codes)]
-                df_filtered.to_csv("non_standard_gadm_" + country_code +  "_raw.csv", index = False)
-
+                df_filtered.to_csv(
+                    "non_standard_gadm_" + country_code + "_raw.csv", index=False
+                )
 
         # append geodataframes
         geodf_list.append(geodf_temp)

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -132,6 +132,9 @@ def get_GADM_layer(country_list, layer_id, geo_crs, update=False, outlogging=Fal
             axis=1
         )          
         
+        # "not found" hardcoded according to country_converter conventions
+        geodf_temp.drop(geodf_temp[geodf_temp["GID_0"] == "not found"].index, inplace=True)
+
         # create a subindex column that is useful
         # in the GADM processing of sub-national zones
         geodf_temp["GADM_ID"] = geodf_temp[f"GID_{layer_id}"]

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -146,23 +146,33 @@ def get_GADM_layer(country_list, layer_id, geo_crs, update=False, outlogging=Fal
             available_gadm_codes = geodf_temp["GADM_ID"].unique()
             code_three_digits = two_2_three_digits_country(country_code)
 
-            # normally the GADM code starts the ISO3 
-            non_std_gadm_codes = [w for w in available_gadm_codes if not w.startswith(code_three_digits)]
+            # normally the GADM code starts the ISO3
+            non_std_gadm_codes = [
+                w for w in available_gadm_codes if not w.startswith(code_three_digits)
+            ]
 
             if len(non_std_gadm_codes) > 0:
 
                 # a "minimalistic" approach outputs a single file (~200kb for CN + IN)
-                d = {"country_code": country_code, "non_standard_gadm_codes": non_std_gadm_codes}
-                df = pd.DataFrame(data = d)
+                d = {
+                    "country_code": country_code,
+                    "non_standard_gadm_codes": non_std_gadm_codes,
+                }
+                df = pd.DataFrame(data=d)
                 output_path = "non_standard_gadm_codes.csv"
-                df.to_csv(output_path, mode = "a", header = not os.path.exists(output_path), 
-                    index = False)
+                df.to_csv(
+                    output_path,
+                    mode="a",
+                    header=not os.path.exists(output_path),
+                    index=False,
+                )
 
                 # a (more useful) approach outputs a file for each of the country (~200kb each for CN and IN)
                 df_filtered = geodf_temp[geodf_temp["GADM_ID"].isin(non_std_gadm_codes)]
                 print(df_filtered)
-                df_filtered.to_csv("non_standard_gadm_" + country_code +  "_raw.csv", index = False)
-
+                df_filtered.to_csv(
+                    "non_standard_gadm_" + country_code + "_raw.csv", index=False
+                )
 
         # append geodataframes
         geodf_list.append(geodf_temp)

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -824,7 +824,9 @@ def gadm(
     # set index and simplify polygons
     df_gadm.set_index("GADM_ID", inplace=True)
     df_gadm["geometry"] = df_gadm["geometry"].map(_simplify_polys)
-    df_gadm = df_gadm[df_gadm.geometry.is_valid & ~df_gadm.geometry.is_empty]
+    df_gadm = df_gadm[~df_gadm.geometry.is_empty].geometry.apply(
+        lambda r: make_valid(r) if not r.is_valid else r
+    )
 
     return df_gadm
 
@@ -881,11 +883,5 @@ if __name__ == "__main__":
         out_logging,
         year,
         nprocesses=nprocesses,
-    )
-    gadm_shapes.geometry = gadm_shapes.apply(
-        lambda row: make_valid(row.geometry)
-        if not row.geometry.is_valid
-        else row.geometry,
-        axis=1,
     )
     save_to_geojson(gadm_shapes, out.gadm_shapes)

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -111,9 +111,9 @@ def build_gadm_df(file=file_gpkg, layer=layer_id, cc=country_code):
 
     # create a subindex column that is useful
     # in the GADM processing of sub-national zones
-    geodf["GADM_ID"] = geodf[f"GID_{layer_id}"]
-
-    if layer_id >= 1:
+    geodf["GADM_ID"] = geodf[f"GID_{layer}"]
+    
+    if layer >= 1:
         available_gadm_codes = geodf["GADM_ID"].unique()
         code_three_digits = two_2_three_digits_country(cc)
 

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -123,26 +123,11 @@ def build_gadm_df(file=file_gpkg, layer=layer_id, cc=country_code):
         ]
 
         if len(non_std_gadm_codes) > 0:
-
-            # a "minimalistic" approach outputs a single file (~200kb for CN + IN)
-            d = {
-                "country_code": cc,
-                "non_standard_gadm_codes": non_std_gadm_codes,
-            }
-            df = pd.DataFrame(data=d)
-            output_path = "non_standard_gadm_codes.csv"
-            df.to_csv(
-                output_path,
-                mode="a",
-                header=not os.path.exists(output_path),
-                index=False,
-            )
-
-            # a (more useful) approach outputs a file for each of the country (~200kb each for CN and IN)
             df_filtered = geodf[geodf["GADM_ID"].isin(non_std_gadm_codes)]
             df_filtered.to_csv(
                 "non_standard_gadm_" + cc + "_raw.csv", index=False
             )
+
         return geodf
 
 

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -80,6 +80,11 @@ def download_GADM(country_code, update=False, out_logging=False):
 
     return GADM_inputfile_gpkg, GADM_filename
 
+def restore_country_code_by_name(row, country_code):
+    if row["GID_0"] != country_code:
+         return country_name_2_two_digits(row["COUNTRY"])
+    else:
+        return row["GID_0"]   
 
 def get_GADM_layer(country_list, layer_id, geo_crs, update=False, outlogging=False):
     """


### PR DESCRIPTION
It has been found during workflow testing on data around the world that underlaying geographical shapes sometimes can be sometimes problematic, namely:

1) it looks like the `GID_0` feature in the gadm file may sometimes have values which do not exactly correspond to the country name. As a result, the`GADM_ID` in the `gadm_shapes.geojson` in may have some unexpected values like `"Z02.28_1"` or `"Z03.28_1"` (taken from data for China), and  leads in `country_shapes.geojson` file to zeros for the population value and `"name": null`. This problem may be reproduced by running `build_shapes` for China or for India and leads to numerous troubles along the workflow.

2) sometimes the country area is a multiply connected region (an area with holes) which is treated by shapely as invalid geometry. In particular, that is the case for Dahagram–Angarpota Bangladeshi enclave in India.

3) it may happen that Voronoi partition leads to empty polygons which are not filtered by `dropna()`, are being written as `none` geometry into `"regions_onshore.geojson"` and cause some troubles propagating along the workflow. In particular, that is the case for Kazakhstan shapes (OSM data on 4.12.2022, 10 clusters).

## Changes proposed in this Pull Request

This pull request is intended to fix such regional-specific issues.

## Checklist

- [x] Clean-up the code
- [x] I tested my contribution locally and it seems to work fine
    - [x] for India (the GADM issue & multply connected regions)
    - [x] for China (the GADM issue)
    - [x] for Kazakhstan (the empty geometry issue)
    - [x] for Malaysia (no issues, a complex shape)
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [x] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.