### PR TITLE
adapt #714 to avoid hydro mismatch

### DIFF
--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -432,7 +432,7 @@ def attach_hydro(n, costs, ppl):
             missing_plants = pd.Index(inflow_buses.unique()).difference(
                 inflow.indexes["plant"]
             )
-            intersection_plants = inflow.indexes["plant"].intersection(inflow_buses)
+            intersection_plants = pd.Index(inflow_buses[inflow_buses.isin(inflow.indexes["plant"])])
 
             # if missing time series are found, notify the user and exclude missing hydro plants
             if not missing_plants.empty:

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -432,7 +432,9 @@ def attach_hydro(n, costs, ppl):
             missing_plants = pd.Index(inflow_buses.unique()).difference(
                 inflow.indexes["plant"]
             )
-            intersection_plants = pd.Index(inflow_buses[inflow_buses.isin(inflow.indexes["plant"])])
+            intersection_plants = pd.Index(
+                inflow_buses[inflow_buses.isin(inflow.indexes["plant"])]
+            )
 
             # if missing time series are found, notify the user and exclude missing hydro plants
             if not missing_plants.empty:


### PR DESCRIPTION
## Changes proposed in this Pull Request

After the merge of #714  an error was thrown for the declaration of `inflow_t` in line 455 of add_electricity.py. This error was thrown due to a dimension mismatch of `inflow.sel(plant=intersection_plants)` and `inflow_idx` which prevents the assignment of data array-coordinates in line 458. The error was thrown for Brazil (tested for kmeans- and alternative clustering) and Morocco (alternative clustering). Most probably this behaviour occurs due to the one-to-many relationship, which exists in these countries between buses and hydroplants. In Brazil for example, the bus 1851 is mapped to 6 different hydro/ror plants. The mismatch tends to increase with the size of cluster regions.


## Checklist

- [x] I consent to the release of this PR's code under the GPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
