### PR TITLE
add graphviz to docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,6 +8,8 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  apt_packages:
+  - graphviz
 
 python:
   install:

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -6,9 +6,19 @@
 Release Notes
 ##########################################
 
-
-Upcoming Release
+Upcoming release
 ================
+
+Please add descriptive release notes like in `PyPSA-Eur <https://github.com/PyPSA/pypsa-eur/blob/master/doc/release_notes.rst>`__.
+E.g. if a new rule becomes available describe how to use it `snakemake -j1 run_tests` and in one sentence what it does.
+
+**New Features and major Changes**
+
+- Fix bug. Add graphviz to docs to compile workflows in the documentation and adapt release notes `PR #719 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/719>`__
+
+
+PyPSA-Earth 0.2.0
+=================
 
 **New Features and major Changes**
 
@@ -94,7 +104,7 @@ Upcoming Release
 
 * Update and improve configuration section in documentation `PR #694 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/694>`__
 
-* Improve earth coverage and add improve make_statistics coverage `PR #654 https://github.com/pypsa-meets-earth/pypsa-earth/pull/654`__
+* Improve earth coverage and add improve make_statistics coverage `PR #654 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/654>`__
 
 PyPSA-Earth 0.1.0
 =================


### PR DESCRIPTION
Applied the fix as in: https://github.com/PyPSA/pypsa-eur/pull/658
We have to again complete workflow images in the docs like :taco: 
![image](https://user-images.githubusercontent.com/61968949/236687041-20fc539b-0b09-4e5e-a450-2ab402f46c1d.png)


## Checklist

- [x] I consent to the release of this PR's code under the GPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
