### PR TITLE
Add run scenarios

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -74,7 +74,7 @@ jobs:
       run: |
         mkdir configs/scenarios
         cp test/config.custom.yaml configs/scenarios/config.custom.yaml
-        snakemake --cores all run_all_scenarios --forceall
+        snakemake --cores 1 run_all_scenarios --forceall
 
     - name: Test monte-carlo workflow
       run: |

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -73,7 +73,7 @@ jobs:
     - name: Test custom workflow
       run: |
         mkdir configs/scenarios
-        cp test/config.custom.yaml configs/scenarios/config.custom.yaml
+        cp test/tmp/config.custom_tmp.yaml configs/scenarios/config.custom.yaml
         snakemake --cores 1 run_all_scenarios --forceall
 
     - name: Test monte-carlo workflow

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -72,8 +72,9 @@ jobs:
 
     - name: Test custom workflow
       run: |
-        cp test/tmp/config.custom_tmp.yaml config.yaml
-        snakemake --cores all solve_all_networks --forceall
+        mkdir configs/scenarios
+        cp test/config.custom.yaml configs/scenarios/config.custom.yaml
+        snakemake --cores all run_all_scenarios --forceall
 
     - name: Test monte-carlo workflow
       run: |

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -73,7 +73,7 @@ jobs:
     - name: Test custom workflow
       run: |
         mkdir configs/scenarios
-        cp test/tmp/config.custom_tmp.yaml configs/scenarios/config.custom.yaml
+        cp test/config.custom.yaml configs/scenarios/config.custom.yaml
         snakemake --cores 1 run_all_scenarios --forceall
 
     - name: Test monte-carlo workflow

--- a/Snakefile
+++ b/Snakefile
@@ -846,7 +846,7 @@ rule run_scenario:
         default_config=DEFAULT_CONFIG,
         diff_config="configs/scenarios/config.{scenario_name}.yaml",
     output:
-        touch("results/{scenario_name}/scenario.done"),
+        touchfile=touch("results/{scenario_name}/scenario.done"),
         copyconfig="results/{scenario_name}/config.yaml",
     threads: 1
     resources:
@@ -865,7 +865,7 @@ rule run_scenario:
         os.system(
             "snakemake -j all solve_all_networks --forceall --rerun-incomplete"
         )
-        copyfile("config.yaml", input.copyconfig)
+        copyfile("config.yaml", output.copyconfig)
 
 
 rule run_all_scenarios:

--- a/Snakefile
+++ b/Snakefile
@@ -870,7 +870,7 @@ rule run_all_scenarios:
         expand(
             "results/{scenario_name}/scenario.done",
             scenario_name=[
-                c.replace("config.", "").replace(".yaml", "")
+                c.stem.replace("config.", "")
                 for c in Path("configs/scenarios").glob("config.*.yaml")
             ],
         ),

--- a/Snakefile
+++ b/Snakefile
@@ -844,7 +844,7 @@ rule run_scenario:
         diff_config="configs/scenarios/config.{scenario_name}.yaml",
     output:
         touch("results/{scenario_name}/scenario.done"),
-        copyconfig="results/" + RDIR + "config.yaml",
+        copyconfig="results/{scenario_name}/config.yaml",
     threads: 1
     resources:
         mem_mb=5000,

--- a/Snakefile
+++ b/Snakefile
@@ -28,6 +28,9 @@ if "config" not in globals() or not config:  # skip when used as sub-workflow
 configfile: "configs/bundle_config.yaml"
 
 
+DEFAULT_CONFIG = "config.tutorial.yaml" if config["tutorial"] else "config.default.yaml"
+
+
 # convert country list according to the desired region
 config["countries"] = create_country_list(config["countries"])
 
@@ -840,7 +843,7 @@ rule build_test_configs:
 
 rule run_scenario:
     input:
-        default_config="config.default.yaml",
+        default_config=DEFAULT_CONFIG,
         diff_config="configs/scenarios/config.{scenario_name}.yaml",
     output:
         touch("results/{scenario_name}/scenario.done"),

--- a/Snakefile
+++ b/Snakefile
@@ -850,9 +850,11 @@ rule run_scenario:
         from scripts.build_test_configs import create_test_config
 
         create_test_config(
-            diff_config, {"run": {"name": scenario_name}}, diff_config
+            input.diff_config,
+            {"run": {"name": wildcards.scenario_name}},
+            input.diff_config,
         )
-        create_test_config(base_config, diff_config, "config.yaml")
+        create_test_config(input.base_config, input.diff_config, "config.yaml")
         os.system(
             "snakemake -j all solve_all_networks --forceall --rerun-incomplete"
         )

--- a/Snakefile
+++ b/Snakefile
@@ -866,7 +866,11 @@ rule run_all_scenarios:
             "results/{scenario_name}/scenario.done",
             scenario_name=[
                 c.replace("config.", "").replace(".yaml", "")
-                for c in os.listdir("configs/scenarios")
+                for c in (
+                    os.listdir("configs/scenarios")
+                    if isdir("configs/scenarios")
+                    else []
+                )
                 if c.startswith("config.") and c.endswith(".yaml")
             ],
         ),

--- a/scripts/build_test_configs.py
+++ b/scripts/build_test_configs.py
@@ -26,6 +26,27 @@ def update(d, u):
     return d
 
 
+def create_test_config(base_path, changes_path, output_path):
+    # Input paths
+    fp_baseconfig = Path(Path.cwd(), base_path)
+    fp_update_file = Path(Path.cwd(), changes_path)
+
+    # Load yaml files
+    yaml = YAML()
+    with open(fp_baseconfig) as fp:
+        base_config = yaml.load(fp)
+
+    # Load update yaml
+    with open(fp_update_file) as fp:
+        update_config = yaml.load(fp)
+    # create updated yaml
+    test_config = update(copy.deepcopy(base_config), update_config)
+    # Output path
+    fp = Path(Path.cwd(), output_path)
+    # Save file
+    yaml.dump(test_config, fp)
+
+
 if __name__ == "__main__":
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
@@ -34,27 +55,12 @@ if __name__ == "__main__":
         snakemake = mock_snakemake("build_test_configs")
 
     # Input paths
-    fp_baseconfig = Path(Path.cwd(), snakemake.input.base_config)
-    fp_update_file_list = [
-        Path(Path.cwd(), i) for i in snakemake.input.update_file_list
-    ]
+    fp_baseconfig = snakemake.input.base_config
+    fp_update_file_list = snakemake.input.update_file_list
+    fp_output_file_list = snakemake.output.tmp_test_configs
 
-    # Load yaml files
-    yaml = YAML()
-    with open(fp_baseconfig) as fp:
-        base_config = yaml.load(fp)
-
-    for c in fp_update_file_list:
-        # Load update yaml
-        with open(c) as fp:
-            update_config = yaml.load(fp)
-        # create updated yaml
-        test_config = update(copy.deepcopy(base_config), update_config)
-        # Output path
-        list_no = fp_update_file_list.index(c)
-        fp = Path(Path.cwd(), snakemake.output[list_no])
-        # Save file
-        yaml.dump(test_config, fp)
+    for (finput, foutput) in zip(fp_update_file_list, fp_output_file_list):
+        create_test_config(fp_baseconfig, finput, foutput)
 
     # Manual output in terminal
     # import sys

--- a/scripts/build_test_configs.py
+++ b/scripts/build_test_configs.py
@@ -26,19 +26,22 @@ def update(d, u):
     return d
 
 
-def create_test_config(base_path, changes_path, output_path):
+def create_test_config(base_path, update_config, output_path):
     # Input paths
     fp_baseconfig = Path(Path.cwd(), base_path)
-    fp_update_file = Path(Path.cwd(), changes_path)
 
     # Load yaml files
     yaml = YAML()
+
+    # get update
+    if isinstance(update_config, str):
+        fp_update_file = Path(Path.cwd(), update_config)
+        # Load update yaml
+        with open(fp_update_file) as fp:
+            update_config = yaml.load(fp)
     with open(fp_baseconfig) as fp:
         base_config = yaml.load(fp)
 
-    # Load update yaml
-    with open(fp_update_file) as fp:
-        update_config = yaml.load(fp)
     # create updated yaml
     test_config = update(copy.deepcopy(base_config), update_config)
     # Output path

--- a/scripts/build_test_configs.py
+++ b/scripts/build_test_configs.py
@@ -29,7 +29,7 @@ def update(d, u):
 def _parse_inputconfig(input_config, yaml):
     """Utility function to parse input config into a dictionary"""
     if isinstance(input_config, dict):
-        return dict
+        return input_config
 
     if isinstance(input_config, str):
         input_config = Path(Path.cwd(), input_config)
@@ -94,7 +94,3 @@ if __name__ == "__main__":
 
     for (finput, foutput) in zip(fp_update_file_list, fp_output_file_list):
         create_test_config(fp_baseconfig, finput, foutput)
-
-    # Manual output in terminal
-    # import sys
-    # yaml.dump(data, sys.stdout)

--- a/scripts/build_test_configs.py
+++ b/scripts/build_test_configs.py
@@ -26,28 +26,58 @@ def update(d, u):
     return d
 
 
-def create_test_config(base_path, update_config, output_path):
-    # Input paths
-    fp_baseconfig = Path(Path.cwd(), base_path)
+def _parse_inputconfig(input_config, yaml):
+    """Utility function to parse input config into a dictionary"""
+    if isinstance(input_config, dict):
+        return dict
+
+    if isinstance(input_config, str):
+        input_config = Path(Path.cwd(), input_config)
+
+    with open(input_config) as fp:
+        return yaml.load(fp)
+
+
+def create_test_config(default_config, diff_config, output_path):
+    """
+    This function takes as input a default dictionary-like object
+    and a difference dictionary-like object, merges the changes of the latter into the former,
+    and saves the output in the desired output path.
+
+    Inputs
+    ------
+    default_config : dict or path-like
+        Default dictionray-like object provided as
+        a dictionary or a path to a yaml file
+    diff_config : dict or path-like
+        Difference dictionray-like object provided as
+        a dictionary or a path to a yaml file
+    output_path : path-like
+        Output path where the merged dictionary is saved
+
+    Outputs
+    -------
+    - merged dictionary
+
+    """
 
     # Load yaml files
     yaml = YAML()
 
-    # get update
-    if isinstance(update_config, str):
-        fp_update_file = Path(Path.cwd(), update_config)
-        # Load update yaml
-        with open(fp_update_file) as fp:
-            update_config = yaml.load(fp)
-    with open(fp_baseconfig) as fp:
-        base_config = yaml.load(fp)
+    default_config = _parse_inputconfig(default_config, yaml)
+    diff_config = _parse_inputconfig(diff_config, yaml)
 
     # create updated yaml
-    test_config = update(copy.deepcopy(base_config), update_config)
+    merged_config = update(copy.deepcopy(default_config), diff_config)
+
     # Output path
-    fp = Path(Path.cwd(), output_path)
+    if isinstance(output_path, str):
+        output_path = Path(Path.cwd(), output_path)
+
     # Save file
-    yaml.dump(test_config, fp)
+    yaml.dump(merged_config, output_path)
+
+    return merged_config
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Closes #503

## Changes proposed in this Pull Request
This branch aims at creating rules and scripts to iteratively test the workflow on a list of countries.
For each country, the workflow is executed and general statistics are collected.
Intermediate results are also stored.
This can be useful to track the overall status of the workflow for the globe, also collecting statistics that can be useful for validation.

Suggestions are welcome, especially on the statistics to include.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [x] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
