### PR TITLE
Fix type conversion in simplify

### DIFF
--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -375,7 +375,7 @@ def simplify_links(n, costs, config, output, aggregation_strategies=dict()):
                 params.setdefault(attr, default)
             n.links.loc[name] = params
 
-            # n.add("Link", **params)
+    logger.debug("Collecting all components using the busmap")
 
     _aggregate_and_move_components(
         n,

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -265,6 +265,7 @@ def _aggregate_and_move_components(
         df = n.df(c)
         n.mremove(c, df.index[df.bus0.isin(buses_to_del) | df.bus1.isin(buses_to_del)])
 
+
 def simplify_links(n, costs, config, output, aggregation_strategies=dict()):
     ## Complex multi-node links are folded into end-points
     logger.info("Simplifying connected link components")

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -222,7 +222,7 @@ def _adjust_capital_costs_using_connection_costs(n, connection_costs_to_bus, out
                     tech,
                     ", ".join(
                         "{:.0f} Eur/MW/a for `{}`".format(d, b)
-                        for b, d in costs.iteritems()
+                        for b, d in costs.items()
                     ),
                 )
             )
@@ -265,9 +265,8 @@ def _aggregate_and_move_components(
         df = n.df(c)
         n.mremove(c, df.index[df.bus0.isin(buses_to_del) | df.bus1.isin(buses_to_del)])
 
-
 def simplify_links(n, costs, config, output, aggregation_strategies=dict()):
-    # Complex multi-node links are folded into end-points
+    ## Complex multi-node links are folded into end-points
     logger.info("Simplifying connected link components")
 
     if n.links.empty:
@@ -286,6 +285,7 @@ def simplify_links(n, costs, config, output, aggregation_strategies=dict()):
 
     def split_links(nodes):
         nodes = frozenset(nodes)
+
         seen = set()
         supernodes = {m for m in nodes if len(G.adj[m]) > 2 or (set(G.adj[m]) - nodes)}
 
@@ -295,7 +295,7 @@ def simplify_links(n, costs, config, output, aggregation_strategies=dict()):
                     continue
 
                 buses = [u, m]
-                links = [list(ls)]
+                links = [list(ls)]  # [name for name in ls]]
 
                 while m not in (supernodes | seen):
                     seen.add(m)
@@ -303,7 +303,7 @@ def simplify_links(n, costs, config, output, aggregation_strategies=dict()):
                         if m2 in seen or m2 == u:
                             continue
                         buses.append(m2)
-                        links.append(list(ls))
+                        links.append(list(ls))  # [name for name in ls])
                         break
                     else:
                         # stub
@@ -339,7 +339,7 @@ def simplify_links(n, costs, config, output, aggregation_strategies=dict()):
 
             all_links = [i for _, i in sum(links, [])]
 
-            p_max_pu = snakemake.config["links"].get("p_max_pu", 1.0)
+            p_max_pu = config["links"].get("p_max_pu", 1.0)
             lengths = n.links.loc[all_links, "length"]
             name = lengths.idxmax() + "+{}".format(len(links) - 1)
             params = dict(
@@ -370,11 +370,11 @@ def simplify_links(n, costs, config, output, aggregation_strategies=dict()):
             n.mremove("Link", all_links)
 
             static_attrs = n.components["Link"]["attrs"].loc[lambda df: df.static]
-            for attr, default in static_attrs.default.iteritems():
+            for attr, default in static_attrs.default.items():
                 params.setdefault(attr, default)
-            n.links.loc[name] = pd.Series(params)
+            n.links.loc[name] = params
 
-    logger.debug("Collecting all components using the busmap")
+            # n.add("Link", **params)
 
     _aggregate_and_move_components(
         n,
@@ -524,7 +524,6 @@ if __name__ == "__main__":
         p: {k: getattr(pd.Series, v) for k, v in aggregation_strategies[p].items()}
         for p in aggregation_strategies.keys()
     }
-
     n, trafo_map = simplify_network_to_380(n, linetype)
 
     n, simplify_links_map = simplify_links(


### PR DESCRIPTION
# Closes #552

## Changes proposed in this Pull Request
This is a simple fix for issue #552 .
The problem was related to type conversions when using the dataframe.loc = pd.Series
This is general bug fixing; no need to add a release_note for that

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
