### PR TITLE
Attach res

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -14,6 +14,8 @@ E.g. if a new rule becomes available describe how to use it `snakemake -j1 run_t
 
 * Add merge and replace functionalities when adding custom powerplants `PR #739 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/739>`__. "Merge" combined the powerplantmatching data with new custom data. "Replace" allows to use fully self-collected data.
 
+* Add functionality of attaching existing renewable caapcities from custom_powerplants.csv. `PR #744 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/744>`__. If custom_powerplants are enabled and custom_powerplants.csv contains wind or solar powerplants, then p_nom and p_nom_min for renewables are extracted from custom_powerplants.csv, aggregated for eacg bus, and set.
+
 PyPSA-Earth 0.2.1
 =================
 

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -352,7 +352,7 @@ def attach_wind_and_solar(
         buses = n.buses.loc[gens.bus.unique()]
         gens_per_bus = gens.groupby("bus").p_nom.count()
 
-        if not gens.empty:
+        if not gens.empty and not df.query("carrier == @tech").empty:
             caps = map_country_bus(df.query("carrier == @tech"), buses)
             caps = caps.groupby(["bus"]).p_nom.sum()
             caps = caps / gens_per_bus.reindex(caps.index, fill_value=1)

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -306,9 +306,9 @@ def attach_wind_and_solar(
         if tech == "hydro":
             continue
 
-        if tech == "offwind-ac": 
+        if tech == "offwind-ac":
             # add all offwind wind power plants by default as offwind-ac
-            df.carrier.mask(df.technology=="Offshore", "offwind-ac",inplace=True)
+            df.carrier.mask(df.technology == "Offshore", "offwind-ac", inplace=True)
 
         df.carrier.mask(df.technology == "Onshore", "onwind", inplace=True)
 
@@ -337,14 +337,14 @@ def attach_wind_and_solar(
                 #     format(connection_cost.min(), connection_cost.max(), tech))
             else:
                 capital_cost = costs.at[tech, "capital_cost"]
-            
+
             if not df.query("carrier == @tech").empty:
                 buses = n.buses.loc[ds.indexes["bus"]]
                 caps = map_country_bus(df.query("carrier == @tech"), buses)
                 caps = caps.groupby(["bus"]).p_nom.sum()
-                caps = pd.Series(data = caps, index = ds.indexes["bus"]).fillna(0)
+                caps = pd.Series(data=caps, index=ds.indexes["bus"]).fillna(0)
             else:
-                caps = pd.Series(index = ds.indexes["bus"]).fillna(0)
+                caps = pd.Series(index=ds.indexes["bus"]).fillna(0)
 
             n.madd(
                 "Generator",

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -361,9 +361,6 @@ def attach_wind_and_solar(
             n.generators.p_nom_min.update(gens.bus.map(caps).dropna())
 
 
-        print(tech)
-
-
 def attach_conventional_generators(
     n,
     costs,

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -95,6 +95,7 @@ import xarray as xr
 from _helpers import configure_logging, getContinent, update_p_nom_max
 from shapely.validation import make_valid
 from vresutils import transfer as vtransfer
+from powerplantmatching.export import map_country_bus
 
 idx = pd.IndexSlice
 
@@ -288,10 +289,13 @@ def update_transmission_costs(n, costs, length_factor=1.0, simple_hvdc_costs=Fal
 
 
 def attach_wind_and_solar(
-    n, costs, input_profiles, technologies, extendable_carriers, line_length_factor=1
+    n, costs, ppl, input_profiles, technologies, extendable_carriers, line_length_factor=1
 ):
     # TODO: rename tech -> carrier, technologies -> carriers
     _add_missing_carriers_from_costs(n, costs, technologies)
+
+    df = ppl.copy()
+    df.rename(columns={"country":"Country"}, inplace=True)
 
     for tech in technologies:
         if tech == "hydro":
@@ -337,6 +341,27 @@ def attach_wind_and_solar(
                 efficiency=costs.at[suptech, "efficiency"],
                 p_max_pu=ds["profile"].transpose("time", "bus").to_pandas(),
             )
+        
+        if suptech == "offwind":
+            continue
+            # df.carrier.mask(df.technology=="Offshore", "offwind-ac",inplace=True)
+
+        df.carrier.mask(df.technology=="Onshore", "onwind",inplace=True)
+
+        gens = n.generators[lambda df: df.carrier == tech]
+        buses = n.buses.loc[gens.bus.unique()]
+        gens_per_bus = gens.groupby("bus").p_nom.count()
+
+        if not gens.empty:
+            caps = map_country_bus(df.query("carrier == @tech"), buses)
+            caps = caps.groupby(["bus"]).p_nom.sum()
+            caps = caps / gens_per_bus.reindex(caps.index, fill_value=1)
+
+            n.generators.p_nom.update(gens.bus.map(caps).dropna())
+            n.generators.p_nom_min.update(gens.bus.map(caps).dropna())
+
+
+        print(tech)
 
 
 def attach_conventional_generators(
@@ -786,6 +811,7 @@ if __name__ == "__main__":
     attach_wind_and_solar(
         n,
         costs,
+        ppl,
         snakemake.input,
         renewable_carriers,
         extendable_carriers,

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -352,15 +352,15 @@ def attach_wind_and_solar(
                 " " + tech,
                 bus=ds.indexes["bus"],
                 carrier=tech,
+                p_nom=caps,
                 p_nom_extendable=tech in extendable_carriers["Generator"],
+                p_nom_min=caps,
                 p_nom_max=ds["p_nom_max"].to_pandas(),
+                p_max_pu=ds["profile"].transpose("time", "bus").to_pandas(),
                 weight=ds["weight"].to_pandas(),
                 marginal_cost=costs.at[suptech, "marginal_cost"],
                 capital_cost=capital_cost,
                 efficiency=costs.at[suptech, "efficiency"],
-                p_max_pu=ds["profile"].transpose("time", "bus").to_pandas(),
-                p_nom=caps,
-                p_nom_min=caps,
             )
 
 

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -93,9 +93,9 @@ import powerplantmatching as pm
 import pypsa
 import xarray as xr
 from _helpers import configure_logging, getContinent, update_p_nom_max
+from powerplantmatching.export import map_country_bus
 from shapely.validation import make_valid
 from vresutils import transfer as vtransfer
-from powerplantmatching.export import map_country_bus
 
 idx = pd.IndexSlice
 
@@ -289,13 +289,19 @@ def update_transmission_costs(n, costs, length_factor=1.0, simple_hvdc_costs=Fal
 
 
 def attach_wind_and_solar(
-    n, costs, ppl, input_profiles, technologies, extendable_carriers, line_length_factor=1
+    n,
+    costs,
+    ppl,
+    input_profiles,
+    technologies,
+    extendable_carriers,
+    line_length_factor=1,
 ):
     # TODO: rename tech -> carrier, technologies -> carriers
     _add_missing_carriers_from_costs(n, costs, technologies)
 
     df = ppl.copy()
-    df.rename(columns={"country":"Country"}, inplace=True)
+    df.rename(columns={"country": "Country"}, inplace=True)
 
     for tech in technologies:
         if tech == "hydro":
@@ -341,12 +347,12 @@ def attach_wind_and_solar(
                 efficiency=costs.at[suptech, "efficiency"],
                 p_max_pu=ds["profile"].transpose("time", "bus").to_pandas(),
             )
-        
+
         if suptech == "offwind":
             continue
             # df.carrier.mask(df.technology=="Offshore", "offwind-ac",inplace=True)
 
-        df.carrier.mask(df.technology=="Onshore", "onwind",inplace=True)
+        df.carrier.mask(df.technology == "Onshore", "onwind", inplace=True)
 
         gens = n.generators[lambda df: df.carrier == tech]
         buses = n.buses.loc[gens.bus.unique()]


### PR DESCRIPTION
## Changes proposed in this Pull Request
Here, I propose a modification to `attach_wind_and_solar` function in `add_electricity.py`. With this modification, it would be possible to set capacities for renewables from `custom_powerplants.csv`. Currently, the only possible option to set the renewable capacities is using `estimate_renewable_capacities_irena`. However, even if you know exact capacities of existing wind and solar powerplants, currently you cannot set them as `p_nom`. With the proposed PR, it will automatically calculate the aggregated `p_nom` for each bus from `custom_powerplants.csv` and set them accordingly.

## Checklist

- [ ] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
