### PR TITLE
Save logger output in lightweight version

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,27 +148,6 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
 <table>
 <tr>
     <td align="center">
-        <a href="https://github.com/hazemakhalek">
-            <img src="https://avatars.githubusercontent.com/u/26235356?v=4" width="100;" alt="hazemakhalek"/>
-            <br />
-            <sub><b>Hazemakhalek</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/jarry7">
-            <img src="https://avatars.githubusercontent.com/u/27745389?v=4" width="100;" alt="jarry7"/>
-            <br />
-            <sub><b>Jarrad Wright</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/fneum">
-            <img src="https://avatars.githubusercontent.com/u/29101152?v=4" width="100;" alt="fneum"/>
-            <br />
-            <sub><b>Fabian Neumann</b></sub>
-        </a>
-    </td>
-    <td align="center">
         <a href="https://github.com/ekatef">
             <img src="https://avatars.githubusercontent.com/u/30229437?v=4" width="100;" alt="ekatef"/>
             <br />
@@ -176,39 +155,10 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
         </a>
     </td>
     <td align="center">
-        <a href="https://github.com/euronion">
-            <img src="https://avatars.githubusercontent.com/u/42553970?v=4" width="100;" alt="euronion"/>
+        <a href="https://github.com/davide-f">
+            <img src="https://avatars.githubusercontent.com/u/67809479?v=4" width="100;" alt="davide-f"/>
             <br />
-            <sub><b>Euronion</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/Justus-coded">
-            <img src="https://avatars.githubusercontent.com/u/44394641?v=4" width="100;" alt="Justus-coded"/>
-            <br />
-            <sub><b>Justus Ilemobayo</b></sub>
-        </a>
-    </td></tr>
-<tr>
-    <td align="center">
-        <a href="https://github.com/mnm-matin">
-            <img src="https://avatars.githubusercontent.com/u/45293386?v=4" width="100;" alt="mnm-matin"/>
-            <br />
-            <sub><b>Mnm-matin</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/desenk">
-            <img src="https://avatars.githubusercontent.com/u/48335263?v=4" width="100;" alt="desenk"/>
-            <br />
-            <sub><b>Desen Kirli</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/LukasFrankenQ">
-            <img src="https://avatars.githubusercontent.com/u/55196140?v=4" width="100;" alt="LukasFrankenQ"/>
-            <br />
-            <sub><b>Lukas Franken</b></sub>
+            <sub><b>Davide-f</b></sub>
         </a>
     </td>
     <td align="center">
@@ -219,27 +169,27 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
         </a>
     </td>
     <td align="center">
-        <a href="https://github.com/Cesare-Caputo">
-            <img src="https://avatars.githubusercontent.com/u/62548290?v=4" width="100;" alt="Cesare-Caputo"/>
+        <a href="https://github.com/restyled-commits">
+            <img src="https://avatars.githubusercontent.com/u/65077583?v=4" width="100;" alt="restyled-commits"/>
             <br />
-            <sub><b>Cesare-Caputo</b></sub>
+            <sub><b>Restyled Commits</b></sub>
         </a>
     </td>
     <td align="center">
-        <a href="https://github.com/davide-f">
-            <img src="https://avatars.githubusercontent.com/u/67809479?v=4" width="100;" alt="davide-f"/>
+        <a href="https://github.com/mnm-matin">
+            <img src="https://avatars.githubusercontent.com/u/45293386?v=4" width="100;" alt="mnm-matin"/>
             <br />
-            <sub><b>Davide-f</b></sub>
+            <sub><b>Mnm-matin</b></sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/DeniseGiub">
+            <img src="https://avatars.githubusercontent.com/u/113139589?v=4" width="100;" alt="DeniseGiub"/>
+            <br />
+            <sub><b>Null</b></sub>
         </a>
     </td></tr>
 <tr>
-    <td align="center">
-        <a href="https://github.com/koen-vg">
-            <img src="https://avatars.githubusercontent.com/u/74298901?v=4" width="100;" alt="koen-vg"/>
-            <br />
-            <sub><b>Koen Van Greevenbroek</b></sub>
-        </a>
-    </td>
     <td align="center">
         <a href="https://github.com/Hazem-IEG">
             <img src="https://avatars.githubusercontent.com/u/87850910?v=4" width="100;" alt="Hazem-IEG"/>
@@ -254,28 +204,6 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
             <sub><b>EnergyLS</b></sub>
         </a>
     </td>
-    <td align="center">
-        <a href="https://github.com/AnasAlgarei">
-            <img src="https://avatars.githubusercontent.com/u/101210563?v=4" width="100;" alt="AnasAlgarei"/>
-            <br />
-            <sub><b>AnasAlgarei</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/restyled-commits">
-            <img src="https://avatars.githubusercontent.com/u/65077583?v=4" width="100;" alt="restyled-commits"/>
-            <br />
-            <sub><b>Restyled Commits</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/DeniseGiub">
-            <img src="https://avatars.githubusercontent.com/u/113139589?v=4" width="100;" alt="DeniseGiub"/>
-            <br />
-            <sub><b>Null</b></sub>
-        </a>
-    </td></tr>
-<tr>
     <td align="center">
         <a href="https://github.com/Tomkourou">
             <img src="https://avatars.githubusercontent.com/u/5240283?v=4" width="100;" alt="Tomkourou"/>
@@ -298,10 +226,39 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
         </a>
     </td>
     <td align="center">
+        <a href="https://github.com/euronion">
+            <img src="https://avatars.githubusercontent.com/u/42553970?v=4" width="100;" alt="euronion"/>
+            <br />
+            <sub><b>Euronion</b></sub>
+        </a>
+    </td></tr>
+<tr>
+    <td align="center">
+        <a href="https://github.com/AnasAlgarei">
+            <img src="https://avatars.githubusercontent.com/u/101210563?v=4" width="100;" alt="AnasAlgarei"/>
+            <br />
+            <sub><b>AnasAlgarei</b></sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/LukasFrankenQ">
+            <img src="https://avatars.githubusercontent.com/u/55196140?v=4" width="100;" alt="LukasFrankenQ"/>
+            <br />
+            <sub><b>Lukas Franken</b></sub>
+        </a>
+    </td>
+    <td align="center">
         <a href="https://github.com/Tooblippe">
             <img src="https://avatars.githubusercontent.com/u/805313?v=4" width="100;" alt="Tooblippe"/>
             <br />
             <sub><b>Jarrad Wright</b></sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/koen-vg">
+            <img src="https://avatars.githubusercontent.com/u/74298901?v=4" width="100;" alt="koen-vg"/>
+            <br />
+            <sub><b>Koen Van Greevenbroek</b></sub>
         </a>
     </td>
     <td align="center">
@@ -319,6 +276,13 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
         </a>
     </td></tr>
 <tr>
+    <td align="center">
+        <a href="https://github.com/jarry7">
+            <img src="https://avatars.githubusercontent.com/u/27745389?v=4" width="100;" alt="jarry7"/>
+            <br />
+            <sub><b>Jarrad Wright</b></sub>
+        </a>
+    </td>
     <td align="center">
         <a href="https://github.com/squoilin">
             <img src="https://avatars.githubusercontent.com/u/4547840?v=4" width="100;" alt="squoilin"/>

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -47,6 +47,8 @@ Upcoming Release
 
 * Fix None geometries into regions `PR #546 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/546>`__
 
+* Restore saving of logger outputs `PR #559 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/559>`__
+
 PyPSA-Earth 0.1.0
 =================
 

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -90,7 +90,7 @@ def configure_logging(snakemake, skip_handlers=False):
                 ]
             }
         )
-    logging.basicConfig(**kwargs)
+    logging.basicConfig(**kwargs, force=True)
 
 
 def load_network(import_name=None, custom_components=None):

--- a/scripts/build_bus_regions.py
+++ b/scripts/build_bus_regions.py
@@ -53,7 +53,7 @@ from vresutils.graph import voronoi_partition_pts
 
 # from scripts.build_shapes import gadm
 
-_logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def custom_voronoi_partition_pts(points, outline, add_bounds_shape=True, multiplier=5):
@@ -200,7 +200,7 @@ if __name__ == "__main__":
 
         c_b = n.buses.country == country
         if n.buses.loc[c_b & n.buses.substation_lv, ["x", "y"]].empty:
-            _logger.warning(f"No low voltage buses found for {country}!")
+            logger.warning(f"No low voltage buses found for {country}!")
             continue
 
         onshore_shape = country_shapes[country]
@@ -232,13 +232,13 @@ if __name__ == "__main__":
 
         # These two logging could be commented out
         if country not in offshore_shapes.index:
-            _logger.warning(f"No off-shore shapes for {country}")
+            logger.warning(f"No off-shore shapes for {country}")
             continue
 
         offshore_shape = offshore_shapes[country]
 
         if n.buses.loc[c_b & n.buses.substation_off, ["x", "y"]].empty:
-            _logger.warning(f"No off-shore substations found for {country}")
+            logger.warning(f"No off-shore substations found for {country}")
             continue
         else:
             offshore_locs = n.buses.loc[c_b & n.buses.substation_off, ["x", "y"]]

--- a/scripts/build_natura_raster.py
+++ b/scripts/build_natura_raster.py
@@ -61,7 +61,6 @@ from rasterio.features import geometry_mask
 from rasterio.warp import transform_bounds
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 CUTOUT_CRS = "EPSG:4326"
 

--- a/scripts/build_natura_raster.py
+++ b/scripts/build_natura_raster.py
@@ -60,8 +60,8 @@ from _helpers import configure_logging
 from rasterio.features import geometry_mask
 from rasterio.warp import transform_bounds
 
-_logger = logging.getLogger(__name__)
-_logger.setLevel(logging.INFO)
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 CUTOUT_CRS = "EPSG:4326"
 
@@ -89,7 +89,7 @@ def get_fileshapes(list_paths, accepted_formats=(".shp",)):
 
 def determine_cutout_xXyY(cutout_name, out_logging):
     if out_logging:
-        _logger.info("Stage 1/5: Determine cutout boundaries")
+        logger.info("Stage 1/5: Determine cutout boundaries")
     cutout = atlite.Cutout(cutout_name)
     assert cutout.crs == CUTOUT_CRS
     x, X, y, Y = cutout.extent
@@ -105,7 +105,7 @@ def determine_cutout_xXyY(cutout_name, out_logging):
 
 def get_transform_and_shape(bounds, res, out_logging):
     if out_logging:
-        _logger.info("Stage 2/5: Get transform and shape")
+        logger.info("Stage 2/5: Get transform and shape")
     left, bottom = [(b // res) * res for b in bounds[:2]]
     right, top = [(b // res + 1) * res for b in bounds[2:]]
     # "latitude, longitude" coordinates order
@@ -131,14 +131,14 @@ def unify_protected_shape_areas(inputs, natura_crs, out_logging):
     from shapely.validation import make_valid
 
     if out_logging:
-        _logger.info("Stage 3/5: Unify protected shape area.")
+        logger.info("Stage 3/5: Unify protected shape area.")
 
     # Read only .shp snakemake inputs
     shp_files = [string for string in inputs if ".shp" in string]
     assert len(shp_files) != 0, "no input shapefiles given"
     # Create one geodataframe with all geometries, of all .shp files
     if out_logging:
-        _logger.info(
+        logger.info(
             "Stage 3/5: Unify protected shape area. Step 1: Create one geodataframe with all shapes"
         )
 
@@ -159,12 +159,12 @@ def unify_protected_shape_areas(inputs, natura_crs, out_logging):
             list_shapes.append(shp)
             read_files += 1
         except:
-            _logger.warning(f"Error reading file {i}")
+            logger.warning(f"Error reading file {i}")
 
     # merge dataframes
     shape = gpd.GeoDataFrame(pd.concat(list_shapes)).to_crs(natura_crs)
 
-    _logger.info(f"Read {read_files} out of {total_files} landcover files")
+    logger.info(f"Read {read_files} out of {total_files} landcover files")
 
     # Removes shapely geometry with null values. Returns geoseries.
     shape = shape["geometry"][shape["geometry"].is_valid]
@@ -175,10 +175,10 @@ def unify_protected_shape_areas(inputs, natura_crs, out_logging):
 
     # Unary_union makes out of i.e. 1000 shapes -> 1 unified shape
     if out_logging:
-        _logger.info("Stage 3/5: Unify protected shape area. Step 2: Unify all shapes")
+        logger.info("Stage 3/5: Unify protected shape area. Step 2: Unify all shapes")
     unified_shape_file = unary_union(shape["geometry"])
     if out_logging:
-        _logger.info(
+        logger.info(
             "Stage 3/5: Unify protected shape area. Step 3: Set geometry of unified shape"
         )
     unified_shape = gpd.GeoDataFrame(geometry=[unified_shape_file], crs=natura_crs)
@@ -218,12 +218,12 @@ if __name__ == "__main__":
     )
 
     if out_logging:
-        _logger.info("Stage 4/5: Mask geometry")
+        logger.info("Stage 4/5: Mask geometry")
     raster = ~geometry_mask(shapes.geometry, out_shape, transform)
     raster = raster.astype(rio.uint8)
 
     if out_logging:
-        _logger.info("Stage 5/5: Export as .tiff")
+        logger.info("Stage 5/5: Export as .tiff")
     with rio.open(
         snakemake.output[0],
         "w",

--- a/scripts/build_osm_network.py
+++ b/scripts/build_osm_network.py
@@ -14,7 +14,6 @@ from shapely.ops import linemerge, split
 from tqdm import tqdm
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 def line_endings_to_bus_conversion(lines):

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -33,7 +33,6 @@ from shapely.validation import make_valid
 from tqdm import tqdm
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 sets_path_to_root("pypsa-earth")
 

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -32,8 +32,8 @@ from shapely.ops import unary_union
 from shapely.validation import make_valid
 from tqdm import tqdm
 
-_logger = logging.getLogger(__name__)
-_logger.setLevel(logging.INFO)
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 sets_path_to_root("pypsa-earth")
 
@@ -68,7 +68,7 @@ def download_GADM(country_code, update=False, out_logging=False):
 
     if not os.path.exists(GADM_inputfile_gpkg) or update is True:
         if out_logging:
-            _logger.warning(
+            logger.warning(
                 f"Stage 4/4: {GADM_filename} of country {two_digits_2_name_country(country_code)} does not exist, downloading to {GADM_inputfile_gpkg}"
             )
         #  create data/osm directory
@@ -156,7 +156,7 @@ def countries(countries, geo_crs, update=False, out_logging=False):
     "Create country shapes"
 
     if out_logging:
-        _logger.info("Stage 1 of 4: Create country shapes")
+        logger.info("Stage 1 of 4: Create country shapes")
 
     # download data if needed and get the layer id 0, corresponding to the countries
     df_countries = get_GADM_layer(countries, 0, geo_crs, update, out_logging)
@@ -174,7 +174,7 @@ def countries(countries, geo_crs, update=False, out_logging=False):
 def country_cover(country_shapes, eez_shapes=None, out_logging=False, distance=0.1):
 
     if out_logging:
-        _logger.info("Stage 3 of 4: Merge country shapes to create continent shape")
+        logger.info("Stage 3 of 4: Merge country shapes to create continent shape")
 
     shapes = country_shapes.apply(lambda x: x.buffer(distance))
     shapes_list = list(shapes)
@@ -244,7 +244,7 @@ def eez(countries, geo_crs, country_shapes, EEZ_gpkg, out_logging=False, distanc
     """
 
     if out_logging:
-        _logger.info("Stage 2 of 4: Create offshore shapes")
+        logger.info("Stage 2 of 4: Create offshore shapes")
 
     # load data
     df_eez = load_EEZ(countries, geo_crs, EEZ_gpkg)
@@ -350,7 +350,7 @@ def download_WorldPop_standard(
         Name of the file
     """
     if out_logging:
-        _logger.info("Stage 3/4: Download WorldPop datasets")
+        logger.info("Stage 3/4: Download WorldPop datasets")
 
     if country_code == "XK":
         WorldPop_filename = f"srb_ppp_{year}_UNadj_constrained.tif"
@@ -372,7 +372,7 @@ def download_WorldPop_standard(
 
     if not os.path.exists(WorldPop_inputfile) or update is True:
         if out_logging:
-            _logger.warning(
+            logger.warning(
                 f"Stage 4/4: {WorldPop_filename} does not exist, downloading to {WorldPop_inputfile}"
             )
         #  create data/osm directory
@@ -387,7 +387,7 @@ def download_WorldPop_standard(
                         loaded = True
                         break
         if not loaded:
-            _logger.error(f"Stage 4/4: Impossible to download {WorldPop_filename}")
+            logger.error(f"Stage 4/4: Impossible to download {WorldPop_filename}")
 
     return WorldPop_inputfile, WorldPop_filename
 
@@ -417,7 +417,7 @@ def download_WorldPop_API(
         Name of the file
     """
     if out_logging:
-        _logger.info("Stage 3/4: Download WorldPop datasets")
+        logger.info("Stage 3/4: Download WorldPop datasets")
 
     WorldPop_filename = f"{two_2_three_digits_country(country_code).lower()}_ppp_{year}_UNadj_constrained.tif"
     # Request to get the file
@@ -441,7 +441,7 @@ def download_WorldPop_API(
                     loaded = True
                     break
     if not loaded:
-        _logger.error(f"Stage 4/4: Impossible to download {WorldPop_filename}")
+        logger.error(f"Stage 4/4: Impossible to download {WorldPop_filename}")
 
     return WorldPop_inputfile, WorldPop_filename
 
@@ -453,7 +453,7 @@ def convert_GDP(name_file_nc, year=2015, out_logging=False):
     """
 
     if out_logging:
-        _logger.info("Stage 4/4: Access to GDP raster data")
+        logger.info("Stage 4/4: Access to GDP raster data")
 
     # tif namefile
     name_file_tif = name_file_nc[:-2] + "tif"
@@ -479,7 +479,7 @@ def convert_GDP(name_file_nc, year=2015, out_logging=False):
     list_years = GDP_dataset["time"]
     if year not in list_years:
         if out_logging:
-            _logger.warning(
+            logger.warning(
                 f"Stage 3/4 GDP data of year {year} not found, selected the most recent data ({int(list_years[-1])})"
             )
         year = float(list_years[-1])
@@ -504,7 +504,7 @@ def load_GDP(
     """
 
     if out_logging:
-        _logger.info("Stage 4/4: Access to GDP raster data")
+        logger.info("Stage 4/4: Access to GDP raster data")
 
     # path of the nc file
     name_file_tif = name_file_nc[:-2] + "tif"
@@ -514,7 +514,7 @@ def load_GDP(
 
     if update | (not os.path.exists(GDP_tif)):
         if out_logging:
-            _logger.warning(
+            logger.warning(
                 f"Stage 4/4: File {name_file_tif} not found, the file will be produced by processing {name_file_nc}"
             )
         convert_GDP(name_file_nc, year, out_logging)
@@ -577,7 +577,7 @@ def add_gdp_data(
         - Includes a new column ["gdp"]
     """
     if out_logging:
-        _logger.info("Stage 4/4: Add gdp data to GADM GeoDataFrame")
+        logger.info("Stage 4/4: Add gdp data to GADM GeoDataFrame")
 
     # initialize new gdp column
     df_gadm["gdp"] = 0.0
@@ -618,7 +618,7 @@ def add_gdp_data(
     #     # gdp_by_geom = out_image.sum()/2 + out_image_int.sum()/2
 
     #     if out_logging == True:
-    #         _logger.info("Stage 4/4 GDP: shape: " + str(index) +
+    #         logger.info("Stage 4/4 GDP: shape: " + str(index) +
     #                      " out of " + str(df_gadm.shape[0]))
 
     #     # update the gdp data in the dataset
@@ -677,7 +677,7 @@ def add_population_data(
     """
 
     if out_logging:
-        _logger.info("Stage 4/4 POP: Add population data to GADM GeoDataFrame")
+        logger.info("Stage 4/4 POP: Add population data to GADM GeoDataFrame")
 
     # initialize new population column
     df_gadm["pop"] = 0.0
@@ -744,7 +744,7 @@ def gadm(
 ):
 
     if out_logging:
-        _logger.info("Stage 4/4: Creation GADM GeoDataFrame")
+        logger.info("Stage 4/4: Creation GADM GeoDataFrame")
 
     # download data if needed and get the desired layer_id
     df_gadm = get_GADM_layer(countries, layer_id, geo_crs, update)

--- a/scripts/download_osm_data.py
+++ b/scripts/download_osm_data.py
@@ -46,8 +46,8 @@ from tqdm import tqdm
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-_logger = logging.getLogger(__name__)
-_logger.setLevel(logging.INFO)
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 # logger.setLevel(logging.WARNING)
 
@@ -63,7 +63,7 @@ def getContinentCountry(code):
         if country:
             return continent, country
 
-    _logger.info(f"Missing geofabrik reference for country code {code}")
+    logger.info(f"Missing geofabrik reference for country code {code}")
 
     return continent, country
 
@@ -105,11 +105,11 @@ def download_pbf(country_code, update, verify, logging=True):
         os.getcwd(), "data", "osm", continent, "pbf", geofabrik_filename
     )
 
-    _logger.info(f" Input file {PBF_inputfile} ")
+    logger.info(f" Input file {PBF_inputfile} ")
 
     if not os.path.exists(PBF_inputfile):
         if logging:
-            _logger.info(f"{geofabrik_filename} downloading to {PBF_inputfile}")
+            logger.info(f"{geofabrik_filename} downloading to {PBF_inputfile}")
         #  create data/osm directory
         os.makedirs(os.path.dirname(PBF_inputfile), exist_ok=True)
         with requests.get(geofabrik_url, stream=True, verify=False) as r:
@@ -120,13 +120,13 @@ def download_pbf(country_code, update, verify, logging=True):
                     shutil.copyfileobj(r.raw, f)
             else:
                 # error status code: file not found
-                _logger.error(
+                logger.error(
                     f"Error code: {r.status_code}. File {geofabrik_filename} not downloaded from {geofabrik_url}"
                 )
 
     if verify is True:
         if verify_pbf(PBF_inputfile, geofabrik_url, update) is False:
-            _logger.warning(f"md5 mismatch, deleting {geofabrik_filename}")
+            logger.warning(f"md5 mismatch, deleting {geofabrik_filename}")
             if os.path.exists(PBF_inputfile):
                 os.remove(PBF_inputfile)
 
@@ -222,7 +222,7 @@ def download_and_filter(feature, country_code, update=False, verify=False):
     if os.path.exists(file_stored_pickle):
         filter_file_exists = True
     else:
-        _logger.warning("Element file not found so pre-filtering")
+        logger.warning("Element file not found so pre-filtering")
         filter_file_exists = False
 
     elementname = f"{country_code}_{feature}s"
@@ -237,7 +237,7 @@ def download_and_filter(feature, country_code, update=False, verify=False):
         # copy backup pickle into Data.pickle
         shutil.copyfile(file_stored_pickle, file_pickle)
 
-        _logger.info(
+        logger.info(
             f"Loading {feature} Pickle for {country_name}, iso-code: {country_code}"
         )
 
@@ -245,10 +245,10 @@ def download_and_filter(feature, country_code, update=False, verify=False):
         create_elements = True
         if country_code not in pre_filtered:  # Ensures pre-filter is not run everytime
             new_prefilter_data = True
-            _logger.info(f"Pre-filtering {country_name} ")
+            logger.info(f"Pre-filtering {country_name} ")
             pre_filtered.append(country_code)
 
-        _logger.info(
+        logger.info(
             f"Creating new {feature} Elements for {country_name}, iso-code: {country_code}"
         )
 
@@ -294,7 +294,7 @@ def download_and_filter(feature, country_code, update=False, verify=False):
     logging.disable(
         logging.NOTSET
     )  # Re-enable logging as run_filter disables logging.INFO
-    _logger.info(
+    logger.info(
         f"Pre: {new_prefilter_data}, Elem: {create_elements}, for {feature} in {country_code}"
     )
 
@@ -315,7 +315,7 @@ def convert_filtered_data_to_dfs(country_code, feature_data, feature):
 def lonlat_lookup(df_way, Data):
     """Lookup refs and convert to list of longlats"""
     if "refs" not in df_way.columns:
-        _logger.warning("refs column not found")
+        logger.warning("refs column not found")
         print(df_way.columns)
 
     def look(ref):
@@ -431,7 +431,7 @@ def output_csv_geojson(output_files, df_all_feature, columns_feature, feature, g
     # get path from snakemake; expected geojson
     path_file_geojson = output_files[feature + "s"]
     if not path_file_geojson.endswith(".geojson"):
-        _logger.error(f"Output file feature {feature} is not a geojson file")
+        logger.error(f"Output file feature {feature} is not a geojson file")
     path_file_csv = path_file_geojson.replace(".geojson", ".csv")  # get csv file
 
     if not os.path.exists(path_file_geojson):
@@ -442,7 +442,7 @@ def output_csv_geojson(output_files, df_all_feature, columns_feature, feature, g
     # check dataframe structure to avoid KeyErrors
     if not "lonlat" in df_all_feature.columns:
         if not "geometry" in df_all_feature.columns:
-            _logger.warning(f"Store empty Dataframe for {feature} as geometry missed.")
+            logger.warning(f"Store empty Dataframe for {feature} as geometry missed.")
             gdf_feature = []
             # create empty file to avoid issues with snakemake
             with open(path_file_geojson, "w") as fp:
@@ -472,7 +472,7 @@ def output_csv_geojson(output_files, df_all_feature, columns_feature, feature, g
     to_csv_nafix(df_all_feature, path_file_csv)  # Generate CSV
 
     if df_all_feature.empty:
-        _logger.warning(f"Store empty Dataframe for {feature}.")
+        logger.warning(f"Store empty Dataframe for {feature}.")
         gdf_feature = []
 
         # create empty file to avoid issues with snakemake
@@ -486,7 +486,7 @@ def output_csv_geojson(output_files, df_all_feature, columns_feature, feature, g
     else:
         gdf_feature = convert_pd_to_gdf_nodes(df_all_feature, geo_crs)
 
-    _logger.info("Writing GeoJSON file")
+    logger.info("Writing GeoJSON file")
     gdf_feature.to_file(path_file_geojson, driver="GeoJSON")  # Generate GeoJson
 
 
@@ -561,7 +561,7 @@ def process_data(
 
     # parallel download of data if parallel download is enabled
     if nprocesses > 1:
-        _logger.info(
+        logger.info(
             f"Parallel raw osm data (pbf files) download with {nprocesses} threads"
         )
         parallel_download_pbf(country_list, nprocesses, update, verify)
@@ -585,11 +585,11 @@ def process_data(
             if feature_category[feature] == "way":
                 convert_ways_lines(
                     df_way, Data, OSM_CRS, distance_crs
-                ) if not df_way.empty else _logger.warning(
+                ) if not df_way.empty else logger.warning(
                     f"Empty Way Dataframe for {feature} in {country_code}"
                 )
                 if not df_node.empty:
-                    _logger.warning(
+                    logger.warning(
                         f"Node dataframe not empty for {feature} in {country_code}"
                     )
 
@@ -657,7 +657,7 @@ def create_country_list(input, iso_coding=True):
 
             # check if elements have been removed and return a working if so
             if len(ret_list) < len(c_list):
-                _logger.warning(
+                logger.warning(
                     "Specified country list contains the following non-iso codes: "
                     + ", ".join(list(set(c_list) - set(ret_list)))
                 )

--- a/scripts/download_osm_data.py
+++ b/scripts/download_osm_data.py
@@ -47,9 +47,6 @@ from tqdm import tqdm
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
-
-# logger.setLevel(logging.WARNING)
 
 OSM_CRS = "EPSG:4326"
 

--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -33,7 +33,7 @@ from matplotlib.patches import Circle, Ellipse
 
 to_rgba = mpl.colors.colorConverter.to_rgba
 
-_logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def make_handler_map_to_scale_circles_as_in(ax, dont_resize_actively=False):
@@ -121,7 +121,7 @@ def plot_map(n, ax=None, attribute="p_nom", opts={}):
         link_widths_exp = n.links.p_nom_opt
         link_widths_cur = n.links.p_nom_min
     else:
-        _logger.error("plotting of {} has not been implemented yet".format(attribute))
+        logger.error("plotting of {} has not been implemented yet".format(attribute))
 
     line_colors_with_alpha = (line_widths_cur / n.lines.s_nom > 1e-3).map(
         {True: line_colors["cur"], False: to_rgba(line_colors["cur"], 0.0)}

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -162,9 +162,7 @@ def plot_energy(infn, fn=None):
     df = df.drop(to_drop)
 
     if not to_drop.empty:
-        logger.info(
-            "Remaining elements in energy dataframe:\n" + df.to_string() + "\n"
-        )
+        logger.info("Remaining elements in energy dataframe:\n" + df.to_string() + "\n")
 
     new_index_energy = df.index.intersection(preferred_order).append(
         df.index.difference(preferred_order)

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -20,7 +20,7 @@ import matplotlib.pyplot as plt
 import pandas as pd
 from _helpers import configure_logging
 
-_logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def rename_techs(label):
@@ -80,7 +80,7 @@ def plot_costs(infn, fn=None):
     to_drop = df.index[df.max(axis=1) < snakemake.config["plotting"]["costs_threshold"]]
 
     if not to_drop.empty:
-        _logger.info(
+        logger.info(
             "Dropping elements from costs dataframe:\n"
             + df.loc[to_drop].to_string()
             + "\n"
@@ -89,7 +89,7 @@ def plot_costs(infn, fn=None):
     df = df.drop(to_drop)
 
     if not to_drop.empty:
-        _logger.info("Remaining elements in costs dataframe:\n" + df.to_string() + "\n")
+        logger.info("Remaining elements in costs dataframe:\n" + df.to_string() + "\n")
 
     new_index_costs = df.index.intersection(preferred_order).append(
         df.index.difference(preferred_order)
@@ -101,7 +101,7 @@ def plot_costs(infn, fn=None):
     fig_costs.set_size_inches((12, 8))
 
     if new_index_costs.empty:
-        _logger.error(
+        logger.error(
             f"No costs data to plot for country {snakemake.wildcards.country}, no valid plot is generated"
         )
         # create empty file to avoid issues with snakemake
@@ -153,7 +153,7 @@ def plot_energy(infn, fn=None):
     ]
 
     if not to_drop.empty:
-        _logger.info(
+        logger.info(
             "Dropping elements from energy dataframe:\n"
             + df.loc[to_drop].to_string()
             + "\n"
@@ -162,7 +162,7 @@ def plot_energy(infn, fn=None):
     df = df.drop(to_drop)
 
     if not to_drop.empty:
-        _logger.info(
+        logger.info(
             "Remaining elements in energy dataframe:\n" + df.to_string() + "\n"
         )
 
@@ -176,7 +176,7 @@ def plot_energy(infn, fn=None):
     fig_energy.set_size_inches((12, 8))
 
     if new_index_energy.empty:
-        _logger.error(
+        logger.error(
             f"No energy data to plot for country {snakemake.wildcards.country}, no valid plot is generated"
         )
         # create empty file to avoid issues with snakemake
@@ -242,6 +242,6 @@ if __name__ == "__main__":
     try:
         func = globals()[f"plot_{summary}"]
     except KeyError:
-        _logger.error(f"plotting function for {summary} has not been defined")
+        logger.error(f"plotting function for {summary} has not been defined")
 
     func(os.path.join(snakemake.input[0], f"{summary}.csv"), snakemake.output[0])

--- a/scripts/retrieve_databundle_light.py
+++ b/scripts/retrieve_databundle_light.py
@@ -91,7 +91,6 @@ from download_osm_data import create_country_list
 from google_drive_downloader import GoogleDriveDownloader as gdd
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 def load_databundle_config(config):


### PR DESCRIPTION
# Closes #535 

That is a lighter version of #555 

It looks like the warnings of our workflow are not saved as the root logger still has some handlers configured when `basicConfig( )` is called. In that case `basicConfig( )` function does nothing, according to [logging documentation](https://github.com/python/cpython/blob/3.8/Lib/logging/__init__.py#L1912). This issue may be resolved just by setting force to True.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [x] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
