### PR TITLE
Fix islanded buses and add clustering by networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,81 +155,10 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
 <table>
 <tr>
     <td align="center">
-        <a href="https://github.com/hazemakhalek">
-            <img src="https://avatars.githubusercontent.com/u/26235356?v=4" width="100;" alt="hazemakhalek"/>
-            <br />
-            <sub><b>Null</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/jarry7">
-            <img src="https://avatars.githubusercontent.com/u/27745389?v=4" width="100;" alt="jarry7"/>
-            <br />
-            <sub><b>Jarrad Wright</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/fneum">
-            <img src="https://avatars.githubusercontent.com/u/29101152?v=4" width="100;" alt="fneum"/>
-            <br />
-            <sub><b>Fabian Neumann</b></sub>
-        </a>
-    </td>
-    <td align="center">
         <a href="https://github.com/ekatef">
             <img src="https://avatars.githubusercontent.com/u/30229437?v=4" width="100;" alt="ekatef"/>
             <br />
             <sub><b>Ekaterina</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/euronion">
-            <img src="https://avatars.githubusercontent.com/u/42553970?v=4" width="100;" alt="euronion"/>
-            <br />
-            <sub><b>Euronion</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/Justus-coded">
-            <img src="https://avatars.githubusercontent.com/u/44394641?v=4" width="100;" alt="Justus-coded"/>
-            <br />
-            <sub><b>Justus Ilemobayo</b></sub>
-        </a>
-    </td></tr>
-<tr>
-    <td align="center">
-        <a href="https://github.com/mnm-matin">
-            <img src="https://avatars.githubusercontent.com/u/45293386?v=4" width="100;" alt="mnm-matin"/>
-            <br />
-            <sub><b>Mnm-matin</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/desenk">
-            <img src="https://avatars.githubusercontent.com/u/48335263?v=4" width="100;" alt="desenk"/>
-            <br />
-            <sub><b>Desen Kirli</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/LukasFrankenQ">
-            <img src="https://avatars.githubusercontent.com/u/55196140?v=4" width="100;" alt="LukasFrankenQ"/>
-            <br />
-            <sub><b>Lukas Franken</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/pz-max">
-            <img src="https://avatars.githubusercontent.com/u/61968949?v=4" width="100;" alt="pz-max"/>
-            <br />
-            <sub><b>Max Parzen</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/Cesare-Caputo">
-            <img src="https://avatars.githubusercontent.com/u/62548290?v=4" width="100;" alt="Cesare-Caputo"/>
-            <br />
-            <sub><b>Null</b></sub>
         </a>
     </td>
     <td align="center">
@@ -238,34 +167,12 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
             <br />
             <sub><b>Davide-f</b></sub>
         </a>
-    </td></tr>
-<tr>
-    <td align="center">
-        <a href="https://github.com/koen-vg">
-            <img src="https://avatars.githubusercontent.com/u/74298901?v=4" width="100;" alt="koen-vg"/>
-            <br />
-            <sub><b>Koen Van Greevenbroek</b></sub>
-        </a>
     </td>
     <td align="center">
-        <a href="https://github.com/Hazem-IEG">
-            <img src="https://avatars.githubusercontent.com/u/87850910?v=4" width="100;" alt="Hazem-IEG"/>
+        <a href="https://github.com/pz-max">
+            <img src="https://avatars.githubusercontent.com/u/61968949?v=4" width="100;" alt="pz-max"/>
             <br />
-            <sub><b>Hazem-IEG</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/energyLS">
-            <img src="https://avatars.githubusercontent.com/u/89515385?v=4" width="100;" alt="energyLS"/>
-            <br />
-            <sub><b>EnergyLS</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/AnasAlgarei">
-            <img src="https://avatars.githubusercontent.com/u/101210563?v=4" width="100;" alt="AnasAlgarei"/>
-            <br />
-            <sub><b>AnasAlgarei</b></sub>
+            <sub><b>Max Parzen</b></sub>
         </a>
     </td>
     <td align="center">
@@ -281,8 +188,29 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
             <br />
             <sub><b>Null</b></sub>
         </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/mnm-matin">
+            <img src="https://avatars.githubusercontent.com/u/45293386?v=4" width="100;" alt="mnm-matin"/>
+            <br />
+            <sub><b>Mnm-matin</b></sub>
+        </a>
     </td></tr>
 <tr>
+    <td align="center">
+        <a href="https://github.com/Hazem-IEG">
+            <img src="https://avatars.githubusercontent.com/u/87850910?v=4" width="100;" alt="Hazem-IEG"/>
+            <br />
+            <sub><b>Hazem-IEG</b></sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/energyLS">
+            <img src="https://avatars.githubusercontent.com/u/89515385?v=4" width="100;" alt="energyLS"/>
+            <br />
+            <sub><b>EnergyLS</b></sub>
+        </a>
+    </td>
     <td align="center">
         <a href="https://github.com/Tomkourou">
             <img src="https://avatars.githubusercontent.com/u/5240283?v=4" width="100;" alt="Tomkourou"/>
@@ -305,10 +233,39 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
         </a>
     </td>
     <td align="center">
+        <a href="https://github.com/euronion">
+            <img src="https://avatars.githubusercontent.com/u/42553970?v=4" width="100;" alt="euronion"/>
+            <br />
+            <sub><b>Euronion</b></sub>
+        </a>
+    </td></tr>
+<tr>
+    <td align="center">
+        <a href="https://github.com/AnasAlgarei">
+            <img src="https://avatars.githubusercontent.com/u/101210563?v=4" width="100;" alt="AnasAlgarei"/>
+            <br />
+            <sub><b>AnasAlgarei</b></sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/LukasFrankenQ">
+            <img src="https://avatars.githubusercontent.com/u/55196140?v=4" width="100;" alt="LukasFrankenQ"/>
+            <br />
+            <sub><b>Lukas Franken</b></sub>
+        </a>
+    </td>
+    <td align="center">
         <a href="https://github.com/Tooblippe">
             <img src="https://avatars.githubusercontent.com/u/805313?v=4" width="100;" alt="Tooblippe"/>
             <br />
             <sub><b>Jarrad Wright</b></sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/koen-vg">
+            <img src="https://avatars.githubusercontent.com/u/74298901?v=4" width="100;" alt="koen-vg"/>
+            <br />
+            <sub><b>Koen Van Greevenbroek</b></sub>
         </a>
     </td>
     <td align="center">
@@ -326,6 +283,13 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
         </a>
     </td></tr>
 <tr>
+    <td align="center">
+        <a href="https://github.com/jarry7">
+            <img src="https://avatars.githubusercontent.com/u/27745389?v=4" width="100;" alt="jarry7"/>
+            <br />
+            <sub><b>Jarrad Wright</b></sub>
+        </a>
+    </td>
     <td align="center">
         <a href="https://github.com/squoilin">
             <img src="https://avatars.githubusercontent.com/u/4547840?v=4" width="100;" alt="squoilin"/>

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -62,6 +62,8 @@ cluster_options:
     exclude_carriers: []
     remove_stubs: true
     remove_stubs_across_borders: true
+    p_threshold_drop_isolated: 10 # [MW] isolated buses are being discarded if bus mean power is below the specified threshold 
+    p_threshold_merge_isolated: 300 # [MW] isolated buses are being merged into a single isolated bus if bus mean power is above the specified threshold 
   cluster_network:
     algorithm: kmeans
     feature: solar+onwind-time

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -62,8 +62,8 @@ cluster_options:
     exclude_carriers: []
     remove_stubs: true
     remove_stubs_across_borders: true
-    p_threshold_drop_isolated: 10 # [MW] isolated buses are being discarded if bus mean power is below the specified threshold 
-    p_threshold_merge_isolated: 300 # [MW] isolated buses are being merged into a single isolated bus if bus mean power is above the specified threshold 
+    p_threshold_drop_isolated: 10 # [MW] isolated buses are being discarded if bus mean power is below the specified threshold
+    p_threshold_merge_isolated: 300 # [MW] isolated buses are being merged into a single isolated bus if bus mean power is above the specified threshold
   cluster_network:
     algorithm: kmeans
     feature: solar+onwind-time

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -74,6 +74,8 @@ cluster_options:
     exclude_carriers: []
     remove_stubs: true
     remove_stubs_across_borders: true
+    p_threshold_drop_isolated: 10 # [MW] isolated buses are being discarded if bus mean power is below the specified threshold 
+    p_threshold_merge_isolated: 300 # [MW] isolated buses are being merged into a single isolated bus if bus mean power is above the specified threshold 
   cluster_network:
     algorithm: kmeans
     feature: solar+onwind-time

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -74,8 +74,8 @@ cluster_options:
     exclude_carriers: []
     remove_stubs: true
     remove_stubs_across_borders: true
-    p_threshold_drop_isolated: 10 # [MW] isolated buses are being discarded if bus mean power is below the specified threshold 
-    p_threshold_merge_isolated: 300 # [MW] isolated buses are being merged into a single isolated bus if bus mean power is above the specified threshold 
+    p_threshold_drop_isolated: 10 # [MW] isolated buses are being discarded if bus mean power is below the specified threshold
+    p_threshold_merge_isolated: 300 # [MW] isolated buses are being merged into a single isolated bus if bus mean power is above the specified threshold
   cluster_network:
     algorithm: kmeans
     feature: solar+onwind-time

--- a/scripts/build_demand_profiles.py
+++ b/scripts/build_demand_profiles.py
@@ -182,7 +182,7 @@ def build_demand_profiles(
     demand_profiles = demand_profiles.loc[start_date:end_date]
     demand_profiles.to_csv(out_path, header=True)
 
-    logger.info(f"Demand_profiles csv file created for the corrisponding snapshots.")
+    logger.info(f"Demand_profiles csv file created for the corresponding snapshots.")
 
 
 if __name__ == "__main__":

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -423,7 +423,20 @@ def aggregate_to_substations(n, aggregation_strategies=dict(), buses_i=None):
         logger.info(
             "Aggregating buses that are no substations or have no valid offshore connection"
         )
-        buses_i = list(set(n.buses.index) - set(n.generators.bus) - set(n.loads.bus))
+        # isolated buses should be excluded from adjacency_matrix calculations
+        n.determine_network_topology()
+        # duplicated sub-networks mean that there is at least one interconnection between buses
+        i_islands = n.buses[
+            (~n.buses.duplicated(subset=["sub_network"], keep=False))
+            & (n.buses.carrier == "AC")
+        ].index
+
+        buses_i = list(
+            set(n.buses.index)
+            - set(i_islands)
+            - set(n.generators.bus)
+            - set(n.loads.bus)
+        )
 
     weight = pd.concat(
         {
@@ -446,6 +459,10 @@ def aggregate_to_substations(n, aggregation_strategies=dict(), buses_i=None):
     for c in n.buses.country.unique():
         incountry_b = n.buses.country == c
         dist.loc[incountry_b, ~incountry_b] = np.inf
+
+    for c in n.buses.carrier.unique():
+        incarrier_b = n.buses.carrier == c
+        dist.loc[incarrier_b, ~incarrier_b] = np.inf
 
     busmap = n.buses.index.to_series()
     busmap.loc[buses_i] = dist.idxmin(1)
@@ -522,6 +539,150 @@ def cluster(
     return clustering.network, clustering.busmap
 
 
+def drop_isolated_nodes(n, threshold):
+    """
+    Find isolated nodes in the network and drop those of them which don't have
+    load or have a load value lower than a threshold
+
+    Parameters
+    ----------
+    iso_code : PyPSA.Network
+        Original network
+    threshold: float
+        Load power used as a threshold to drop isolated nodes
+
+    Returns
+    -------
+    modified network
+    """
+    n.determine_network_topology()
+
+    # keep original values of the overall load and generation in the network
+    # to track changes due to drop of buses
+    generators_mean_origin = n.generators.p_nom.mean()
+    load_mean_origin = n.loads_t.p_set.mean().mean()
+
+    # duplicated sub-networks mean that there is at least one interconnection between buses
+    i_islands = n.buses[
+        (~n.buses.duplicated(subset=["sub_network"], keep=False))
+        & (n.buses.carrier == "AC")
+    ].index
+
+    i_load_islands = n.loads_t.p_set.columns.intersection(i_islands)
+
+    # isolated buses without load should be discarded
+    isl_no_load = i_islands.difference(i_load_islands)
+    n.mremove("Bus", isl_no_load)
+    n.determine_network_topology()
+
+    # isolated buses with load lower than a specified threshold should be discarded as well
+    i_small_load = i_load_islands[
+        n.loads_t.p_set[i_load_islands].mean(axis=0) <= threshold
+    ]
+
+    if (i_islands.empty) | (len(i_small_load) == 0):
+        return n
+
+    i_loads_drop = n.loads[n.loads.bus.isin(i_small_load)].index
+    i_generators_drop = n.generators[n.generators.bus.isin(i_small_load)].index
+
+    n.mremove("Bus", i_small_load)
+    n.mremove("Load", i_loads_drop)
+    n.mremove("Generator", i_generators_drop)
+
+    n.determine_network_topology()
+
+    load_mean_final = n.loads_t.p_set.mean().mean()
+    generators_mean_final = n.generators.p_nom.mean()
+
+    logger.info(
+        f"Dropped {len(i_small_load)} buses. A resulted load discrepancy is {(100 * ((load_mean_final - load_mean_origin)/load_mean_origin)):2.1}% and {(100 * ((generators_mean_final - generators_mean_origin)/generators_mean_origin)):2.1}% for average load and generation capacity, respectivelly"
+    )
+
+    return n
+
+
+def merge_isolated_nodes(n, threshold, aggregation_strategies=dict()):
+    """
+    Find isolated nodes in the network and merge those of them which have
+    load value below than a specified threshold into a single isolated node
+    which represents all the remote generation
+
+    Parameters
+    ----------
+    n : PyPSA.Network
+        Original network
+    threshold : float
+        Load power used as a threshold to merge isolated nodes
+
+    Returns
+    -------
+    modified network
+    """
+    # keep original values of the overall load and generation in the network
+    # to track changes due to drop of buses
+    generators_mean_origin = n.generators.p_nom.mean()
+    load_mean_origin = n.loads_t.p_set.mean().mean()
+
+    n.determine_network_topology()
+
+    # duplicated sub-networks mean that there is at least one interconnection between buses
+    i_islands = n.buses[
+        (~n.buses.duplicated(subset=["sub_network"], keep=False))
+        & (n.buses.carrier == "AC")
+    ].index
+
+    # isolated buses with load below than a specified threshold should be merged
+    i_load_islands = n.loads_t.p_set.columns.intersection(i_islands)
+    i_suffic_load = i_load_islands[
+        n.loads_t.p_set[i_load_islands].mean(axis=0) <= threshold
+    ]
+
+    if (i_islands.empty) | (len(i_suffic_load) == 0):
+        return n, n.buses.index.to_series()
+
+    # all the noded to be merged should be mapped into a single node
+    agg_buses_list = []
+    countries_list = n.buses.country.unique()
+    for c in countries_list:
+        buses_in_country = n.buses.loc[i_suffic_load].country == c
+        i_aggreg_bus = n.buses.loc[i_suffic_load][buses_in_country].index[0]
+        agg_buses_list.append(i_aggreg_bus)
+
+    country_to_buses_dict = dict(zip(countries_list, agg_buses_list))
+    n_buses_df = n.buses[["country"]].copy().assign(bus_id=n.buses.index)
+    n_buses_df["agg_bus"] = n_buses_df.loc[i_suffic_load, "country"].map(
+        country_to_buses_dict
+    )
+    n_buses_df["agg_bus"].fillna(n_buses_df.bus_id, inplace=True)
+    busmap = n_buses_df["agg_bus"]
+
+    bus_strategies, generator_strategies = get_aggregation_strategies(
+        aggregation_strategies
+    )
+
+    clustering = get_clustering_from_busmap(
+        n,
+        busmap,
+        bus_strategies=bus_strategies,
+        aggregate_generators_weighted=True,
+        aggregate_generators_carriers=None,
+        aggregate_one_ports=["Load", "StorageUnit"],
+        line_length_factor=1.0,
+        generator_strategies=generator_strategies,
+        scale_link_capital_costs=False,
+    )
+
+    load_mean_final = n.loads_t.p_set.mean().mean()
+    generators_mean_final = n.generators.p_nom.mean()
+
+    logger.info(
+        f"Merged {len(i_suffic_load)} buses. Load attached to a single bus with discrepancies of {(100 * ((load_mean_final - load_mean_origin)/load_mean_origin)):2.1E}% and {(100 * ((generators_mean_final - generators_mean_origin)/generators_mean_origin)):2.1E}% for load and generation capacity, respectivelly"
+    )
+
+    return clustering.network, busmap
+
+
 if __name__ == "__main__":
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
@@ -577,7 +738,7 @@ if __name__ == "__main__":
     # treatment of outliers (nodes without a profile for considered carrier):
     # all nodes that have no profile of the given carrier are being aggregated to closest neighbor
     if (
-        snakemake.config.get("clustering", {})
+        snakemake.config.get("cluster_options", {})
         .get("cluster_network", {})
         .get("algorithm", "hac")
         == "hac"
@@ -587,8 +748,18 @@ if __name__ == "__main__":
             cluster_config.get("feature", "solar+onwind-time").split("-")[0].split("+")
         )
         for carrier in carriers:
+            # isolated buses should be excluded from adjacency_matrix calculations
+            n.determine_network_topology()
+            # duplicated sub-networks mean that there is at least one interconnection between buses
+            i_islands = n.buses[
+                (~n.buses.duplicated(subset=["sub_network"], keep=False))
+                & (n.buses.carrier == "AC")
+            ].index
+
             buses_i = list(
-                set(n.buses.index) - set(n.generators.query("carrier == @carrier").bus)
+                set(n.buses.index)
+                - set(i_islands)
+                - set(n.generators.query("carrier == @carrier").bus)
             )
             logger.info(
                 f"clustering preparaton (hac): aggregating {len(buses_i)} buses of type {carrier}."
@@ -619,6 +790,20 @@ if __name__ == "__main__":
     n.buses = n.buses.drop(buses_c, axis=1)
 
     update_p_nom_max(n)
+
+    p_threshold_drop_isolated = max(
+        0.0, cluster_config.get("p_threshold_drop_isolated", 0.0)
+    )
+    p_threshold_merge_isolated = cluster_config.get("p_threshold_merge_isolated", 0.0)
+
+    n = drop_isolated_nodes(n, threshold=p_threshold_drop_isolated)
+    if p_threshold_merge_isolated:
+        n, merged_nodes_map = merge_isolated_nodes(
+            n,
+            threshold=p_threshold_merge_isolated,
+            aggregation_strategies=aggregation_strategies,
+        )
+        busmaps.append(merged_nodes_map)
 
     n.meta = dict(snakemake.config, **dict(wildcards=dict(snakemake.wildcards)))
     n.export_to_netcdf(snakemake.output.network)


### PR DESCRIPTION
## Closes #531 

## Changes proposed in this Pull Request
A fix for islanded buses treatment is introduced into `simplify_network` to switch-on clustering by country and sub-network in `cluster_network`.

As discussed with @davide-f (thanks a lot for the discussions!), all the load and generation capacity is aggregated and attached to a single islanded bus.

Position of this representative islanded buses should calculated:
* disregarding buses having a load below a given threshold;
* using spatial-weighted average of the buses with the load higher a threshold.

## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
