### PR TITLE
Add a fix for missing column with empty generators dataframe

### DIFF
--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -779,5 +779,8 @@ if __name__ == "__main__":
     update_p_nom_max(n)
     add_nice_carrier_names(n, snakemake.config)
 
+    if not ("weight" in n.generators.columns):
+        n.generators["weight"] = pd.Series()
+
     n.meta = snakemake.config
     n.export_to_netcdf(snakemake.output[0])


### PR DESCRIPTION
Quick fix for #704 

## Changes proposed in this Pull Request

Added "weight" column to n.generators dataframe to match with a structure expected by `PyPSA::aggregategenerators`

## Checklist

- [x] I consent to the release of this PR's code under the GPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
