### PR TITLE
Add custom renewables

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -13,6 +13,8 @@ Please add descriptive release notes like in `PyPSA-Eur <https://github.com/PyPS
 E.g. if a new rule becomes available describe how to use it `snakemake -j1 run_tests` and in one sentence what it does.
 
 * Add merge and replace functionalities when adding custom powerplants `PR #739 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/739>`__. "Merge" combined the powerplantmatching data with new custom data. "Replace" allows to use fully self-collected data.
+  
+* Add functionality of attaching existing renewable caapcities from custom_powerplants.csv `PR #742 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/742>`__. If custom_powerplants are enabled and electricity:estimate_renewable_capacities:stats are set to False, then p_nom and p_nom_min for renewables are extracted from custom_powerplants.csv.
 
 PyPSA-Earth 0.2.1
 =================

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -93,9 +93,9 @@ import powerplantmatching as pm
 import pypsa
 import xarray as xr
 from _helpers import configure_logging, getContinent, update_p_nom_max
+from powerplantmatching.export import map_country_bus
 from shapely.validation import make_valid
 from vresutils import transfer as vtransfer
-from powerplantmatching.export import map_country_bus
 
 idx = pd.IndexSlice
 
@@ -630,8 +630,9 @@ def attach_custom_renewables(n, tech_map, ppl):
     df = ppl
     technology_b = ~df.technology.isin(["Onshore", "Offshore"])
     df["Fueltype"] = df.carrier.where(technology_b, df.technology).replace(
-        {"solar": "PV"})
-    df.rename(columns={"country":"Country"}, inplace=True)
+        {"solar": "PV"}
+    )
+    df.rename(columns={"country": "Country"}, inplace=True)
     df = df.query("Fueltype in @tech_map").powerplant.convert_country_to_alpha2()
 
     for fueltype, carriers in tech_map.items():
@@ -821,10 +822,14 @@ if __name__ == "__main__":
 
     estimate_renewable_capacities_irena(n, snakemake.config)
 
-    if snakemake.config["electricity"]["custom_powerplants"] and \
-        snakemake.config["electricity"]["estimate_renewable_capacities"]["stats"] !='irena':
+    if (
+        snakemake.config["electricity"]["custom_powerplants"]
+        and snakemake.config["electricity"]["estimate_renewable_capacities"]["stats"]
+        != "irena"
+    ):
         tech_map = snakemake.config["electricity"]["estimate_renewable_capacities"][
-                    "technology_mapping"]
+            "technology_mapping"
+        ]
         attach_custom_renewables(n, tech_map, ppl)
 
     update_p_nom_max(n)


### PR DESCRIPTION
## Changes proposed in this Pull Request
Here, I propose a function `attach_custom_renewables` function similar to `attach_OPSD_renewables` function of PyPSA-Eur. With this functionality, it would be possible to set capacities for renewables from `custom_powerplants.csv`. Currently, the only possible option to set the renewable capacities is using `estimate_renewable_capacities_irena`. However, even if you know exact capacities of existing wind and solar powerplants, currently you cannot set them as p_nom. With the proposed PR, it will automatically calculate the aggregated p_nom for each bus and set them accordingly.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
