### PR TITLE
fix numpy version

### DIFF
--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -26,7 +26,7 @@ dependencies:
 - ruamel.yaml
 - pytables
 - lxml
-- numpy
+- numpy<1.24
 - pandas
 - geopandas>=0.11.0
 - fiona!=1.8.22


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request
I've experienced that with numpy v1.24 (the latest version) the np.float is no more available and it leads to conflicts with some packages.
The PR is ready in case of problems.

Currently the CI is using numpy < 1.24 so we haven't experienced that yet.

## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
