### PR TITLE
Add a check on a match between a cutout and a modelled area

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -22,6 +22,8 @@ E.g. if a new rule becomes available describe how to use it `snakemake -j1 run_t
 
 * Drop code-dependency from vresutil `PR #803 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/803>`__
 
+* Add a check to ensure match between a cutout and a modelled area `PR #805 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/805>`__
+
 PyPSA-Earth 0.2.2
 =================
 

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -222,14 +222,18 @@ def check_cutout_match(cutout, geodf):
     region_box = box(*regions.total_bounds)
 
     assert not region_box.intersection(cutout_box).is_empty, (
-        "The requester region is completely out cutout area.\n\r"
-        "Check please the provided cutout. More details on cutout generation are available in docs:\n\r"
-        "https://pypsa-earth.readthedocs.io/en/latest/tutorial.html#adjust-the-model-configuration \n\r"
+        "The requested region is completely out of the cutout area.\n\r"
+        "Check please the provided cutout.\n\r"
+        "More details on cutout generation are available in docs:\n\r"
+        "https://pypsa-earth.readthedocs.io/en/latest/tutorial.html\n\r"
     )
 
     if not region_box.covered_by(cutout_box):
         logger.warning(
-            "Weather data does not fully cover the requester region. It's recommended to check the provided cutout. More details are provided in https://pypsa-earth.readthedocs.io/en/latest/tutorial.html#adjust-the-model-configuration"
+            "Weather data does not fully cover the requester region.\n\r"
+            "It's recommended to check the provided cutout.\n\r"
+            "More details on cutout generation are available in docs:\n\r"
+            "https://pypsa-earth.readthedocs.io/en/latest/tutorial.html"
         )
 
 

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -508,26 +508,30 @@ if __name__ == "__main__":
     cutout = atlite.Cutout(paths["cutout"])
 
     # TODO Test with alternative clustering
-    low_x_out_cutout = regions.x.min() < cutout.coords["x"].min()
-    up_x_complet_out_cutout = regions.x.max() < cutout.coords["x"].min()
+    x_low_out_cutout = regions.x.min() < cutout.coords["x"].min()
+    x_up_completly_out_cutout = regions.x.max() < cutout.coords["x"].min()
 
-    up_x_out_cutout = regions.x.max() > cutout.coords["x"].max()
-    low_x_complet_out_cutout = regions.x.min() > cutout.coords["x"].max()
+    x_up_out_cutout = regions.x.max() > cutout.coords["x"].max()
+    x_low_completly_out_cutout = regions.x.min() > cutout.coords["x"].max()
 
-    low_y_out_cutout = regions.y.min() < cutout.coords["y"].min()
-    low_y_complet_out_cutout = regions.y.max() < cutout.coords["y"].min()
+    y_low_out_cutout = regions.y.min() < cutout.coords["y"].min()
+    y_up_completly_out_cutout = regions.y.max() < cutout.coords["y"].min()
 
-    up_y_out_cutout = regions.y.max() > cutout.coords["y"].max()
-    up_y_complet_out_cutout = regions.y.min() > cutout.coords["y"].max()
+    y_up_out_cutout = regions.y.max() > cutout.coords["y"].max()
+    y_low_completly_out_cutout = regions.y.min() > cutout.coords["y"].max()
 
-    if (low_x_complet_out_cutout or up_x_complet_out_cutout) or (
-        low_y_complet_out_cutout or up_y_complet_out_cutout
-    ):
-        logger.exception(
-            "The requester region is not covered with the provided weather data. It's recommended to check the provided cutout. More details are provided in https://pypsa-earth.readthedocs.io/en/latest/tutorial.html#adjust-the-model-configuration"
-        )
-        raise Exception("Cutout Error")
-    elif low_x_out_cutout or up_x_out_cutout or low_y_out_cutout or up_y_out_cutout:
+    assert not (
+        x_low_completly_out_cutout
+        or x_up_completly_out_cutout
+        or y_low_completly_out_cutout
+        or y_up_completly_out_cutout
+    ), (
+        "The requester region is not covered with the provided weather data\n\r"
+        "Check please the provided cutout.\n\r"
+        "More details are provided in docs on \n\r"
+        "https://pypsa-earth.readthedocs.io/en/latest/tutorial.html#adjust-the-model-configuration \n\r"
+    )
+    if x_low_out_cutout or x_up_out_cutout or y_low_out_cutout or y_up_out_cutout:
         logger.warning(
             "Weather data does not fully cover the requester region. It's recommended to check the provided cutout. More details are provided in https://pypsa-earth.readthedocs.io/en/latest/tutorial.html#adjust-the-model-configuration"
         )

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -506,6 +506,32 @@ if __name__ == "__main__":
     client = Client(cluster, asynchronous=True)
 
     cutout = atlite.Cutout(paths["cutout"])
+
+    # TODO Test with alternative clustering
+    low_x_out_cutout = regions.x.min() < cutout.coords["x"].min()
+    up_x_complet_out_cutout = regions.x.max() < cutout.coords["x"].min()
+
+    up_x_out_cutout = regions.x.max() > cutout.coords["x"].max()
+    low_x_complet_out_cutout = regions.x.min() > cutout.coords["x"].max()
+
+    low_y_out_cutout = regions.y.min() < cutout.coords["y"].min()
+    low_y_complet_out_cutout = regions.y.max() < cutout.coords["y"].min()
+
+    up_y_out_cutout = regions.y.max() > cutout.coords["y"].max()
+    up_y_complet_out_cutout = regions.y.min() > cutout.coords["y"].max()
+
+    if (low_x_complet_out_cutout or up_x_complet_out_cutout) or (
+        low_y_complet_out_cutout or up_y_complet_out_cutout
+    ):
+        logger.exception(
+            "The requester region is not covered with the provided weather data. It's recommended to check the provided cutout. More details are provided in https://pypsa-earth.readthedocs.io/en/latest/tutorial.html#adjust-the-model-configuration"
+        )
+        raise Exception("Cutout Error")
+    elif low_x_out_cutout or up_x_out_cutout or low_y_out_cutout or up_y_out_cutout:
+        logger.warning(
+            "Weather data does not fully cover the requester region. It's recommended to check the provided cutout. More details are provided in https://pypsa-earth.readthedocs.io/en/latest/tutorial.html#adjust-the-model-configuration"
+        )
+
     if not snakemake.wildcards.technology.startswith("hydro"):
         # the region should be restricted for non-hydro technologies, as the hydro potential is calculated across hydrobasins which may span beyond the region of the country
         cutout = filter_cutout_region(cutout, regions)


### PR DESCRIPTION
# Closes #528 

Currently, an error message is quite obscure if there is a mismatch between a cutout and a modelled region.

A check has been added to ensure that extent of the provided cutout corresponds to the coordinates of the considered region: 

- a warning is issued in case there is only a partial overlap, 
- an exception is raised if the region is completely out of a cutout extent.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
