### PR TITLE
Fix an output error for connections costs

### DIFF
--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -269,6 +269,7 @@ def simplify_links(n, costs, config, output, aggregation_strategies=dict()):
     logger.info("Simplifying connected link components")
 
     if n.links.empty:
+        pd.DataFrame({}).to_csv(output.connection_costs)
         return n, n.buses.index.to_series()
 
     # Determine connected link components, ignore all links but DC

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -269,7 +269,8 @@ def simplify_links(n, costs, config, output, aggregation_strategies=dict()):
     logger.info("Simplifying connected link components")
 
     if n.links.empty:
-        pd.DataFrame({}).to_csv(output.connection_costs)
+        with open(output.connection_costs, "w") as fp:
+            pass
         return n, n.buses.index.to_series()
 
     # Determine connected link components, ignore all links but DC


### PR DESCRIPTION
# Closes #647

Currently a connection costs file is written by `_adjust_capital_costs_using_connection_costs` which is called after simplifying links and when removing stubs. If there are no links in the network and `remove_stubs: false`, a connection costs file is not written which leads to snakemake `MissingOutputException` error.

Added an output of an empty data frame for connection costs to a short-cut of `simplify_links()` corresponding to a case without links in the network. In case `remove_stubs` is called, it happens after `simplify_links()` and an empty connections costs file will simply be overwriten. 

## Checklist

- [x] I consent to the release of this PR's code under the GPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
