### PR TITLE
bugfix: Fix admin needs for windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 *.pbf
 *.zip
 *.png
+*.done
 
 # Untracked files
 config.yaml

--- a/Snakefile
+++ b/Snakefile
@@ -701,7 +701,7 @@ if config["monte_carlo"]["options"].get("add_to_snakefile", False) == False:
         resources:
             mem=memory,
         shadow:
-            "shallow"
+            "copy-minimal" if os.name == "nt" else "shallow"
         script:
             "scripts/solve_network.py"
 

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -12,7 +12,7 @@ dependencies:
 - pip
 - mamba   # esp for windows build
 
-- pypsa>=0.23, <0.25
+- pypsa>=0.24, <0.25
 # - atlite>=0.2.4  # until https://github.com/PyPSA/atlite/issues/244 is not merged
 - dask
 - powerplantmatching>=0.5.7


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request

This PR fixes the need for administrative rights on windows.
The issue is related to the handling of shadow folders in snakemake that creats symlinks.
In windows that requires admin rights, yet that can be skipped using raw copy of input files, yet that is slightly more inefficient
