### PR TITLE
Revise download and cleaning of world osm data

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -91,6 +91,7 @@ build_shape_options:
   worldpop_method: "standard"  # "standard" pulls from web 1kmx1km raster, "api" pulls from API 100mx100m raster, false (not "false") no pop addition to shape which is useful when generating only cutout
   gdp_method: "standard"  # "standard" pulls from web 1x1km raster, false (not "false") no gdp addition to shape which useful when generating only cutout
   contended_flag: "set_by_country" # "set_by_country" assigns the contended areas to the countries according to the GADM database, "drop" drops these contended areas from the model
+
 clean_osm_data_options:  # osm = OpenStreetMap
   names_by_shapes: true  # Set the country name based on the extended country shapes
   threshold_voltage: 35000  # [V] assets below that voltage threshold will not be used (cable, line, generator, etc.)
@@ -103,6 +104,7 @@ build_osm_network:  # Options of the build_osm_network script; osm = OpenStreetM
   group_tolerance_buses: 500  # [m] (default 500) Tolerance in meters of the close buses to merge
   split_overpassing_lines: true  # When True, lines overpassing buses are splitted and connected to the bueses
   overpassing_lines_tolerance: 1  # [m] (default 1) Tolerance to identify lines overpassing buses
+  force_ac: false  # When true, it forces all components (lines and substation) to be AC-only. To be used if DC assets create problem.
 
 base_network:
   min_voltage_substation_offshore: 35000  # [V] minimum voltage of the offshore substations

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -104,6 +104,7 @@ build_shape_options:
   worldpop_method: "standard"  # "standard" pulls from web 1kmx1km raster, "api" pulls from API 100mx100m raster, false (not "false") no pop addition to shape which is useful when generating only cutout
   gdp_method: "standard"  # "standard" pulls from web 1x1km raster, false (not "false") no gdp addition to shape which useful when generating only cutout
   contended_flag: "set_by_country" # "set_by_country" assigns the contended areas to the countries according to the GADM database, "drop" drops these contended areas from the model
+
 clean_osm_data_options:
   names_by_shapes: true  # Set the country name based on the extended country shapes
   threshold_voltage: 35000  # [V] minimum voltage threshold to keep the asset (cable, line, generator, etc.) [V]
@@ -116,6 +117,7 @@ build_osm_network:  # Options of the build_osm_network script; osm = OpenStreetM
   group_tolerance_buses: 500  # [m] (default 500) Tolerance in meters of the close buses to merge
   split_overpassing_lines: true  # When True, lines overpassing buses are splitted and connected to the bueses
   overpassing_lines_tolerance: 1  # [m] (default 1) Tolerance to identify lines overpassing buses
+  force_ac: false  # When true, it forces all components (lines and substation) to be AC-only. To be used if DC assets create problem.
 
 base_network:
   min_voltage_substation_offshore: 35000  # [V] minimum voltage of the offshore substations

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -73,6 +73,8 @@ Upcoming Release
 
 * Update simplify_network and cluster_network according to PyPSA-Eur developments `PR #597 https://github.com/pypsa-meets-earth/pypsa-earth/pull/597`__
 
+* Revise OSM cleaning to improve the cleaning process and error resilience `PR #620 https://github.com/pypsa-meets-earth/pypsa-earth/pull/620`__
+
 PyPSA-Earth 0.1.0
 =================
 

--- a/scripts/build_osm_network.py
+++ b/scripts/build_osm_network.py
@@ -725,6 +725,8 @@ def built_network(inputs, outputs, config, geo_crs, distance_crs, force_ac=False
     lines = gpd.read_file(inputs["lines"])
     generators = read_geojson(inputs["generators"])
 
+    lines = line_endings_to_bus_conversion(lines)
+
     if force_ac:
         logger.info(
             "Stage 2/5: AC and DC network: disabled, forced buses and lines to AC"

--- a/scripts/build_osm_network.py
+++ b/scripts/build_osm_network.py
@@ -705,8 +705,14 @@ def fix_overpassing_lines(lines, buses, distance_crs, tol=1):
 
 
 def force_ac_lines(df, col="tag_frequency"):
-    "Function to force AC for lines"
+    """
+    Function that forces all PyPSA lines to be AC lines.
 
+    A network can contain AC and DC power lines that are modelled as PyPSA "Line" component.
+    When DC lines are available, their power flow can be controlled by their converter.
+    When it is artificially converted into AC, this feature is lost.
+    However, for debugging and preliminary analysis, it can be useful to bypass problems.
+    """
     DC_freq = 0.0
     DC_lines = (df["tag_frequency"] - DC_freq).abs() <= 0.01
 

--- a/scripts/build_osm_network.py
+++ b/scripts/build_osm_network.py
@@ -33,47 +33,6 @@ def line_endings_to_bus_conversion(lines):
     return lines
 
 
-def add_line_endings_tosubstations(substations, lines):
-    # extract columns from substation df
-    bus_s = gpd.GeoDataFrame(columns=substations.columns)
-    bus_e = gpd.GeoDataFrame(columns=substations.columns)
-
-    is_ac = lines["tag_frequency"].astype(float) != 0
-
-    # Read information from line.csv
-    bus_s[["voltage", "country"]] = lines[["voltage", "country"]]  # line start points
-    bus_s["geometry"] = lines.geometry.boundary.map(lambda p: p.geoms[0])
-    bus_s["lon"] = bus_s["geometry"].x
-    bus_s["lat"] = bus_s["geometry"].y
-    bus_s["bus_id"] = lines["line_id"].astype(str) + "_s"
-    bus_s["dc"] = ~is_ac
-
-    bus_e[["voltage", "country"]] = lines[["voltage", "country"]]  # line start points
-    bus_e["geometry"] = lines.geometry.boundary.map(lambda p: p.geoms[1])
-    bus_e["lon"] = bus_s["geometry"].x
-    bus_e["lat"] = bus_s["geometry"].y
-    bus_e["bus_id"] = lines["line_id"].astype(str) + "_e"
-    bus_e["dc"] = ~is_ac
-
-    bus_all = pd.concat([bus_s, bus_e], ignore_index=True).set_crs(substations.crs)
-    # Assign index to bus_id
-    bus_all["bus_id"] = bus_all.index
-
-    # Add NaN as default
-    bus_all["station_id"] = np.nan
-    # bus_all["dc"] = False  # np.nan
-    # Assuming substations completed for installed lines
-    bus_all["under_construction"] = False
-    bus_all["tag_area"] = 0.0  # np.nan
-    bus_all["symbol"] = "substation"
-    # TODO: this tag may be improved, maybe depending on voltage levels
-    bus_all["tag_substation"] = "transmission"
-
-    buses = pd.concat([substations, bus_all], ignore_index=True)
-
-    return buses
-
-
 # tol in m
 def set_substations_ids(buses, distance_crs, tol=2000):
     """
@@ -745,18 +704,35 @@ def fix_overpassing_lines(lines, buses, distance_crs, tol=1):
     return lines, buses
 
 
-def built_network(inputs, outputs, config, geo_crs, distance_crs):
+def force_ac_lines(df, col="tag_frequency"):
+    "Function to force AC for lines"
+
+    DC_freq = 0.0
+    DC_lines = (df["tag_frequency"] - DC_freq).abs() <= 0.01
+
+    # TODO: default frequency may be by country
+    default_frequency = 50
+
+    df[df[DC_lines].index] = default_frequency
+
+    return df
+
+
+def built_network(inputs, outputs, config, geo_crs, distance_crs, force_ac=False):
     logger.info("Stage 1/5: Read input data")
 
-    substations = gpd.read_file(inputs["substations"])
+    buses = gpd.read_file(inputs["substations"])
     lines = gpd.read_file(inputs["lines"])
     generators = read_geojson(inputs["generators"])
 
-    logger.info("Stage 2/5: Add line endings to the substation datasets")
-
-    # Use lines and create bus/line df
-    lines = line_endings_to_bus_conversion(lines)
-    buses = add_line_endings_tosubstations(substations, lines)
+    if force_ac:
+        logger.info(
+            "Stage 2/5: AC and DC network: disabled, forced buses and lines to AC"
+        )
+        lines = force_ac_lines(lines)
+        buses["dc"] = False
+    else:
+        logger.info("Stage 2/5: AC and DC network: enabled")
 
     # Address the overpassing line issue Step 3/5
     if config.get("build_osm_network", {}).get("split_overpassing_lines", False):
@@ -867,9 +843,15 @@ if __name__ == "__main__":
     # load default crs
     geo_crs = snakemake.config["crs"]["geo_crs"]
     distance_crs = snakemake.config["crs"]["distance_crs"]
+    force_ac = snakemake.config["build_osm_network"].get("force_ac", False)
 
     sets_path_to_root("pypsa-earth")
 
     built_network(
-        snakemake.input, snakemake.output, snakemake.config, geo_crs, distance_crs
+        snakemake.input,
+        snakemake.output,
+        snakemake.config,
+        geo_crs,
+        distance_crs,
+        force_ac=force_ac,
     )

--- a/scripts/clean_osm_data.py
+++ b/scripts/clean_osm_data.py
@@ -770,15 +770,15 @@ def clean_data(
         df_all_lines.apply(lambda x: africa_shape.contains(x.geometry.boundary), axis=1)
     ]
 
-    # set unique line ids
-    df_all_lines = set_unique_id(df_all_lines, "line_id")
-
     df_all_lines = gpd.GeoDataFrame(df_all_lines, geometry="geometry")
 
     # set the country name by the shape
     if names_by_shapes:
         logger.info("Setting lines country name using the GADM shapes")
         df_all_lines = set_countryname_by_shape(df_all_lines, ext_country_shapes)
+
+    # set unique line ids
+    df_all_lines = set_unique_id(df_all_lines, "line_id")
 
     # save lines output
     logger.info("Saving lines output")
@@ -816,9 +816,6 @@ def clean_data(
     # finalize dataframe types
     df_all_substations = finalize_substation_types(df_all_substations)
 
-    # set unique bus ids
-    df_all_substations = set_unique_id(df_all_substations, "bus_id")
-
     # save to geojson file
     df_all_substations = gpd.GeoDataFrame(df_all_substations, geometry="geometry")
 
@@ -830,6 +827,9 @@ def clean_data(
             ext_country_shapes,
             col_country="Country",
         )
+
+    # set unique bus ids
+    df_all_substations = set_unique_id(df_all_substations, "bus_id")
 
     # save substations output
     logger.info("Saving substations output")

--- a/scripts/clean_osm_data.py
+++ b/scripts/clean_osm_data.py
@@ -45,8 +45,8 @@ def prepare_substation_df(df_all_substations):
 
     # Add NaN as default
     df_all_substations["station_id"] = np.nan
-    df_all_substations["dc"] = np.nan
-    df_all_substations["under_construction"] = np.nan
+    df_all_substations["dc"] = False
+    df_all_substations["under_construction"] = False
 
     # Rearrange columns
     clist = [
@@ -70,17 +70,13 @@ def prepare_substation_df(df_all_substations):
         if c not in df_all_substations:
             df_all_substations[c] = np.nan
 
-    # add the under_construction and dc
-    df_all_substations["under_construction"] = False
-    df_all_substations["dc"] = False
-
     return df_all_substations
 
 
 def add_line_endings_tosubstations(substations, lines):
     # extract columns from substation df
-    bus_s = gpd.GeoDataFrame(columns=substations.columns)
-    bus_e = gpd.GeoDataFrame(columns=substations.columns)
+    bus_s = gpd.GeoDataFrame(columns=substations.columns, crs=substations.crs)
+    bus_e = gpd.GeoDataFrame(columns=substations.columns, crs=substations.crs)
 
     is_ac = lines["tag_frequency"].astype(float) != 0
 
@@ -111,7 +107,6 @@ def add_line_endings_tosubstations(substations, lines):
 
     # Add NaN as default
     bus_all["station_id"] = np.nan
-    bus_all["dc"] = False  # np.nan
     # Assuming substations completed for installed lines
     bus_all["under_construction"] = False
     bus_all["tag_area"] = 0.0  # np.nan
@@ -157,7 +152,7 @@ def set_unique_id(df, col):
     return df
 
 
-def split_cells(df, lst_col="voltage"):
+def split_cells(df, cols=["voltage"]):
     """
     Split semicolon separated cells i.e. [66000;220000] and create new identical rows
 
@@ -165,40 +160,54 @@ def split_cells(df, lst_col="voltage"):
     ----------
     df : dataframe
         Dataframe under analysis
-    lst_col : str
-        Target column over which to perform the analysis
+    cols : list
+        List of target columns over which to perform the analysis
     """
     if df.empty:
         return df
 
-    x = df.assign(**{lst_col: df[lst_col].str.split(";")})
-    x = pd.DataFrame(
-        {
-            col: np.repeat(x[col].values, x[lst_col].str.len())
-            for col in x.columns.difference([lst_col])
-        }
-    ).assign(**{lst_col: np.concatenate(x[lst_col].values)})[x.columns.tolist()]
-    return x
+    x = df.assign(**{col: df[col].str.split(";") for col in cols})
+
+    return x.explode(cols, ignore_index=True)
 
 
 def filter_voltage(df, threshold_voltage=35000):
-    # Drop any row with N/A voltage
-    df = df.dropna(subset=["voltage"])
-
-    # Split semicolon separated cells i.e. [66000;220000] and create new identical rows
-    df = split_cells(df)
-
-    # Convert voltage to float, if impossible, discard row
-    df["voltage"] = (
-        df["voltage"].apply(lambda x: pd.to_numeric(x, errors="coerce")).astype(float)
-    )
-    df = df.dropna(subset=["voltage"])  # Drop any row with Voltage = N/A
+    # Convert to numeric and drop any row with N/A voltage
+    df["voltage"] = pd.to_numeric(df["voltage"], errors="coerce").astype(float)
+    df.dropna(subset=["voltage"], inplace=True)
 
     # convert voltage to int
     df["voltage"] = df["voltage"].astype(int)
 
     # keep only lines with a voltage no lower than than threshold_voltage
     df = df[df.voltage >= threshold_voltage]
+
+    return df
+
+
+def filter_frequency(df, accepted_values=[50, 60, 0]):
+    df["tag_frequency"] = pd.to_numeric(df["tag_frequency"], errors="coerce").astype(
+        float
+    )
+    df.dropna(subset=["tag_frequency"], inplace=True)
+
+    accepted_rows = pd.concat(
+        [(df["tag_frequency"] - f_val).abs() <= 0.01 for f_val in accepted_values],
+        axis=1,
+    ).any(axis="columns")
+
+    df.drop(df[~accepted_rows].index, inplace=True)
+
+    return df
+
+
+def filter_circuits(df, min_value_circuit=0.1):
+    df["circuits"] = pd.to_numeric(df["circuits"], errors="coerce").astype(float)
+    df.dropna(subset=["circuits"], inplace=True)
+
+    accepted_rows = df["circuits"] >= min_value_circuit
+
+    df.drop(df[~accepted_rows].index, inplace=True)
 
     return df
 
@@ -279,279 +288,320 @@ def finalize_lines_type(df_lines):
     return df_lines
 
 
-def split_cells_multiple(df, list_col=["cables", "circuits", "voltage"]):
+def parse_frequency(df):
+    "Function to parse raw frequency column: manual fixing and drop undesired values"
+
+    # replace raw values
+    repl_freq = {
+        "16.67": "16.7",
+        "50;50;16.716.7": "50;50;16.7;16.7",
+        "50;50;16.716.7": "50;50;16.7;16.7",
+        "50;16.7?": "50;16.7",
+        # "24 kHz": "24000",
+    }
+
+    # TODO: default frequency may be by country
+    # default frequency
+    default_frequency = "50"
+
+    df["tag_frequency"] = (
+        df["tag_frequency"].replace(repl_freq).fillna(default_frequency)
+    )
+
+    return df
+
+
+def parse_voltage(df):
+    "Function to parse raw voltage column: manual fixing and drop undesired values"
+
+    # replace raw values
+    repl_voltage = {
+        "medium": "33000",
+        "19.1 kV": "19100",
+        "high": "220000",
+        "240 VAC": "240",
+        "2*220000": "220000;220000",
+        "KV30": "30kV",
+    }
+
+    df["voltage"] = (
+        df["voltage"]
+        .replace(repl_voltage)
+        .str.lower()
+        .str.replace(" ", "")
+        .str.replace("_", "")
+        .str.replace("kv", "000")
+        .str.replace("v", "")
+        # .str.replace("/", ";")
+    )
+
+    # drop na values in voltage
+    df.dropna(subset=["voltage"], inplace=True)
+
+    return df
+
+
+def parse_circuits(df):
+    "Function to parse raw circuits column: manual fixing and drop undesired values"
+
+    # replace raw values
+    repl_circuits = {
+        "1/3": "0",
+        "2/3": "0",
+        # assumption of two lines and one grounding wire
+        "2-1": "2",
+        "single": "1",
+        "partial": "1",
+        "1;1 disused": "1;0",
+        # assuming that in case of a typo there is at least one line
+        "`": "1",
+        "^1": "1",
+        "e": "1",
+        "d": "1",
+        "1.": "1",
+    }
+
+    df["circuits"] = df["circuits"].replace(repl_circuits).str.replace(" ", "")
+
+    return df
+
+
+def parse_cables(df):
+    "Function to parse raw cables column: manual fixing and drop undesired values"
+
+    # replace raw values
+    repl_cables = {
+        "single": "1",
+        "triple": "3",
+        "partial": "1",
+        "1 disused": "0",
+        "3;3 disused": "3;0",
+        "1 (Looped - Haul & Return) + 1 power wire": "1",
+        "ground": "0",
+        "line": "1",
+        # assuming that in case of a typo there is at least one line
+        "`": "1",
+        "^1": "1",
+        "e": "1",
+        "d": "1",
+        "2-1": "3",
+        "3+3": "6",
+        "6+1": "6",
+        "2x3": "6",
+        "3x2": "6",
+        "2x2": "4",
+    }
+
+    df["cables"] = df["cables"].replace(repl_cables).str.replace(" ", "")
+
+    return df
+
+
+def split_and_match_vf(df):
     """
-    Split function for cables and voltage
-
-    One line with 'cable':{3,6} and 'voltage':{220000,110000} or
-    only 'voltage':{110000, 220000, 3330000} needs to split in several lines
-    with new line_ID
+    Function to match the length of the columns in subset
+    by duplicating the last value in the column
     """
-    # TODO: split multiple cell probably needs fix
-    n_rows = df.shape[0]
-    row_list = []
-    for i in range(n_rows):
-        sub = df[list_col].iloc[i]  # for each cables and voltage
-        if sub.notnull().all() == True:  # check not both empty
-            # check both contain ";"
-            if [";" in s for s in sub].count(True) == len(list_col):
-                d = [s.split(";") for s in sub]  # split them
-                r = df.loc[i].copy()
-                df.loc[i, list_col[0]] = d[0][0]  # first split  [0]
-                df.loc[i, list_col[1]] = d[1][0]
-                r[list_col[0]] = d[0][1]  # second split [1]
-                r[list_col[1]] = d[1][1]
-                row_list.append(r)
+    for col in ["tag_frequency", "voltage"]:
+        df[col] = df[col].str.split(";")
 
-    if row_list:
-        df = pd.concat([df, gpd.GeoDataFrame(row_list, crs=df.crs)], ignore_index=True)
+    len_freq = df["tag_frequency"].map(len)
+    len_voltage = df["voltage"].map(len)
 
-    # if some columns still contain ";" then sum the values
-    for cl_name in list_col:
-        if df[cl_name].dtype == "string":
-            sel_ids = df[cl_name].str.contains(";") == True
-            # TODO: split multiple cell need fix
-            df = df.drop(
-                df.loc[sel_ids, cl_name].index,
-            )
-    return df  # return new frame
+    def _fill_by_last(row, col_to_fill, size_col):
+        size_to_fill = len(row[size_col])
+        if not row[col_to_fill]:
+            return None
+        n_missing = size_to_fill - len(row[col_to_fill])
+        fill_val = row[col_to_fill][-1]
+
+        new_row = row[col_to_fill].copy()
+
+        return row[col_to_fill] + [fill_val] * n_missing
+
+    df_fhv = df[len_freq > len_voltage].apply(
+        lambda row: _fill_by_last(row, "voltage", "tag_frequency"),
+        axis=1,
+    )
+    df.loc[df_fhv.index, "voltage"] = df_fhv
+
+    df_vhf = df[len_freq < len_voltage].apply(
+        lambda row: _fill_by_last(row, "tag_frequency", "voltage"),
+        axis=1,
+    )
+    df.loc[df_vhf.index, "tag_frequency"] = df_vhf
+
+    return df
 
 
-# cable and circuit tags may be in a non-numeric format
-cables_tag_to_n_cables = {
-    "single": "1",
-    "triple": "3",
-    "partial": "1",
-    "1 disused": "0",
-    "3 disused": "0",
-    "1 (Looped - Haul & Return) + 1 power wire": "1",
-    "ground": "0",
-    "line": "1",
-    # assuming that in case of a typo there is at least one line
-    "`": "1",
-    "^1": "1",
-    "e": "1",
-    "d": "1",
-    "2-1": "3",
-    "3+3": "6",
-    "6+1": "6",
-    "2x3": "6",
-    "3x2": "6",
-    "2x2": "4",
-}
+def fill_circuits(df):
+    """
+    This function fills the circuits column to match the length of v/f columns
+    The value of cables may be used to parse the values
+    """
 
-circuits_tag_to_n_circuits = {
-    "1/3": "0",
-    "2/3": "0",
-    # assumption of two lines and one grounding wire
-    "2-1": "2",
-    "single": "1",
-    "partial": "1",
-    "1 disused": "0",
-    # assuming that in case of a typo there is at least one line
-    "`": "1",
-    "^1": "1",
-    "e": "1",
-    "d": "1",
-    "1.": "1",
-}
+    def _get_circuits_status(df):
+        len_f = df["tag_frequency"].map(len)
+        len_c = df["circuits"].str.count(";") + 1
+        isna_c = df["circuits"].isna()
+        len_cab = df["cables"].str.count(";") + 1
+        isna_cab = df["cables"].isna()
+        return len_f, len_c, isna_c, len_cab, isna_cab
 
-dropped_cables_tags = [
-    x for x in cables_tag_to_n_cables.keys() if cables_tag_to_n_cables[x] == "0"
-]
-dropped_circuits_tags = [
-    x for x in circuits_tag_to_n_circuits.keys() if circuits_tag_to_n_circuits[x] == "0"
-]
+    def _parse_float(x, ret_def=0.0):
+        if isinstance(x, (int, float)):
+            return float(x)
+        str_x = str(x)
+        if str_x.isnumeric():
+            return float(str_x)
+        return ret_def
+
+    # cables requirement for circuits calculation
+    cables_req = {
+        "50": 3,
+        "60": 3,
+        "16.7": 2,
+        "0": 2,
+    }
+
+    def _basic_cables(f_val, cables_req=cables_req, def_circ=2):
+        return cables_req[f_val] if f_val in cables_req.keys() else def_circ
+
+    len_f, len_c, isna_c, len_cab, isna_cab = _get_circuits_status(df)
+
+    to_fill = isna_c | (len_f != len_c)
+    to_fill_direct = to_fill & (len_cab == len_f)
+    to_fill_merge = to_fill & (len_cab > len_f)
+    to_fill_indirect = to_fill & ~to_fill_direct & df["cables"].str.isnumeric()
+    to_fill_default = to_fill & ~to_fill_merge & ~to_fill_direct & ~to_fill_indirect
+
+    # length of cables match the frequency one
+    # matching uses directly only the cables series
+    df_match_by_cables = df[to_fill_direct][["tag_frequency", "cables"]].copy()
+    df_match_by_cables["cables"] = df_match_by_cables["cables"].str.split(";")
+
+    def _filter_cables(row):
+        return ";".join(
+            [
+                str(_parse_float(vc) / _basic_cables(vf))
+                for (vc, vf) in zip(row["cables"], row["tag_frequency"])
+            ]
+        )
+
+    df.loc[df_match_by_cables.index, "circuits"] = df_match_by_cables.apply(
+        _filter_cables, axis=1
+    )
+
+    # length of cables elements is larger than frequency; the last cable data are merged to match
+    df_merge_by_cables = df[to_fill_merge][["tag_frequency", "cables"]].copy()
+    df_merge_by_cables["cables"] = df_merge_by_cables["cables"].str.split(";")
+
+    def _parse_cables_to_len(row):
+        lf = len(row["tag_frequency"])
+        float_cable = [_parse_float(vc) for vc in row["cables"]]
+        parsed_cable_list = float_cable[0 : lf - 1] + [sum(float_cable[lf - 1 :])]
+
+        return ";".join(
+            [
+                str(vc / _basic_cables(vf))
+                for (vc, vf) in zip(parsed_cable_list, row["tag_frequency"])
+            ]
+        )
+
+    df.loc[df_merge_by_cables.index, "circuits"] = df_merge_by_cables.apply(
+        _parse_cables_to_len, axis=1
+    )
+
+    # indirect matching exploiting the total numeric value in cables
+    # the minimum requirement of cables by frequency value is calculated
+    # then using the total numeric cables number, the values are scaled proportionally
+    df_indirect = df[to_fill_indirect]
+
+    basic_cables = (
+        df_indirect["tag_frequency"]
+        .map(lambda x: [_basic_cables(v) for v in x])
+        .rename("basic_cables")
+    )
+    min_cables = basic_cables.map(sum).rename("min_cables")
+    multiplier = (
+        pd.to_numeric(df_indirect["cables"], errors="coerce") / min_cables
+    ).rename("multiplier")
+    filled_values = pd.concat([basic_cables, multiplier], axis=1).apply(
+        lambda x: ";".join([str(x["multiplier"] * v) for v in x["basic_cables"]]),
+        axis=1,
+    )
+    df.loc[filled_values.index, "circuits"] = filled_values
+
+    # otherwise assume a circuit per element
+    df_fill_default = df[to_fill_default]
+    df.loc[df_fill_default.index, "circuits"] = len_f.loc[df_fill_default.index].map(
+        lambda x: ";".join(["1"] * x)
+    )
+
+    # explode column
+    df["circuits"] = df["circuits"].str.split(";")
+
+    return df
+
+
+def explode_columns(df, cols):
+    # check if all row elements are list
+    is_all_list = df[cols].applymap(lambda x: isinstance(x, list)).all(axis=1)
+    if not is_all_list.all():
+        df_nonlist = df[~is_all_list]
+        logger.warning(
+            f"Unexpected non-list values in dataframe; dropping rows. Needed fix for entries:\n{df_nonlist}"
+        )
+        df.drop(df_nonlist.index, inplace=True)
+
+    # check if errors in the columns
+    nunique_values = df[cols].applymap(len).nunique(axis=1)
+    df_nunique = df[nunique_values != 1]
+    if not df_nunique.empty:
+        logger.warning(
+            f"Improper explosion of dataframe entries; dropping rows. Needed fix for entries:\n{df_nunique}"
+        )
+        df.drop(df_nunique.index, inplace=True)
+
+    df = df.explode(cols, ignore_index=True)
+
+    return df
 
 
 def integrate_lines_df(df_all_lines, distance_crs):
     """
     Function to add underground, under_construction, frequency and circuits
     """
+    # explode frequency and columns
+    df = pd.DataFrame(df_all_lines)
+
+    # preliminary raw parsing of raw columns
+    parse_frequency(df)
+    parse_voltage(df)
+    parse_circuits(df)
+    parse_cables(df)
+
+    # fill voltage and frequency columns length for explode
+    split_and_match_vf(df)
+
+    # fill the circuits column for explode
+    fill_circuits(df)
+
     # Add under construction info
     # Default = False. No more information available atm
-    df_all_lines["under_construction"] = False
+    df["under_construction"] = False
 
     # Add underground flag to check whether the line (cable) is underground
     # Simplified. If tag_type cable then underground is True
-    df_all_lines["underground"] = df_all_lines["tag_type"] == "cable"
+    df["underground"] = df["tag_type"] == "cable"
 
-    # More information extractable for "underground" by looking at "tag_location".
-    if "tag_location" in df_all_lines:  # drop column if exist
-        df_all_lines.drop(columns="tag_location", inplace=True)
+    # drop columns
+    df.drop(columns=["tag_location", "cables"], errors="ignore", inplace=True)
 
-    # Keep original frequency if it exists  and set a standard value
-    # NB The standard frequency value may be regional-dependent
-    # TODO Fill by adjancent value
+    # explode columns
+    df = explode_columns(df, ["tag_frequency", "voltage", "circuits"])
 
-    # Initialize a default frequency value
-    ac_freq_default = 50.0
-
-    if "tag_frequency" in df_all_lines.columns:
-        ac_grid_freq_levels = (
-            df_all_lines["tag_frequency"]
-            .value_counts(sort=True, dropna=True)
-            .drop(["0", 0], errors="ignore")
-        )
-
-        if not ac_grid_freq_levels.empty:
-            ac_freq_default = float(ac_grid_freq_levels.idxmax())
-
-        df_all_lines.tag_frequency.fillna(ac_freq_default, inplace=True)
-
-        df_all_lines["tag_frequency"] = (
-            df_all_lines.tag_frequency.astype(str)
-            .str.split(pat=";", n=1)
-            .str[0]
-            .astype(float)
-        )
-
-    # Add frequency column if not present in data
-    else:
-        df_all_lines["tag_frequency"] = ac_freq_default
-
-    df_all_lines = split_cells_multiple(df_all_lines)
-    # Add circuits information
-    # if not int make int
-    if df_all_lines["cables"].dtype != int:
-        dropped_cables = [
-            x for x in dropped_cables_tags if x in df_all_lines["cables"].values
-        ]
-        if len(dropped_cables) != 0:
-            logger.info(
-                f"The lines with a cables tag in {set(dropped_cables)} will be dropped."
-            )
-
-        # map known non-numerical issues into a reasonable n_cables value
-        df_all_lines["cables"] = (
-            df_all_lines["cables"]
-            .map(cables_tag_to_n_cables)
-            .fillna(df_all_lines["cables"])
-        )
-        # HERE. "0" if cables "None", "nan" or "1"
-        df_all_lines.loc[
-            (df_all_lines["cables"] < "3") | df_all_lines["cables"].isna(), "cables"
-        ] = "0"
-
-        # there may be some non-known numerical issues
-        not_resolved_cables = (
-            ~pd.to_numeric(df_all_lines["cables"], errors="coerce")
-            .astype(float)
-            .apply(float.is_integer)
-        )
-        unknown_cables_tags = set(
-            df_all_lines.loc[not_resolved_cables]["cables"].values
-        )
-        if any(not_resolved_cables):
-            df_all_lines.drop(df_all_lines[not_resolved_cables].index, inplace=True)
-            logger.warning(
-                f"The lines with an unexpected cables tag value in {unknown_cables_tags} will be dropped."
-            )
-
-        df_all_lines["cables"] = df_all_lines["cables"].astype("int")
-
-    # downgrade 4 and 5 cables to 3...
-    if 4 or 5 in df_all_lines["cables"].values:
-        # Reason: 4 cables have 1 lighting protection cables, 5 cables has 2 LP cables - not transferring energy;
-        # see https://hackaday.com/2019/06/11/a-field-guide-to-transmission-lines/
-        # where circuits are "0" make "1"
-        df_all_lines.loc[
-            (df_all_lines["cables"] == 4) | (df_all_lines["cables"] == 5), "cables"
-        ] = 3
-
-    # one circuit contains 3 cable under a preliminary assumption of an AC line
-    df_all_lines.loc[df_all_lines["circuits"].isna(), "circuits"] = (
-        df_all_lines.loc[df_all_lines["circuits"].isna(), "cables"] / 3
-    )
-
-    # where circuits are "0" make "1"
-    df_all_lines.loc[
-        (df_all_lines["circuits"] == "0") | (df_all_lines["circuits"] == 0),
-        "circuits",
-    ] = 1
-
-    if df_all_lines["circuits"].dtype != int:
-        # it's possible that some df_all_lines["circuits"] are in manually dropped_tags
-        if any(df_all_lines["circuits"].isin(dropped_circuits_tags)):
-            # reset indexing to avoid 'SettingWithCopyWarning' troubles in further operations with the data frame
-            df_one_third_circuits = df_all_lines.loc[
-                df_all_lines["circuits"].isin(dropped_circuits_tags)
-            ].reset_index()
-
-            # avoid mixing column name with geopandas method
-            df_one_third_circuits = df_one_third_circuits.rename(
-                columns={
-                    "length": "length_osm",
-                }
-            )
-
-            # transfrom to metric crs to obtain length in m from coordinates
-            df_one_third_circuits_m = df_one_third_circuits.to_crs(distance_crs)
-
-            length_from_crs = df_one_third_circuits_m.length
-            df_one_third_circuits["length_crs"] = length_from_crs
-
-            # in case a line length is not available directly
-            df_one_third_circuits.loc[
-                df_one_third_circuits["length_osm"].isna(), "length_osm"
-            ] = df_one_third_circuits.loc[
-                df_one_third_circuits["length_osm"].isna(), "length_crs"
-            ]
-
-            # [m] -> [km]
-            dropped_length = round(df_one_third_circuits["length_osm"].sum() / 1e3, 1)
-            dropped_values = set(df_one_third_circuits["circuits"])
-            logger.warning(
-                f"The lines with a circuit tag in {dropped_values} of an overal length {dropped_length} km dropped."
-            )
-
-            # troubles with projections can lead to discrepancy between the length values
-            tol = 0.1  # [m]
-            length_diff = (
-                df_one_third_circuits["length_osm"]
-                - df_one_third_circuits["length_crs"]
-            )
-
-            if any(length_diff > tol):
-                total_length_diff = round(sum(length_diff), 2)
-                logger.warning(
-                    f"There is a difference of {total_length_diff} m in the dropped lines length as compared with values extracted from geographical coordinates."
-                )
-
-        # drop circuits if "None" or "nan"
-        df_all_lines.loc[
-            df_all_lines["circuits"].isna(),
-            "circuits",
-        ] = "0"
-        # map known non-numerical issues into a reasonable n_circuits value
-        df_all_lines["circuits"] = (
-            df_all_lines["circuits"]
-            .map(circuits_tag_to_n_circuits)
-            .fillna(df_all_lines["circuits"])
-        )
-
-        # there may be some non-known numerical issues
-        not_resolved_circuits = (
-            ~pd.to_numeric(df_all_lines["circuits"], errors="coerce")
-            .astype(float)
-            .apply(float.is_integer)
-        )
-        unknown_circuits_tags = set(
-            df_all_lines.loc[not_resolved_circuits]["circuits"].values
-        )
-        if any(not_resolved_circuits):
-            df_all_lines.drop(df_all_lines[not_resolved_circuits].index, inplace=True)
-            logger.warning(
-                f"The lines with an unexpected circuits tag value in {unknown_circuits_tags} will be dropped."
-            )
-
-        df_all_lines["circuits"] = df_all_lines["circuits"].astype(int)
-
-    # drop column if exist
-    if "cables" in df_all_lines:
-        df_all_lines.drop(columns="cables", inplace=True)
-
-    return df_all_lines
+    return gpd.GeoDataFrame(df, crs=df_all_lines.crs)
 
 
 def filter_lines_by_geometry(df_all_lines):
@@ -586,6 +636,7 @@ def prepare_generators_df(df_all_generators):
     )
 
     # convert electricity column from string to float value
+    # TODO: this filtering can be improved
     df_all_generators = df_all_generators[
         df_all_generators["power_output_MW"].astype(str).str.contains("MW")
     ]
@@ -597,11 +648,11 @@ def prepare_generators_df(df_all_generators):
 
 
 def find_first_overlap(geom, country_geoms, default_name):
-    """Return the first country whose shape intersects the geometry"""
-    for c_name, c_geom in country_geoms.items():
-        if not geom.disjoint(c_geom):
-            return c_name
-    return default_name
+    """Return the first index whose shape intersects the geometry"""
+    return next(
+        (idx for idx, c_geom in country_geoms.items() if not geom.disjoint(c_geom)),
+        default_name,
+    )
 
 
 def set_countryname_by_shape(
@@ -674,6 +725,7 @@ def clean_data(
     add_line_endings=True,
     generator_name_method="OSM",
 ):
+    logger.info("Process OSM lines")
     # Load raw data lines
     df_lines = gpd.read_file(input_files["lines"])
 
@@ -686,6 +738,7 @@ def clean_data(
 
     # load cables only if data are stored
     if os.path.getsize(input_files["cables"]) > 0:
+        logger.info("Add OSM cables to data")
         # Load raw data lines
         df_cables = gpd.read_file(input_files["cables"])
 
@@ -695,16 +748,22 @@ def clean_data(
 
         # concatenate lines and cables in a single dataframe
         df_all_lines = pd.concat([df_lines, df_cables], ignore_index=True)
+    else:
+        logger.info("No OSM cables to add: skipping")
 
     # Add underground, under_construction, frequency and circuits columns to the dataframe
     # and drop corresponding unused columns
     df_all_lines = integrate_lines_df(df_all_lines, distance_crs)
 
-    # filter lines by voltage
-    df_all_lines = filter_voltage(df_all_lines, threshold_voltage)
+    logger.info("Filter lines by voltage, frequency, circuits and geometry")
 
-    # filter lines to make sure the geometry is appropriate
+    # filter lines
+    df_all_lines = filter_voltage(df_all_lines, threshold_voltage)
+    df_all_lines = filter_frequency(df_all_lines)
+    df_all_lines = filter_circuits(df_all_lines)
     df_all_lines = filter_lines_by_geometry(df_all_lines)
+
+    logger.info("Select lines and cables in the region of interest")
 
     # drop lines crossing regions with and without the region under interest
     df_all_lines = df_all_lines[
@@ -718,28 +777,38 @@ def clean_data(
 
     # set the country name by the shape
     if names_by_shapes:
+        logger.info("Setting lines country name using the GADM shapes")
         df_all_lines = set_countryname_by_shape(df_all_lines, ext_country_shapes)
 
+    # save lines output
+    logger.info("Saving lines output")
     save_to_geojson(df_all_lines, output_files["lines"])
 
     # ----------- SUBSTATIONS -----------
+
+    logger.info("Process OSM substations")
 
     df_all_substations = gpd.read_file(input_files["substations"])
 
     # prepare dataset for substations
     df_all_substations = prepare_substation_df(df_all_substations)
 
-    # add line endings if option is enabled
-    if add_line_endings:
-        df_all_substations = add_line_endings_tosubstations(
-            df_all_substations, df_all_lines
-        )
-
     # filter substations by tag
     if tag_substation:  # if the string is not empty check it
         df_all_substations = df_all_substations[
             df_all_substations["tag_substation"] == tag_substation
         ]
+
+    df_all_substations = gpd.GeoDataFrame(
+        split_cells(pd.DataFrame(df_all_substations)),
+        crs=df_all_substations.crs,
+    )
+
+    # add line endings if option is enabled
+    if add_line_endings:
+        df_all_substations = add_line_endings_tosubstations(
+            df_all_substations, df_all_lines
+        )
 
     # filter substation by voltage
     df_all_substations = filter_voltage(df_all_substations, threshold_voltage)
@@ -755,15 +824,20 @@ def clean_data(
 
     if names_by_shapes:
         # set the country name by the shape
+        logger.info("Setting substations country name using the GADM shapes")
         df_all_substations = set_countryname_by_shape(
             df_all_substations,
             ext_country_shapes,
             col_country="Country",
         )
 
+    # save substations output
+    logger.info("Saving substations output")
     save_to_geojson(df_all_substations, output_files["substations"])
 
     # ----------- GENERATORS -----------
+
+    logger.info("Process OSM generators")
 
     df_all_generators = gpd.read_file(input_files["generators"])
 
@@ -772,6 +846,7 @@ def clean_data(
 
     if names_by_shapes:
         # set the country name by the shape
+        logger.info("Setting generators country name using the GADM shapes")
         df_all_generators = set_countryname_by_shape(
             df_all_generators,
             ext_country_shapes,
@@ -780,12 +855,14 @@ def clean_data(
 
     # set name tag by closest city when the value is nan
     if generator_name_method == "closest_city":
+        logger.info("Setting unknown generators name using the closest city")
         df_all_generators = set_name_by_closestcity(df_all_generators)
 
     # save to csv
     to_csv_nafix(df_all_generators, output_files["generators_csv"])
 
     # save to geojson
+    logger.info("Saving generators output")
     save_to_geojson(df_all_generators, output_files["generators"])
 
     return None

--- a/scripts/clean_osm_data.py
+++ b/scripts/clean_osm_data.py
@@ -645,11 +645,6 @@ def integrate_lines_df(df_all_lines, distance_crs):
     clean_cables(df)
 
     # analyse each row of voltage and requency and match their content
-    # Example:
-    #       tag_frequency   voltage
-    # row1: 50;50           33000
-    # Becomes
-    # row1: 50;50           33000;33000
     split_and_match_voltage_frequency_size(df)
 
     # fill the circuits column for explode

--- a/scripts/clean_osm_data.py
+++ b/scripts/clean_osm_data.py
@@ -62,12 +62,13 @@ def prepare_substation_df(df_all_substations):
         "geometry",
         "country",
     ]
-    df_all_substations = df_all_substations[clist]
 
     # Check. If column is not in df create an empty one.
     for c in clist:
         if c not in df_all_substations:
             df_all_substations[c] = np.nan
+
+    df_all_substations = df_all_substations[clist]
 
     return df_all_substations
 

--- a/scripts/clean_osm_data.py
+++ b/scripts/clean_osm_data.py
@@ -101,7 +101,7 @@ def add_line_endings_tosubstations(substations, lines):
     bus_e["lon"] = bus_e["geometry"].map(lambda p: p.x if p != None else None)
     bus_e["lat"] = bus_e["geometry"].map(lambda p: p.y if p != None else None)
     bus_e["bus_id"] = bus_s["bus_id"].max() + 1 + bus_e.index
-    bus_s["dc"] = ~is_ac
+    bus_e["dc"] = ~is_ac
 
     bus_all = pd.concat([bus_s, bus_e], ignore_index=True)
 
@@ -809,6 +809,9 @@ def clean_data(
         df_all_substations = add_line_endings_tosubstations(
             df_all_substations, df_all_lines
         )
+
+    # drop substations with nan geometry
+    df_all_substations.dropna(subset=["geometry"], axis=0, inplace=True)
 
     # filter substation by voltage
     df_all_substations = filter_voltage(df_all_substations, threshold_voltage)

--- a/scripts/config_osm_data.py
+++ b/scripts/config_osm_data.py
@@ -577,14 +577,19 @@ iso_to_geofk_dict = {
     "VA": "IT",  # Vatican is merged to Italy
     "HT": "haiti-and-domrep",  # Haiti and Dominican Republic are merged in OSM
     "DO": "haiti-and-domrep",  # Haiti and Dominican Republic are merged in OSM
+    "PA": "panama",  # Panama
     "NF": "AU",  # norfolk island is an AU territory
     "MP": "american-oceania",  # northern mariana islands are US territory
     "GU": "american-oceania",  # Guam is a US territory
     "AS": "american-oceania",  # American Samoa is a US territory
     "CP": "ile-de-clipperton",  # Ile de clipperton
     "PF": "polynesie-francaise",  # Polynesie Francaise
-    "VU": "tokelau",  #  tokelau
-    "WS": "wallis-et-futuna",  # Wallis et Fortnuna
+    "VU": "vanuatu",  #  Vanuatu
+    "TK": "tokelau",  # Tokelau
+    "MH": "marshall-islands",  # Marshal islands
+    "PN": "pitcairn-islands",  # Pitcairn
+    "WF": "wallis-et-futuna",  # Wallis et Fortnuna
+    "XK": "RS-KM",  # Kosovo
 }
 
 # data for some islands seem to be merged with some other areas data

--- a/test/config.landlock.yaml
+++ b/test/config.landlock.yaml
@@ -10,3 +10,6 @@ countries: ["BW"]
 
 electricity:
   renewable_carriers: [solar, onwind, hydro]
+
+build_osm_network:
+  force_ac: true  # When true, it forces all components (lines and substation) to be AC-only


### PR DESCRIPTION
# Closes #601 , #619 and #504

## Changes proposed in this Pull Request
This PR aims at restructuring the osm cleaning process to be more exception-resilient.
In particular:
- it fixes the interface with earth-osm for selected countries to be compliant with our "Earth" list
- it improves and normalizes the split_cells procedure to be length-independent, eventually using some heuristics to fix the mismatch
- it makes the cleaning process resilient to unexpected values: it drops them
- it decomposes the cleaning process by OSM column (voltage/frequency/circuits) in specific sub-functions
- it improves the logging
- add "force_ac" option in build osm network to force lines and buses to be AC-only
- clean duplication between clean_osm_data and build_osm_network

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
