### PR TITLE
Update to numpy 1.24 and shapely 2

### DIFF
--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -26,7 +26,7 @@ dependencies:
 - ruamel.yaml
 - pytables
 - lxml
-- numpy<1.24
+- numpy
 - pandas
 - geopandas>=0.11.0
 - fiona!=1.8.22
@@ -35,7 +35,7 @@ dependencies:
 - networkx
 - scipy
 - pydoe2
-- shapely>=1.8a1, <2.0
+- shapely>=2
 - pre-commit
 - pyomo
 - matplotlib<=3.5.2
@@ -78,7 +78,7 @@ dependencies:
 - pip:
   - git+https://github.com/davide-f/google-drive-downloader@master  # google drive with fix for virus scan
   - git+https://github.com/davide-f/atlite.git@master
-  - vresutils>=0.3.1
+  - git+https://github.com/FRESNA/vresutils@master  # until new pip release > 0.3.1 (strictly)
   - tsam>=1.1.0
   - esy-osm-pbf
   - esy-osmfilter


### PR DESCRIPTION
# Closes #561 

## Changes proposed in this Pull Request
Fix numpy and shapely 2.

Note: with the new release, some weird warnings appear in build_bus_regions:
`/home/davidef/miniconda3/envs/pypsa-earth-new/lib/python3.10/site-packages/shapely/set_operations.py:133: RuntimeWarning: invalid value encountered in intersection
  return lib.intersection(a, b, **kwargs)`

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [x] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
