### PR TITLE
Fix a KeyError in simplify_links caused by misinterpretation of AC lines

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -26,6 +26,8 @@ PyPSA-Earth 0.2.1
 * Fix hard-coded simplification of lines to 380kV `PR #732 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/732>`__.
   It is now possible to simplify the network to any other voltage level with config option `base_voltage`.
 
+* Fix a KeyError in simplify_links caused by misinterpretation of AC lines as DC ones `PR #740 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/740>`__.  
+
 PyPSA-Earth 0.2.0
 =================
 

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-name: pypsa-earth
+name: pypsa-earth-upd11
 channels:
 - conda-forge
 - bioconda

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -230,6 +230,7 @@ def _load_converters_from_osm(fp_osm_converters, buses):
     # converters = _remove_dangling_branches(converters, buses)
 
     converters["carrier"] = "B2B"
+    converters["dc"] = True
 
     return converters
 

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -250,6 +250,8 @@ def _load_transformers_from_osm(fp_osm_transformers, buses):
 
 def _set_electrical_parameters_lines(config, lines):
     v_noms = config["electricity"]["voltages"]
+    lines["carrier"] = "AC"
+    lines["dc"] = False
     linetypes = config["lines"]["types"]
 
     for v_nom in v_noms:
@@ -263,6 +265,7 @@ def _set_electrical_parameters_lines(config, lines):
 def _set_electrical_parameters_dc_lines(config, lines):
     v_noms = config["electricity"]["voltages"]
     lines["carrier"] = "DC"
+    lines["dc"] = True
 
     lines["type"] = config["lines"]["dc_type"]
 
@@ -280,6 +283,7 @@ def _set_electrical_parameters_links(config, links):
     links["p_min_pu"] = -p_max_pu
 
     links["carrier"] = "DC"
+    links["dc"] = True
 
     return links
 

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -300,7 +300,13 @@ def simplify_links(n, costs, config, output, aggregation_strategies=dict()):
                 while m not in (supernodes | seen):
                     seen.add(m)
                     for m2, ls in G.adj[m].items():
-                        if m2 in seen or m2 == u:
+                        # there may be AC lines which connect ends of DC chains
+                        ls_is_ac = (
+                            n.lines.loc[n.lines.index == list(ls)[0][1]].tag_frequency
+                            != 0
+                        )
+                        # in case ls is a link, all() on empty series gives True
+                        if m2 in seen or m2 == u or ls_is_ac.all():
                             continue
                         buses.append(m2)
                         links.append(list(ls))  # [name for name in ls])

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -283,6 +283,16 @@ def simplify_links(n, costs, config, output, aggregation_strategies=dict()):
 
     G = n.graph()
 
+    # AC lines should not be included into DC part
+    def is_ac(ls):
+        ls_is_ac = n.lines.loc[n.lines.index == list(ls)[0][1]].tag_frequency != 0
+        if ls_is_ac.empty:
+            ac_flag = False
+        else:
+            ac_flag = ls_is_ac.any()
+        return ac_flag
+
+    # Split DC part by supernodes
     def split_links(nodes):
         nodes = frozenset(nodes)
 
@@ -291,7 +301,11 @@ def simplify_links(n, costs, config, output, aggregation_strategies=dict()):
 
         for u in supernodes:
             for m, ls in G.adj[u].items():
-                if m not in nodes or m in seen:
+                # AC lines can be captured in case of complicated network topologies
+                # even despite using `nodes` defined by links
+                # if is_ac(ls):
+                #    continue
+                if m not in nodes or m in seen or is_ac(ls):
                     continue
 
                 buses = [u, m]
@@ -299,17 +313,12 @@ def simplify_links(n, costs, config, output, aggregation_strategies=dict()):
 
                 while m not in (supernodes | seen):
                     seen.add(m)
-                    for m2, ls in G.adj[m].items():
+                    for m2, ls2 in G.adj[m].items():
                         # there may be AC lines which connect ends of DC chains
-                        ls_is_ac = (
-                            n.lines.loc[n.lines.index == list(ls)[0][1]].tag_frequency
-                            != 0
-                        )
-                        # in case ls is a link, all() on empty series gives True
-                        if m2 in seen or m2 == u or ls_is_ac.all():
+                        if m2 in seen or m2 == u or is_ac(ls2):
                             continue
                         buses.append(m2)
-                        links.append(list(ls))  # [name for name in ls])
+                        links.append(list(ls2))  # [name for name in ls])
                         break
                     else:
                         # stub

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -265,7 +265,7 @@ def _aggregate_and_move_components(
 
 # Filter AC lines to avoid mixing with DC part when processing links
 def contains_ac(ls):
-    def capture_ac(x):
+    def is_ac_branch(x):
         if x[0] == "Link":
             return n.links.loc[x[1]].dc != True
         elif x[0] == "Line":
@@ -273,7 +273,7 @@ def contains_ac(ls):
         else:
             logger.error("Unknown branch type for the instance {x}")
 
-    return any(list(map(lambda x: capture_ac(x), ls)))
+    return any(list(map(lambda x: is_ac_branch(x), ls)))
 
 
 def simplify_links(n, costs, config, output, aggregation_strategies=dict()):


### PR DESCRIPTION
Closes #586 (and most likely #703, as well)

## Changes proposed in this Pull Request

It appears that the current implementation of `simplify_network` has troubles in processing a following type on network topologies:

<img width="408" alt="key_error_scheme" src="https://github.com/pypsa-meets-earth/pypsa-earth/assets/30229437/d63ac8b9-52ee-433f-ae47-2624c7961227">

blue = AC lines, red = DC links

A chain of links `A-A_dc-B_dc-B` is treated in `simplify_links()` by building an adjacency matrix for a graph defined by A, A_dc, B_dc and B nodes. It is assumed that such a subgraph definition contains only DC elements which makes it possible to focus on geometrical transformations only when making further transformations.

It is possible however that sometimes we also capture `A-B` edge, when taking this set of points. As `A-B` is an AC line, treating it as DC one, leads to an error.

In particular, this line returns a node and an edge for each graph edge starting in a DC "supernode" (a node which is a part of more than two buses, `A` in the example above):

https://github.com/pypsa-meets-earth/pypsa-earth/blob/7b005623096f8be2434a766107bce9e1432c7b8a/scripts/simplify_network.py#L293

Nothings prevents an algorithm from taking `A-B` edge and appending it to the list of links:

https://github.com/pypsa-meets-earth/pypsa-earth/blob/7b005623096f8be2434a766107bce9e1432c7b8a/scripts/simplify_network.py#L306

Further, an attempt to read a line length for `A-B` from `n.lines` results in a KeyError:

https://github.com/pypsa-meets-earth/pypsa-earth/blob/7b005623096f8be2434a766107bce9e1432c7b8a/scripts/simplify_network.py#L342

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine:
    * [x] Philippines
    * [x] Congo Democratic Republic
    * [x] Japan
    * [x] China
    * [x] India
    * [x] Nigeria
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [x] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
