### PR TITLE
Avoid dropping generators with empty time series when clips equal zero

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -96,6 +96,8 @@ Upcoming Release
 
 * Improve earth coverage and add improve make_statistics coverage `PR #654 https://github.com/pypsa-meets-earth/pypsa-earth/pull/654`__
 
+* Fix bug for missing renewable profiles and generators `PR #714 https://github.com/pypsa-meets-earth/pypsa-earth/pull/714`__
+
 PyPSA-Earth 0.1.0
 =================
 

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -779,5 +779,8 @@ if __name__ == "__main__":
     update_p_nom_max(n)
     add_nice_carrier_names(n, snakemake.config)
 
+    if not ("weight" in n.generators.columns):
+        n.generators["weight"] = pd.Series()
+
     n.meta = snakemake.config
     n.export_to_netcdf(snakemake.output[0])

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -780,6 +780,7 @@ if __name__ == "__main__":
     add_nice_carrier_names(n, snakemake.config)
 
     if not ("weight" in n.generators.columns):
+        logger.warning("Unexpected missing 'weight' column; typical when no generators are detected. Manually added.")
         n.generators["weight"] = pd.Series()
 
     n.meta = snakemake.config

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -465,7 +465,7 @@ if __name__ == "__main__":
         from _helpers import mock_snakemake
 
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
-        snakemake = mock_snakemake("build_renewable_profiles", technology="hydro")
+        snakemake = mock_snakemake("build_renewable_profiles", technology="solar")
         sets_path_to_root("pypsa-earth")
     configure_logging(snakemake)
 
@@ -594,7 +594,7 @@ if __name__ == "__main__":
                 inflow["plant"] = regions.shape_id.loc[inflow["plant"]].values
 
             if "clip_min_inflow" in config:
-                inflow = inflow.where(inflow > config["clip_min_inflow"], 0)
+                inflow = inflow.where(inflow >= config["clip_min_inflow"], 0)
 
             # check if normalization field belongs to the settings and it is not false
             if normalization:
@@ -783,8 +783,8 @@ if __name__ == "__main__":
         # select only buses with some capacity and minimal capacity factor
         ds = ds.sel(
             bus=(
-                (ds["profile"].mean("time") > config.get("min_p_max_pu", 0.0))
-                & (ds["p_nom_max"] > config.get("min_p_nom_max", 0.0))
+                (ds["profile"].mean("time") >= config.get("min_p_max_pu", 0.0))
+                & (ds["p_nom_max"] >= config.get("min_p_nom_max", 0.0))
             )
         )
 

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -499,7 +499,11 @@ if __name__ == "__main__":
     regions = regions.set_index("name").rename_axis("bus")
 
     cutout = atlite.Cutout(paths["cutout"])
-    cutout = filter_cutout_region(cutout, regions)
+    if not snakemake.wildcards.technology.startswith("hydro"):
+        # if technology is not hydro, restrict the region of the cutout
+        # hydrobasins may span beyond the region of the country, so
+        # it is unsafe to restrict the region for hydro
+        cutout = filter_cutout_region(cutout, regions)
 
     if snakemake.config["cluster_options"]["alternative_clustering"]:
         regions = gpd.GeoDataFrame(

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -500,9 +500,7 @@ if __name__ == "__main__":
 
     cutout = atlite.Cutout(paths["cutout"])
     if not snakemake.wildcards.technology.startswith("hydro"):
-        # if technology is not hydro, restrict the region of the cutout
-        # hydrobasins may span beyond the region of the country, so
-        # it is unsafe to restrict the region for hydro
+        # the region should be restricted for non-hydro technologies, as the hydro potential is calculated across hydrobasins which may span beyond the region of the country
         cutout = filter_cutout_region(cutout, regions)
 
     if snakemake.config["cluster_options"]["alternative_clustering"]:


### PR DESCRIPTION
# Closes #704, #706

## Changes proposed in this Pull Request
This PR co-authored with @ekatef that identified the issue address the problem of no generators being found and no weight column to be found.
This issue may complement the PR #709.

## Checklist

- [x] I consent to the release of this PR's code under the GPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [x] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
