### PR TITLE
Fix runoff in case runoff data are missed for some hydropower plants

### DIFF
--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -457,7 +457,7 @@ def attach_hydro(n, costs, ppl):
             missing_plants = pd.Index(inflow_buses.unique()).difference(
                 inflow.indexes["plant"]
             )
-            intersection_plants = pd.Index(
+            plants_with_data = pd.Index(
                 inflow_buses[inflow_buses.isin(inflow.indexes["plant"])]
             )
 
@@ -465,9 +465,7 @@ def attach_hydro(n, costs, ppl):
             if not missing_plants.empty:
                 # original total p_nom
                 total_p_nom = ror.p_nom.sum() + hydro.p_nom.sum()
-                idxs_to_keep = inflow_buses[
-                    inflow_buses.isin(intersection_plants)
-                ].index
+                idxs_to_keep = inflow_buses[inflow_buses.isin(plants_with_data)].index
                 ror = ror.loc[ror.index.intersection(idxs_to_keep)]
                 hydro = hydro.loc[hydro.index.intersection(idxs_to_keep)]
                 # loss of p_nom
@@ -480,9 +478,10 @@ def attach_hydro(n, costs, ppl):
             else:
                 idxs_to_keep = inflow_idx
 
-            if not intersection_plants.empty:
+            # if there are any plants for which runoff data are available
+            if not plants_with_data.empty:
                 inflow_t = (
-                    inflow.sel(plant=intersection_plants)
+                    inflow.sel(plant=plants_with_data)
                     .rename({"plant": "name"})
                     .assign_coords(name=idxs_to_keep)
                     .transpose("time", "name")

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -475,14 +475,14 @@ def attach_hydro(n, costs, ppl):
 
                 logger.warning(
                     f"'{snakemake.input.profile_hydro}' is missing inflow time-series for at least one bus: {', '.join(missing_plants)}."
-                    f"Corresponding hydro plants are dropped, corresponding to a total loss of {loss_p_nom}MW out of {total_p_nom}MW."
+                    f"Corresponding hydro plants are dropped, corresponding to a total loss of {loss_p_nom:.2f}MW out of {total_p_nom:.2f}MW."
                 )
 
             if not intersection_plants.empty:
                 inflow_t = (
                     inflow.sel(plant=intersection_plants)
                     .rename({"plant": "name"})
-                    .assign_coords(name=inflow_idx)
+                    .assign_coords(name=idxs_to_keep)
                     .transpose("time", "name")
                     .to_pandas()
                 )

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -470,6 +470,7 @@ def attach_hydro(n, costs, ppl):
                 # update plants_with_data to ensure proper match between "plant" index and bus_id
                 plants_with_data = inflow_buses[inflow_buses.isin(plants_to_keep)]
                 network_buses_to_keep = plants_with_data.index
+                plants_to_keep = plants_with_data.to_numpy()
 
                 ror = ror.loc[ror.index.intersection(network_buses_to_keep)]
                 hydro = hydro.loc[hydro.index.intersection(network_buses_to_keep)]

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -477,6 +477,8 @@ def attach_hydro(n, costs, ppl):
                     f"'{snakemake.input.profile_hydro}' is missing inflow time-series for at least one bus: {', '.join(missing_plants)}."
                     f"Corresponding hydro plants are dropped, corresponding to a total loss of {loss_p_nom:.2f}MW out of {total_p_nom:.2f}MW."
                 )
+            else:
+                idxs_to_keep = inflow_idx
 
             if not intersection_plants.empty:
                 inflow_t = (


### PR DESCRIPTION
PR fixes an issue appeared in a workflow for India with gadm clustering on. The problem is caused by a case when there are hydropower plants on islands, namely Kalpong hydro power plant for India, for which ERA5 can miss the data:

<img width="423" alt="image" src="https://github.com/pypsa-meets-earth/pypsa-earth/assets/30229437/623ac703-e5a9-4072-96ce-942154288ba6">


## Changes proposed in this Pull Request

Hydropower indices are matched with plants names.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [x] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
