### PR TITLE
GitHub template patch

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText:  PyPSA-Earth and PyPSA-Eur Authors
-
-SPDX-License-Identifier: GPL-3.0-or-later
--->
-
 ---
 name: Bug report
 about: Create a report if something doesn't work quite right.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText:  PyPSA-Earth and PyPSA-Eur Authors
-#
-# SPDX-License-Identifier: CC0-1.0
 
 blank_issues_enabled: false
 contact_links:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,3 @@
-
 blank_issues_enabled: false
 contact_links:
 - name: Discussion board

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText:  PyPSA-Earth and PyPSA-Eur Authors
-
-SPDX-License-Identifier: GPL-3.0-or-later
--->
-
 ---
 name: Feature request
 about: Suggest an idea for this project

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText:  PyPSA-Earth and PyPSA-Eur Authors
-
-SPDX-License-Identifier: GPL-3.0-or-later
--->
-
 # Closes # (if applicable).
 
 ## Changes proposed in this Pull Request

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -1,4 +1,3 @@
-
 name: CI-linux
 
 on:

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText:  PyPSA-Earth and PyPSA-Eur Authors
-#
-# SPDX-License-Identifier: CC0-1.0
 
 name: CI-linux
 

--- a/.github/workflows/ci-mac.yaml
+++ b/.github/workflows/ci-mac.yaml
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText:  PyPSA-Earth and PyPSA-Eur Authors
-#
-# SPDX-License-Identifier: CC0-1.0
 
 name: CI-mac
 

--- a/.github/workflows/ci-mac.yaml
+++ b/.github/workflows/ci-mac.yaml
@@ -1,4 +1,3 @@
-
 name: CI-mac
 
 on:

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText:  PyPSA-Earth and PyPSA-Eur Authors
-#
-# SPDX-License-Identifier: CC0-1.0
 
 name: CI-windows
 

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -1,4 +1,3 @@
-
 name: CI-windows
 
 on:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,3 @@
-
 on:
   push:
     branches:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText:  PyPSA-Earth and PyPSA-Eur Authors
-#
-# SPDX-License-Identifier: CC0-1.0
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -162,81 +162,10 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
 <table>
 <tr>
     <td align="center">
-        <a href="https://github.com/hazemful">
-            <img src="https://avatars.githubusercontent.com/u/26235356?v=4" width="100;" alt="hazemful"/>
-            <br />
-            <sub><b>Null</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/jarry7">
-            <img src="https://avatars.githubusercontent.com/u/27745389?v=4" width="100;" alt="jarry7"/>
-            <br />
-            <sub><b>Jarrad Wright</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/fneum">
-            <img src="https://avatars.githubusercontent.com/u/29101152?v=4" width="100;" alt="fneum"/>
-            <br />
-            <sub><b>Fabian Neumann</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/ekatef">
-            <img src="https://avatars.githubusercontent.com/u/30229437?v=4" width="100;" alt="ekatef"/>
-            <br />
-            <sub><b>Ekaterina</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/euronion">
-            <img src="https://avatars.githubusercontent.com/u/42553970?v=4" width="100;" alt="euronion"/>
-            <br />
-            <sub><b>Euronion</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/Justus-coded">
-            <img src="https://avatars.githubusercontent.com/u/44394641?v=4" width="100;" alt="Justus-coded"/>
-            <br />
-            <sub><b>Justus Ilemobayo</b></sub>
-        </a>
-    </td></tr>
-<tr>
-    <td align="center">
-        <a href="https://github.com/mnm-matin">
-            <img src="https://avatars.githubusercontent.com/u/45293386?v=4" width="100;" alt="mnm-matin"/>
-            <br />
-            <sub><b>Mnm-matin</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/desenk">
-            <img src="https://avatars.githubusercontent.com/u/48335263?v=4" width="100;" alt="desenk"/>
-            <br />
-            <sub><b>Desen Kirli</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/LukasFrankenQ">
-            <img src="https://avatars.githubusercontent.com/u/55196140?v=4" width="100;" alt="LukasFrankenQ"/>
-            <br />
-            <sub><b>Lukas Franken</b></sub>
-        </a>
-    </td>
-    <td align="center">
         <a href="https://github.com/pz-max">
             <img src="https://avatars.githubusercontent.com/u/61968949?v=4" width="100;" alt="pz-max"/>
             <br />
             <sub><b>Max Parzen</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/Cesare-Caputo">
-            <img src="https://avatars.githubusercontent.com/u/62548290?v=4" width="100;" alt="Cesare-Caputo"/>
-            <br />
-            <sub><b>Null</b></sub>
         </a>
     </td>
     <td align="center">
@@ -245,34 +174,12 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
             <br />
             <sub><b>Davide-f</b></sub>
         </a>
-    </td></tr>
-<tr>
-    <td align="center">
-        <a href="https://github.com/koen-vg">
-            <img src="https://avatars.githubusercontent.com/u/74298901?v=4" width="100;" alt="koen-vg"/>
-            <br />
-            <sub><b>Koen Van Greevenbroek</b></sub>
-        </a>
     </td>
     <td align="center">
-        <a href="https://github.com/hazemakhalek">
-            <img src="https://avatars.githubusercontent.com/u/87850910?v=4" width="100;" alt="hazemakhalek"/>
+        <a href="https://github.com/ekatef">
+            <img src="https://avatars.githubusercontent.com/u/30229437?v=4" width="100;" alt="ekatef"/>
             <br />
-            <sub><b>Null</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/energyLS">
-            <img src="https://avatars.githubusercontent.com/u/89515385?v=4" width="100;" alt="energyLS"/>
-            <br />
-            <sub><b>EnergyLS</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/AnasAlgarei">
-            <img src="https://avatars.githubusercontent.com/u/101210563?v=4" width="100;" alt="AnasAlgarei"/>
-            <br />
-            <sub><b>AnasAlgarei</b></sub>
+            <sub><b>Ekaterina</b></sub>
         </a>
     </td>
     <td align="center">
@@ -288,8 +195,29 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
             <br />
             <sub><b>Null</b></sub>
         </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/mnm-matin">
+            <img src="https://avatars.githubusercontent.com/u/45293386?v=4" width="100;" alt="mnm-matin"/>
+            <br />
+            <sub><b>Mnm-matin</b></sub>
+        </a>
     </td></tr>
 <tr>
+    <td align="center">
+        <a href="https://github.com/hazemakhalek">
+            <img src="https://avatars.githubusercontent.com/u/87850910?v=4" width="100;" alt="hazemakhalek"/>
+            <br />
+            <sub><b>Null</b></sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/energyLS">
+            <img src="https://avatars.githubusercontent.com/u/89515385?v=4" width="100;" alt="energyLS"/>
+            <br />
+            <sub><b>EnergyLS</b></sub>
+        </a>
+    </td>
     <td align="center">
         <a href="https://github.com/Tomkourou">
             <img src="https://avatars.githubusercontent.com/u/5240283?v=4" width="100;" alt="Tomkourou"/>
@@ -312,10 +240,39 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
         </a>
     </td>
     <td align="center">
+        <a href="https://github.com/euronion">
+            <img src="https://avatars.githubusercontent.com/u/42553970?v=4" width="100;" alt="euronion"/>
+            <br />
+            <sub><b>Euronion</b></sub>
+        </a>
+    </td></tr>
+<tr>
+    <td align="center">
+        <a href="https://github.com/AnasAlgarei">
+            <img src="https://avatars.githubusercontent.com/u/101210563?v=4" width="100;" alt="AnasAlgarei"/>
+            <br />
+            <sub><b>AnasAlgarei</b></sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/LukasFrankenQ">
+            <img src="https://avatars.githubusercontent.com/u/55196140?v=4" width="100;" alt="LukasFrankenQ"/>
+            <br />
+            <sub><b>Lukas Franken</b></sub>
+        </a>
+    </td>
+    <td align="center">
         <a href="https://github.com/Tooblippe">
             <img src="https://avatars.githubusercontent.com/u/805313?v=4" width="100;" alt="Tooblippe"/>
             <br />
             <sub><b>Jarrad Wright</b></sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/koen-vg">
+            <img src="https://avatars.githubusercontent.com/u/74298901?v=4" width="100;" alt="koen-vg"/>
+            <br />
+            <sub><b>Koen Van Greevenbroek</b></sub>
         </a>
     </td>
     <td align="center">
@@ -333,6 +290,13 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
         </a>
     </td></tr>
 <tr>
+    <td align="center">
+        <a href="https://github.com/jarry7">
+            <img src="https://avatars.githubusercontent.com/u/27745389?v=4" width="100;" alt="jarry7"/>
+            <br />
+            <sub><b>Jarrad Wright</b></sub>
+        </a>
+    </td>
     <td align="center">
         <a href="https://github.com/squoilin">
             <img src="https://avatars.githubusercontent.com/u/4547840?v=4" width="100;" alt="squoilin"/>

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -80,6 +80,8 @@ Upcoming Release
 
 * Add REUSE compatability `PR #651 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/651>`__
 
+* Fix bug of missing GitHub issue template `PR #660 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/660>`__
+
 PyPSA-Earth 0.1.0
 =================
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
It was not possible to create issues or feature requests on the Repo. 
The reason were the licensing strings on top of each file introduced by https://github.com/pypsa-meets-earth/pypsa-earth/pull/651
Removing them solved the issue. 

Also, the changes won't break the REUSE lint (I tested it) since the License information are given for all files in `./.github/*` in `./reuse/dep5`. So we had a duplication that is removed now.

## Checklist

- [x] I consent to the release of this PR's code under the GPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.