### PR TITLE
fix - layer_id not resetting after each loop

### DIFF
--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -156,6 +156,9 @@ def get_GADM_layer(
     geodf_list = []
 
     for country_code in country_list:
+        # Set the current layer id (cur_layer_id) to global layer_id
+        cur_layer_id = layer_id
+
         # download file gpkg
         file_gpkg, name_file = download_GADM(country_code, update, outlogging)
 
@@ -163,18 +166,18 @@ def get_GADM_layer(
         list_layers = fiona.listlayers(file_gpkg)
 
         # get layer name
-        if (layer_id < 0) or (layer_id >= len(list_layers)):
+        if (cur_layer_id < 0) or (cur_layer_id >= len(list_layers)):
             # when layer id is negative or larger than the number of layers, select the last layer
-            layer_id = len(list_layers) - 1
+            cur_layer_id = len(list_layers) - 1
 
         # read gpkg file
-        geodf_temp = gpd.read_file(file_gpkg, layer="ADM_ADM_" + str(layer_id)).to_crs(
-            geo_crs
-        )
+        geodf_temp = gpd.read_file(
+            file_gpkg, layer="ADM_ADM_" + str(cur_layer_id)
+        ).to_crs(geo_crs)
 
         geodf_temp = filter_gadm(
             geodf=geodf_temp,
-            layer=layer_id,
+            layer=cur_layer_id,
             cc=country_code,
             contended_flag=contended_flag,
             output_nonstd_to_csv=False,
@@ -182,7 +185,7 @@ def get_GADM_layer(
 
         # create a subindex column that is useful
         # in the GADM processing of sub-national zones
-        geodf_temp["GADM_ID"] = geodf_temp[f"GID_{layer_id}"]
+        geodf_temp["GADM_ID"] = geodf_temp[f"GID_{cur_layer_id}"]
 
         # append geodataframes
         geodf_list.append(geodf_temp)


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request

When running `build_shapes` for `['earth']` there were inconsistencies in the `gadm_layer_id` of countries, see below:

`gadm_layer_id = 1`

![Earth_layer_id_1](https://user-images.githubusercontent.com/127969728/229375142-6a6c57fd-3c41-448d-b8e7-e46c8d75f982.png)

`gadm_layer_id = 10`

![Earth_layer_id_10](https://user-images.githubusercontent.com/127969728/229375148-f471e58b-7019-4520-addc-fa6f539074f4.png)

By going through the code it seems layer_id wasn't being set to the global `gdam_layer_id` in `get_GADM_layer`.
This would result in layer_id being set to 0 once countries such as 'NU' were reached, then all following countries would use 0 instead of the original `gadm_layer_id`.

## Checklist

- [x] I consent to the release of this PR's code under the GPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [x] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
