### PR TITLE
Move PyPSA dependency back to the main repository

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -141,7 +141,7 @@ lines:
     220.: "Al/St 240/40 2-bundle 220.0"
     300.: "Al/St 240/40 3-bundle 300.0"
     380.: "Al/St 240/40 4-bundle 380.0"
-  dc_type: "DC_custom_linetype"
+  dc_type: "HVDC XLPE 1000"
   s_max_pu: 0.7
   s_nom_max: .inf
   length_factor: 1.25

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -155,7 +155,7 @@ lines:
     220.: "Al/St 240/40 2-bundle 220.0"
     300.: "Al/St 240/40 3-bundle 300.0"
     380.: "Al/St 240/40 4-bundle 380.0"
-  dc_type: "DC_custom_linetype"
+  dc_type: "HVDC XLPE 1000"
   s_max_pu: 0.7
   s_nom_max: .inf
   length_factor: 1.25

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -41,6 +41,8 @@ Upcoming Release
 
 * Calculate the outputs of retrieve_databundle dynamically depending on settings `PR #529 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/529>`__
 
+* Adapt dependencies on PyPSA to the PyPSA main branch `PR #538 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/538>`__
+
 PyPSA-Earth 0.1.0
 =================
 

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -76,7 +76,6 @@ dependencies:
 - gurobi
 
 - pip:
-  - git+https://github.com/PyPSA/powerplantmatching.git@master
   - git+https://github.com/davide-f/google-drive-downloader@master  # google drive with fix for virus scan
   - git+https://github.com/davide-f/atlite.git@master
   - vresutils>=0.3.1

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -76,11 +76,10 @@ dependencies:
 - gurobi
 
 - pip:
-  # - git+https://github.com/pypsa/pypsa.git#egg=pypsa
+  - git+https://github.com/pypsa/pypsa.git#egg=pypsa
   - git+https://github.com/PyPSA/powerplantmatching.git@master
   - git+https://github.com/davide-f/google-drive-downloader@master  # google drive with fix for virus scan
   - git+https://github.com/davide-f/atlite.git@master
-  - git+https://github.com/ekatef/PyPSA.git@master
   - vresutils>=0.3.1
   - tsam>=1.1.0
   - esy-osm-pbf

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -35,7 +35,7 @@ dependencies:
 - networkx
 - scipy
 - pydoe2
-- shapely<2
+- shapely>=1.8a1, <2.0
 - pre-commit
 - pyomo
 - matplotlib<=3.5.2

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -15,7 +15,7 @@ dependencies:
 - pypsa>=0.21.3
 # - atlite>=0.2.4  # until https://github.com/PyPSA/atlite/issues/244 is not merged
 - dask
-# - powerplantmatching>=0.5.4 # until entsoe-py>=0.5.9 will be available via conda-forge
+- powerplantmatching>=0.5.5
 
   # Dependencies of the workflow itself
 - xlrd

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -15,7 +15,7 @@ dependencies:
 - pypsa>=0.21.3
 # - atlite>=0.2.4  # until https://github.com/PyPSA/atlite/issues/244 is not merged
 - dask
-  # - powerplantmatching>=0.4.8
+# - powerplantmatching>=0.5.4 # until entsoe-py>=0.5.9 will be available via conda-forge
 
   # Dependencies of the workflow itself
 - xlrd

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -12,7 +12,7 @@ dependencies:
 - pip
 - mamba   # esp for windows build
 
-# - pypsa>=0.17.1
+- pypsa>=0.21.3
 # - atlite>=0.2.4  # until https://github.com/PyPSA/atlite/issues/244 is not merged
 - dask
   # - powerplantmatching>=0.4.8
@@ -76,7 +76,6 @@ dependencies:
 - gurobi
 
 - pip:
-  - git+https://github.com/pypsa/pypsa.git#egg=pypsa
   - git+https://github.com/PyPSA/powerplantmatching.git@master
   - git+https://github.com/davide-f/google-drive-downloader@master  # google drive with fix for virus scan
   - git+https://github.com/davide-f/atlite.git@master

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -35,7 +35,7 @@ dependencies:
 - networkx
 - scipy
 - pydoe2
-- shapely>=1.8a1
+- shapely<2
 - pre-commit
 - pyomo
 - matplotlib<=3.5.2


### PR DESCRIPTION
## Changes proposed in this Pull Request

After merging https://github.com/PyPSA/PyPSA/pull/517 we may git rid on the fork dependency

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [x] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
