### PR TITLE
Adaptations to GADM id usage and alternative clustering

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -82,6 +82,8 @@ Upcoming Release
 
 * Fix bug of missing GitHub issue template `PR #660 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/660>`__
 
+* Fix GADM bug when using alternative clustering and store gadm shape with two letter instead of three letter ISO code  `PR #670 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/670>`__
+
 PyPSA-Earth 0.1.0
 =================
 

--- a/scripts/build_bus_regions.py
+++ b/scripts/build_bus_regions.py
@@ -49,7 +49,7 @@ import geopandas as gpd
 import numpy
 import pandas as pd
 import pypsa
-from _helpers import REGION_COLS, configure_logging, two_2_three_digits_country
+from _helpers import REGION_COLS, configure_logging
 from shapely.geometry import Point, Polygon
 from shapely.ops import unary_union
 from vresutils.graph import voronoi_partition_pts
@@ -135,9 +135,7 @@ def custom_voronoi_partition_pts(points, outline, add_bounds_shape=True, multipl
 def get_gadm_shape(onshore_locs, gadm_shapes):
     def locate_bus(coords):
         point = Point(Point(coords["x"], coords["y"]))
-        gadm_shapes_country = gadm_shapes.filter(
-            like=two_2_three_digits_country(country), axis=0
-        )
+        gadm_shapes_country = gadm_shapes.filter(like=country, axis=0)
 
         try:
             return gadm_shapes[gadm_shapes.contains(point)].item()
@@ -148,9 +146,7 @@ def get_gadm_shape(onshore_locs, gadm_shapes):
 
     def get_id(coords):
         point = Point(Point(coords["x"], coords["y"]))
-        gadm_shapes_country = gadm_shapes.filter(
-            like=two_2_three_digits_country(country), axis=0
-        )
+        gadm_shapes_country = gadm_shapes.filter(like=country, axis=0)
 
         try:
             return gadm_shapes[gadm_shapes.contains(point)].index.item()

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -312,8 +312,15 @@ if __name__ == "__main__":
 
             point = Point(coords["lon"], coords["lat"])
 
-            # try:
-            return gdf_co[gdf_co.contains(point)]["GADM_ID"].item()
+            try:
+                return gdf_co[gdf_co.contains(point)][
+                    'GADM_ID'
+                    ].item()  # filter gdf_co which contains point and returns the bus
+
+            except ValueError:
+                return gdf_co[gdf_co.geometry == min(gdf_co.geometry, key=(point.distance))][
+                    'GADM_ID'
+                ].item()  # looks for closest one shape=node
 
         ppl["region_id"] = ppl[["lon", "lat", "Country"]].apply(
             lambda pp: locate_bus(pp[["lon", "lat"]], pp["Country"]), axis=1

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -323,6 +323,7 @@ if __name__ == "__main__":
                 ][
                     "GADM_ID"
                 ].item()  # looks for closest one shape=node
+                # fixing https://github.com/pypsa-meets-earth/pypsa-earth/pull/670
 
         ppl["region_id"] = ppl[["lon", "lat", "Country"]].apply(
             lambda pp: locate_bus(pp[["lon", "lat"]], pp["Country"]), axis=1

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -73,10 +73,8 @@ import pypsa
 import yaml
 from _helpers import (
     configure_logging,
-    country_name_2_two_digits,
     read_csv_nafix,
     to_csv_nafix,
-    two_2_three_digits_country,
     two_digits_2_name_country,
 )
 from build_shapes import get_GADM_layer
@@ -308,7 +306,7 @@ if __name__ == "__main__":
         gdf = gpd.read_file(snakemake.input.gadm_shapes)
 
         def locate_bus(coords, co):
-            gdf_co = gdf[gdf["GADM_ID"].str.contains(two_2_three_digits_country(co))]
+            gdf_co = gdf[gdf["GADM_ID"].str.contains(co)]
 
             point = Point(coords["lon"], coords["lat"])
 

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -314,12 +314,14 @@ if __name__ == "__main__":
 
             try:
                 return gdf_co[gdf_co.contains(point)][
-                    'GADM_ID'
-                    ].item()  # filter gdf_co which contains point and returns the bus
+                    "GADM_ID"
+                ].item()  # filter gdf_co which contains point and returns the bus
 
             except ValueError:
-                return gdf_co[gdf_co.geometry == min(gdf_co.geometry, key=(point.distance))][
-                    'GADM_ID'
+                return gdf_co[
+                    gdf_co.geometry == min(gdf_co.geometry, key=(point.distance))
+                ][
+                    "GADM_ID"
                 ].item()  # looks for closest one shape=node
 
         ppl["region_id"] = ppl[["lon", "lat", "Country"]].apply(

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -331,7 +331,10 @@ def rescale_hydro(plants, runoff, normalize_using_yearly, normalization_year):
     if plants.empty or plants.installed_hydro.any() == False:
         logger.info("No bus has installed hydro plants, ignoring normalization.")
         return runoff
-
+    
+    if snakemake.config["cluster_options"]["alternative_clustering"]:
+        plants = plants.set_index('shape_id')
+    
     years_statistics = normalize_using_yearly.index
     if isinstance(years_statistics, pd.DatetimeIndex):
         years_statistics = years_statistics.year
@@ -566,7 +569,7 @@ if __name__ == "__main__":
 
         resource["plants"] = regions.rename(
             columns={"x": "lon", "y": "lat", "country": "countries"}
-        ).loc[bus_in_hydrobasins, ["lon", "lat", "countries"]]
+        ).loc[bus_in_hydrobasins, ["lon", "lat", "countries", "shape_id"]]
 
         resource["plants"]["installed_hydro"] = [
             True if (bus_id in hydro_ppls.bus.values) else False

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -331,10 +331,10 @@ def rescale_hydro(plants, runoff, normalize_using_yearly, normalization_year):
     if plants.empty or plants.installed_hydro.any() == False:
         logger.info("No bus has installed hydro plants, ignoring normalization.")
         return runoff
-    
+
     if snakemake.config["cluster_options"]["alternative_clustering"]:
-        plants = plants.set_index('shape_id')
-    
+        plants = plants.set_index("shape_id")
+
     years_statistics = normalize_using_yearly.index
     if isinstance(years_statistics, pd.DatetimeIndex):
         years_statistics = years_statistics.year

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -859,9 +859,11 @@ def gadm(
 
     # renaming 3 letter to 2 letter ISO code before saving GADM file
     # solves issue: https://github.com/pypsa-meets-earth/pypsa-earth/issues/671
-    df_gadm["GADM_ID"] = df_gadm["GADM_ID"].str.split(".").apply(
-        lambda id: three_2_two_digits_country(id[0]) + '.' + id[1]
-        )
+    df_gadm["GADM_ID"] = (
+        df_gadm["GADM_ID"]
+        .str.split(".")
+        .apply(lambda id: three_2_two_digits_country(id[0]) + "." + id[1])
+    )
     df_gadm.set_index("GADM_ID", inplace=True)
     df_gadm["geometry"] = df_gadm["geometry"].map(_simplify_polys)
     df_gadm.geometry = df_gadm.geometry.apply(

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -857,12 +857,11 @@ def gadm(
             name_file_nc="GDP_PPP_1990_2015_5arcmin_v2.nc",
         )
 
-    # set index and simplify polygons
-    df_gadm["GADM_ID"] = (
-        df_gadm["GADM_ID"]
-        .str.split(".")
-        .apply(lambda id: three_2_two_digits_country(id[0]) + "." + id[1])
-    )
+    # renaming 3 letter to 2 letter ISO code before saving GADM file
+    # solves issue: https://github.com/pypsa-meets-earth/pypsa-earth/issues/671
+    df_gadm["GADM_ID"] = df_gadm["GADM_ID"].str.split(".").apply(
+        lambda id: three_2_two_digits_country(id[0]) + '.' + id[1]
+        )
     df_gadm.set_index("GADM_ID", inplace=True)
     df_gadm["geometry"] = df_gadm["geometry"].map(_simplify_polys)
     df_gadm.geometry = df_gadm.geometry.apply(

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -24,7 +24,6 @@ import rioxarray as rx
 import xarray as xr
 from _helpers import (
     configure_logging,
-    country_name_2_two_digits,
     sets_path_to_root,
     three_2_two_digits_country,
     two_2_three_digits_country,
@@ -859,6 +858,9 @@ def gadm(
         )
 
     # set index and simplify polygons
+    df_gadm["GADM_ID"] = df_gadm["GADM_ID"].str.split(".").apply(
+        lambda id: three_2_two_digits_country(id[0]) + '.' + id[1]
+        )
     df_gadm.set_index("GADM_ID", inplace=True)
     df_gadm["geometry"] = df_gadm["geometry"].map(_simplify_polys)
     df_gadm.geometry = df_gadm.geometry.apply(

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -858,9 +858,11 @@ def gadm(
         )
 
     # set index and simplify polygons
-    df_gadm["GADM_ID"] = df_gadm["GADM_ID"].str.split(".").apply(
-        lambda id: three_2_two_digits_country(id[0]) + '.' + id[1]
-        )
+    df_gadm["GADM_ID"] = (
+        df_gadm["GADM_ID"]
+        .str.split(".")
+        .apply(lambda id: three_2_two_digits_country(id[0]) + "." + id[1])
+    )
     df_gadm.set_index("GADM_ID", inplace=True)
     df_gadm["geometry"] = df_gadm["geometry"].map(_simplify_polys)
     df_gadm.geometry = df_gadm.geometry.apply(

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -137,8 +137,8 @@ from _helpers import (
     configure_logging,
     get_aggregation_strategies,
     sets_path_to_root,
-    two_2_three_digits_country,
     three_2_two_digits_country,
+    two_2_three_digits_country,
     update_p_nom_max,
 )
 from add_electricity import load_costs
@@ -391,7 +391,7 @@ def busmap_for_gadm_clusters(inputs, n, gadm_level, geo_crs, country_list):
             gadm_id = gdf_co[
                 gdf_co.geometry == min(gdf_co.geometry, key=(point.distance))
             ]["GADM_ID"].item()
-            return three_2_two_digits_country( gadm_id[:3]) + gadm_id[3:]
+            return three_2_two_digits_country(gadm_id[:3]) + gadm_id[3:]
 
     buses = n.buses
     buses["gadm_{}".format(gadm_level)] = buses[["x", "y", "country"]].apply(

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -138,6 +138,7 @@ from _helpers import (
     get_aggregation_strategies,
     sets_path_to_root,
     two_2_three_digits_country,
+    three_2_two_digits_country,
     update_p_nom_max,
 )
 from add_electricity import load_costs
@@ -383,12 +384,14 @@ def busmap_for_gadm_clusters(inputs, n, gadm_level, geo_crs, country_list):
         point = Point(coords["x"], coords["y"])
 
         try:
-            return gdf_co[gdf_co.contains(point)]["GADM_ID"].item()
+            gadm_id = gdf_co[gdf_co.contains(point)]["GADM_ID"].item()
+            return three_2_two_digits_country(gadm_id[:3]) + gadm_id[3:]
 
         except ValueError:
-            return gdf_co[
+            gadm_id = gdf_co[
                 gdf_co.geometry == min(gdf_co.geometry, key=(point.distance))
             ]["GADM_ID"].item()
+            return three_2_two_digits_country( gadm_id[:3]) + gadm_id[3:]
 
     buses = n.buses
     buses["gadm_{}".format(gadm_level)] = buses[["x", "y", "country"]].apply(

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -137,8 +137,6 @@ from _helpers import (
     configure_logging,
     get_aggregation_strategies,
     sets_path_to_root,
-    three_2_two_digits_country,
-    two_2_three_digits_country,
     update_p_nom_max,
 )
 from add_electricity import load_costs
@@ -380,18 +378,16 @@ def busmap_for_gadm_clusters(inputs, n, gadm_level, geo_crs, country_list):
     gdf = gpd.read_file(inputs.gadm_shapes)
 
     def locate_bus(coords, co):
-        gdf_co = gdf[gdf["GADM_ID"].str.contains(two_2_three_digits_country(co))]
+        gdf_co = gdf[gdf["GADM_ID"].str.contains(co)]
         point = Point(coords["x"], coords["y"])
 
         try:
-            gadm_id = gdf_co[gdf_co.contains(point)]["GADM_ID"].item()
-            return three_2_two_digits_country(gadm_id[:3]) + gadm_id[3:]
+            return gdf_co[gdf_co.contains(point)]["GADM_ID"].item()
 
         except ValueError:
-            gadm_id = gdf_co[
+            return gdf_co[
                 gdf_co.geometry == min(gdf_co.geometry, key=(point.distance))
             ]["GADM_ID"].item()
-            return three_2_two_digits_country(gadm_id[:3]) + gadm_id[3:]
 
     buses = n.buses
     buses["gadm_{}".format(gadm_level)] = buses[["x", "y", "country"]].apply(
@@ -645,7 +641,7 @@ if __name__ == "__main__":
 
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
         snakemake = mock_snakemake(
-            "cluster_network", network="elec", simpl="", clusters="60"
+            "cluster_network", network="elec", simpl="", clusters="10"
         )
         sets_path_to_root("pypsa-earth")
     configure_logging(snakemake)


### PR DESCRIPTION
# Closes #671 

## Changes proposed in this Pull Request

The alphabetic 3-digit country code, which is contained in the GADM id, was replaced by the 2-digit code, before storing the GADM shapes in the script build_shapes. Thus, multiple applications of the country code conversion helper function could be avoided in the scripts build_bus_regions, build_powerplants and cluster_network.

## Further changes

Running the workflow with alternative clustering turned to true, some minor issues were encountered for the countries Namibia, Ukraine and Brazil. They occurred at the stages of building the powerplants, the renewable profiles and the network clustering.


**Changes in build_powerplants:**
Some powerplants were not contained within GADM shapes. When running the model for Brazil, it was observed that this case can occur for different types of power plant sites, often located near water bodies:

1. Power plant is located in the border area between two GADM regions within the country e.g. (-9.1439, -38.3133), (-20.38278, -51.36222)
2. Power plant is located in the border area to neighbour country e.g. ( -9.1439, -38.3133), (-4.3521, -70.0258)
3. Power plant is located in the ocean, distant to border regions e.g. (-3.7132, -38.5336)
4. Power plant is located on the mainland, distant to border regions e.g. (-22.899, -43.1985)

The proposed PR maps these powerplants to the closest GADM region.

**Changes in build_renewable_profiles:**
 Some minor adaptions were made in order to fix errors, that occured for cases where the GADM id was indexed.


## Checklist

- [x] I consent to the release of this PR's code under the GPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
