### PR TITLE
Pyogrio added, speedup of load_eez

### DIFF
--- a/envs/environment.fixed.yaml
+++ b/envs/environment.fixed.yaml
@@ -302,6 +302,7 @@ dependencies:
 - pyct=0.4.6
 - pyct-core=0.4.6
 - pygments=2.13.0
+- pyogrio=0.5.1
 - pyomo=6.4.2
 - pyopenssl=22.0.0
 - pyparsing=3.0.9

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -43,6 +43,7 @@ dependencies:
 - matplotlib<=3.5.2
 - reverse-geocode
 - country_converter
+- pyogrio
 
   # Keep in conda environment when calling ipython
 - ipython

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -281,7 +281,7 @@ def load_EEZ(countries_codes, geo_crs, EEZ_gpkg="./data/eez/eez_v11.gpkg"):
             f"File EEZ {EEZ_gpkg} not found, please download it from https://www.marineregions.org/download_file.php?name=World_EEZ_v11_20191118_gpkg.zip and copy it in {os.path.dirname(EEZ_gpkg)}"
         )
 
-    geodf_EEZ = gpd.read_file(EEZ_gpkg).to_crs(geo_crs)
+    geodf_EEZ = gpd.read_file(EEZ_gpkg, engine="pyogrio").to_crs(geo_crs)
     geodf_EEZ.dropna(axis=0, how="any", subset=["ISO_TER1"], inplace=True)
     # [["ISO_TER1", "TERRITORY1", "ISO_SOV1", "ISO_SOV2", "ISO_SOV3", "geometry"]]
     geodf_EEZ = geodf_EEZ[["ISO_TER1", "geometry"]]


### PR DESCRIPTION
## Changes proposed in this Pull Request

Use pyogrio as the backend for loading the eez file.
Results in ~20x speedup of file loading. (33.6s -> 1.7s)

Pyogrio is also maintained by the geopandas team, hence it seems reasonable to allow this as an additional dependency.

## Methods

Add cProfile decorator function to `load_EEZ` (see https://github.com/pypsa-meets-earth/pypsa-earth/discussions/557#discussion-4726612)
Run `python ./scripts/build_shapes.py` (Both before and after change)

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [x] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
