### PR TITLE
pin max pypsa version

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -8,7 +8,7 @@ sphinx_book_theme
 sphinxcontrib-bibtex
 myst-parser  # recommark is deprecated, https://stackoverflow.com/a/71660856/13573820
 
-pypsa
+pypsa>=0.21.3, <0.24
 vresutils>=0.3.1
 powerplantmatching>=0.4.8
 atlite>=0.2.2

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -12,7 +12,7 @@ dependencies:
 - pip
 - mamba   # esp for windows build
 
-- pypsa>=0.21.3
+- pypsa>=0.21.3, <0.24
 # - atlite>=0.2.4  # until https://github.com/PyPSA/atlite/issues/244 is not merged
 - dask
 - powerplantmatching>=0.5.7


### PR DESCRIPTION

## Changes proposed in this Pull Request
Pin the max pypsa version because of the [deprecation of the pypsa.networkclustering module ](https://github.com/PyPSA/PyPSA/releases/tag/v0.24.0) in pypsa v0.24
The module is used in [scripts/cluster_network.py]( https://github.com/pypsa-meets-earth/pypsa-earth/blob/186d2d23f6fad955e8a2f253e08c8b129af0e423/scripts/cluster_network.py#L144) and [scripts/simplify_network.py](https://github.com/pypsa-meets-earth/pypsa-earth/blob/main/scripts/simplify_network.py#L100)

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [NA] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [NA] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [NA] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [NA] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
