### PR TITLE
fix build_powerplants FuelType

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -12,6 +12,8 @@ Upcoming release
 Please add descriptive release notes like in `PyPSA-Eur <https://github.com/PyPSA/pypsa-eur/blob/master/doc/release_notes.rst>`__.
 E.g. if a new rule becomes available describe how to use it `snakemake -j1 run_tests` and in one sentence what it does.
 
+* Fix Natural Gas assignment bug in build_powerplants rule `PR #754 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/754>`__.
+
 * Add GEM datasets to the powerplantmatching config `PR #750 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/750>`__. 
 
 * Add merge and replace functionalities when adding custom powerplants `PR #739 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/739>`__. "Merge" combined the powerplantmatching data with new custom data. "Replace" allows to use fully self-collected data.

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -256,12 +256,12 @@ def add_custom_powerplants(ppl, inputs, config):
 def replace_natural_gas_technology(df):
     mapping = {"Steam Turbine": "CCGT", "Combustion Engine": "OCGT"}
     tech = df.Technology.replace(mapping).fillna("CCGT")
-    return df.Technology.where(df.Fueltype != "Natural Gas", tech)
+    return df.Technology.mask(df.Fueltype == "Natural Gas", tech)
 
 
 def replace_natural_gas_fueltype(df):
-    return df.Fueltype.where(
-        (df.Technology != "OCGT") | (df.Technology != "CCGT"), "Natural Gas"
+    return df.Fueltype.mask(
+        (df.Technology == "OCGT") | (df.Technology == "CCGT"), "Natural Gas"
     )
 
 

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -253,16 +253,6 @@ def add_custom_powerplants(ppl, inputs, config):
         return add_ppls
 
 
-def replace_natural_gas_technology(df):
-    mapping = {"Steam Turbine": "OCGT", "Combustion Engine": "OCGT"}
-    tech = df.Technology.replace(mapping).fillna("OCGT")
-    return df.Technology.where(df.Fueltype != "Natural Gas", tech)
-
-
-def replace_natural_gas_fueltype(df):
-    return df.Fueltype.where(df.Fueltype != "Natural Gas", df.Technology)
-
-
 if __name__ == "__main__":
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
@@ -302,12 +292,7 @@ if __name__ == "__main__":
         pm.powerplants(from_url=False, update=True, config_update=config)
         .powerplant.fill_missing_decommissioning_years()
         .query('Fueltype not in ["Solar", "Wind"] and Country in @countries_names')
-        .replace({"Technology": {"Steam Turbine": "OCGT", "Combustion Engine": "OCGT"}})
         .powerplant.convert_country_to_alpha2()
-        .assign(
-            Technology=replace_natural_gas_technology,
-            Fueltype=replace_natural_gas_fueltype,
-        )
     )
 
     ppl = add_custom_powerplants(

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -253,6 +253,16 @@ def add_custom_powerplants(ppl, inputs, config):
         return add_ppls
 
 
+def replace_natural_gas_technology(df):
+    mapping = {"Steam Turbine": "CCGT", "Combustion Engine": "OCGT"}
+    tech = df.Technology.replace(mapping).fillna("CCGT")
+    return df.Technology.where(df.Fueltype != "Natural Gas", tech)
+
+
+def replace_natural_gas_fueltype(df):
+    return df.Fueltype.where(df.Technology != "OCGT", "Natural Gas")
+
+
 if __name__ == "__main__":
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
@@ -293,6 +303,10 @@ if __name__ == "__main__":
         .powerplant.fill_missing_decommissioning_years()
         .query('Fueltype not in ["Solar", "Wind"] and Country in @countries_names')
         .powerplant.convert_country_to_alpha2()
+        .assign(
+            Technology=replace_natural_gas_technology,
+            Fueltype=replace_natural_gas_fueltype,
+        )
     )
 
     ppl = add_custom_powerplants(

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -260,7 +260,9 @@ def replace_natural_gas_technology(df):
 
 
 def replace_natural_gas_fueltype(df):
-    return df.Fueltype.where(df.Technology != "OCGT", "Natural Gas")
+    return df.Fueltype.where(
+        (df.Technology != "OCGT") | (df.Technology != "CCGT"), "Natural Gas"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request

Removes the Gas transformations in build_powerplants as they don't seem necessary any longer. Tested on Egypt and tutorial countries and works well. 

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
