### PR TITLE
fix readthedocs built with python 3.11

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@
 version: 2
 
 python:
-  version: 3.8
+  version: 3.11  # https://github.com/pylint-dev/astroid/pull/2165/files
   install:
   - requirements: doc/requirements.txt
   system_packages: false


### PR DESCRIPTION
# Closes # (if applicable).

Our readthedocs built is currently not online because there is an error `Could not import extension sphinx.builders.linkcheck (exception: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with OpenSSL 1.0.2n  7 Dec 2017. See: https://github.com/urllib3/urllib3/issues/2168)`

This PR builds the docs with 3.11 which should fix this: https://github.com/urllib3/urllib3/issues/2168
