### PR TITLE
Fix invalid outline which stopped workflow

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -41,6 +41,8 @@ Upcoming Release
 
 * Calculate the outputs of retrieve_databundle dynamically depending on settings `PR #529 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/529>`__
 
+* Fix shape bug in the Voronoi cell creation `PR #541 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/541>`__
+
 PyPSA-Earth 0.1.0
 =================
 

--- a/scripts/build_bus_regions.py
+++ b/scripts/build_bus_regions.py
@@ -122,6 +122,9 @@ def custom_voronoi_partition_pts(points, outline, add_bounds_shape=True, multipl
             if not poly.is_valid:
                 poly = poly.buffer(0)
 
+            if not outline.is_valid:
+                outline = outline.buffer(0)
+
             poly = poly.intersection(outline)
 
             polygons_arr[i] = poly


### PR DESCRIPTION
## Changes proposed in this Pull Request
Apply make_valid also to outline to fix bug.
**It was not possible to intersect a valid with an invalid shape

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
