### PR TITLE
Custom ppl opts

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -142,7 +142,7 @@ electricity:
     Link: []  # H2 pipeline
 
   powerplants_filter: (DateOut >= 2022 or DateOut != DateOut)
-  custom_powerplants: false  # "false" - no custom powerplants, "merge" uses both open-source and custom powerplants, "replace" uses only custom powerplants
+  custom_powerplants: false  #  "false" use only powerplantmatching (ppm) data, "merge" combines ppm and custom powerplants, "replace" use only custom powerplants
 
   conventional_carriers: [nuclear, oil, OCGT, CCGT, coal, lignite, geothermal, biomass]
   renewable_carriers: [solar, onwind, offwind-ac, offwind-dc, hydro]

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -142,7 +142,7 @@ electricity:
     Link: []  # H2 pipeline
 
   powerplants_filter: (DateOut >= 2022 or DateOut != DateOut)
-  custom_powerplants: false
+  custom_powerplants: false  # "false" - no custom powerplants, "merge" uses both open-source and custom powerplants, "replace" uses only custom powerplants
 
   conventional_carriers: [nuclear, oil, OCGT, CCGT, coal, lignite, geothermal, biomass]
   renewable_carriers: [solar, onwind, offwind-ac, offwind-dc, hydro]

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -156,7 +156,7 @@ electricity:
     Link: []  # H2 pipeline
 
   powerplants_filter: (DateOut >= 2022 or DateOut != DateOut)
-  custom_powerplants: false
+  custom_powerplants: false  # "false" - no custom powerplants, "merge" uses both open-source and custom powerplants, "replace" uses only custom powerplants
 
   conventional_carriers: [nuclear, oil, OCGT, CCGT, coal, lignite, geothermal, biomass]
   renewable_carriers: [solar, onwind, offwind-ac, offwind-dc, hydro]

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -156,7 +156,7 @@ electricity:
     Link: []  # H2 pipeline
 
   powerplants_filter: (DateOut >= 2022 or DateOut != DateOut)
-  custom_powerplants: false  # "false" - no custom powerplants, "merge" uses both open-source and custom powerplants, "replace" uses only custom powerplants
+  custom_powerplants: false  #  "false" use only powerplantmatching (ppm) data, "merge" combines ppm and custom powerplants, "replace" use only custom powerplants
 
   conventional_carriers: [nuclear, oil, OCGT, CCGT, coal, lignite, geothermal, biomass]
   renewable_carriers: [solar, onwind, offwind-ac, offwind-dc, hydro]

--- a/doc/configtables/electricity.csv
+++ b/doc/configtables/electricity.csv
@@ -19,7 +19,7 @@ extendable_carriers,,,
 -- Store,--,"Any subset of {battery,H2}", "Adds extendable storage units (battery and/or hydrogen) at every node/bus after clustering without capacity limits and with zero initial capacity."
 -- Link,--, "Any subset of {H2 pipeline}", "Adds extendable links (H2 pipelines only) at every connection where there are lines or HVDC links without capacity limits and with zero initial capacity. Hydrogen pipelines require hydrogen storage to be modelled as ``Store``."
 powerplants_filter,--,"use `pandas.query <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.query.html>`_ strings here, e.g. Country not in ['Germany']", "Filter query for the default powerplant database."
-custom_powerplants,--,"use `pandas.query <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.query.html>`_ strings here, e.g. Country in ['Germany']", "Filter query for the custom powerplant database."
+custom_powerplants,--,"{false, merge, replace}", "Adds custom powerplants from ``custom_powerplants.csv``: false - use only powerplantmatching (ppm) data, merge - combines ppm and custom powerplants, replace - use only custom powerplants."
 conventional_carriers,--,"Any subset of {nuclear, oil, OCGT, CCGT, coal, lignite, geothermal, biomass}", "List of conventional power plants to include in the model from ``resources/powerplants.csv``."
 renewable_carriers,--, "Any subset of {solar, onwind, offwind-ac, offwind-dc, hydro}", "List of renewable power plants to include in the model from ``resources/powerplants.csv``."
 estimate_renewable_capacities,,,

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -24,6 +24,7 @@ PyPSA-Earth 0.2.1
 * Fix hard-coded simplification of lines to 380kV `PR #732 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/732>`__.
   It is now possible to simplify the network to any other voltage level with config option `base_voltage`.
 
+* Add merge and replace functionalities while adding custom powerplants `PR #739 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/739>`__
 
 PyPSA-Earth 0.2.0
 =================

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -12,6 +12,8 @@ Upcoming release
 Please add descriptive release notes like in `PyPSA-Eur <https://github.com/PyPSA/pypsa-eur/blob/master/doc/release_notes.rst>`__.
 E.g. if a new rule becomes available describe how to use it `snakemake -j1 run_tests` and in one sentence what it does.
 
+* Add merge and replace functionalities when adding custom powerplants `PR #739 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/739>`__. "Merge" combined the powerplantmatching data with new custom data. "Replace" allows to use fully self-collected data.
+
 PyPSA-Earth 0.2.1
 =================
 
@@ -23,8 +25,6 @@ PyPSA-Earth 0.2.1
 
 * Fix hard-coded simplification of lines to 380kV `PR #732 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/732>`__.
   It is now possible to simplify the network to any other voltage level with config option `base_voltage`.
-
-* Add merge and replace functionalities while adding custom powerplants `PR #739 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/739>`__
 
 PyPSA-Earth 0.2.0
 =================

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -244,8 +244,6 @@ def add_custom_powerplants(ppl, inputs, config):
     add_ppls = read_csv_nafix(
         inputs.custom_powerplants, index_col=0, dtype={"bus": "str"}
     )
-    # if isinstance(custom_ppl_query, str):
-    #     add_ppls.query(custom_ppl_query, inplace=True)
 
     if custom_ppl_query == "merge":
         return pd.concat(

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -247,9 +247,10 @@ def add_custom_powerplants(ppl, inputs, config):
     # if isinstance(custom_ppl_query, str):
     #     add_ppls.query(custom_ppl_query, inplace=True)
 
-    return pd.concat(
-        [ppl, add_ppls], sort=False, ignore_index=True, verify_integrity=True
-    )
+    if custom_ppl_query == "merge":
+        return pd.concat([ppl, add_ppls], sort=False, ignore_index=True, verify_integrity=True)
+    elif custom_ppl_query == "replace":
+        return add_ppls
 
 
 def replace_natural_gas_technology(df):

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -248,7 +248,9 @@ def add_custom_powerplants(ppl, inputs, config):
     #     add_ppls.query(custom_ppl_query, inplace=True)
 
     if custom_ppl_query == "merge":
-        return pd.concat([ppl, add_ppls], sort=False, ignore_index=True, verify_integrity=True)
+        return pd.concat(
+            [ppl, add_ppls], sort=False, ignore_index=True, verify_integrity=True
+        )
     elif custom_ppl_query == "replace":
         return add_ppls
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
Here I propose an extension of functionality of custom powerplants addition. Currently, there are only two options: 1) Use open-source powerplants with `custom_powerplants: false`, and 2) Attach custom powerplants from `custom_powerplants.csv` to open-source data and use both with `custom_powerplants: true`. There is no option to select only *custom powerplants*. This functionality is very useful. Sometimes you can have an accurate custom powerplants information and you would like to replace retrieved open-source plants with custom data. On the other situations, you might need to use both open-source and custom powerplants. 
Therefore, I propose to extend the functionality to three options: 
1) `false` - no custom power plants are used;
2) `merge` - both open-source and custom powerplants from `custom_powerplants.csv` are merged and used;
3) `replace` - only custom powerplants from `custom_powerplants.csv` are used.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
