### PR TITLE
bump python version for docs built

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,8 +4,12 @@
 
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 python:
-  version: 3.11  # https://github.com/pylint-dev/astroid/pull/2165/files
   install:
   - requirements: doc/requirements.txt
   system_packages: false


### PR DESCRIPTION
This did not work.. https://github.com/pypsa-meets-earth/pypsa-earth/pull/716
My bad leading to the error: `Problem in your project's configuration. Invalid "python.version": expected one of (2, 2.7, 3, 3.5, 3.6, 3.7, 3.8, pypy3.5), got 3.11`

This PR implements now that stuff in the above linked PR correctly.