### PR TITLE
fix append powerplant bug

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -86,6 +86,8 @@ Upcoming Release
 
 * Fix GADM naming bug related to level-2 clustering `PR #684 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/684>`__
 
+* Fix append bug in build_powerplants rule `PR #686 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/686>`__
+
 PyPSA-Earth 0.1.0
 =================
 

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -247,7 +247,9 @@ def add_custom_powerplants(ppl, inputs, config):
     # if isinstance(custom_ppl_query, str):
     #     add_ppls.query(custom_ppl_query, inplace=True)
 
-    return pd.concat([ppl, add_ppls], sort=False, ignore_index=True, verify_integrity=True)
+    return pd.concat(
+        [ppl, add_ppls], sort=False, ignore_index=True, verify_integrity=True
+    )
 
 
 def replace_natural_gas_technology(df):

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -247,7 +247,7 @@ def add_custom_powerplants(ppl, inputs, config):
     # if isinstance(custom_ppl_query, str):
     #     add_ppls.query(custom_ppl_query, inplace=True)
 
-    return ppl.append(add_ppls, sort=False, ignore_index=True, verify_integrity=True)
+    return pd.concat([ppl, add_ppls], sort=False, ignore_index=True, verify_integrity=True)
 
 
 def replace_natural_gas_technology(df):


### PR DESCRIPTION
## Changes proposed in this Pull Request
Here I propose to change Pandas "append" method with "concat" to fix the bug related with newer versions Pandas. The error was: AttributeError: 'DataFrame' object has no attribute 'append'.

What was before: return ppl.append(add_ppls, sort=False, ignore_index=True, verify_integrity=True)
Proposed changes: return pd.concat([ppl, add_ppls], sort=False, ignore_index=True, verify_integrity=True)

## Checklist

- [x] I consent to the release of this PR's code under the GPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
