### PR TITLE
re-write fix_overpassing_lines (800x faster) 🚀

### DIFF
--- a/scripts/build_osm_network.py
+++ b/scripts/build_osm_network.py
@@ -631,12 +631,12 @@ def fix_overpassing_lines(lines, buses, distance_crs, tol=1):
     joined = gpd.sjoin(df_l, buffer_df, how="inner", op="intersects")
 
     # group lines by their ids
-    group_lines = joined.groupby("id")
+    group_lines = joined.groupby("line_id")
 
     # iterate over the groups, TODO: change to apply
     for i, group in group_lines:
-        line_id = group["id"].iloc[0]  # pick the line id that represents the group
-        line_geom = df_l[df_l["id"] == line_id]["geometry"].iloc[0]
+        line_id = i  # pick the line id that represents the group
+        line_geom = df_l[df_l["line_id"] == line_id]["geometry"].iloc[0]
 
         # number of points that intersect with the line
         num_points = len(group)
@@ -666,7 +666,7 @@ def fix_overpassing_lines(lines, buses, distance_crs, tol=1):
         # in that case replace the start point with the point that is intersecting the start point of the line
 
         # replace the line with the split line
-        df_l.loc[df_l["id"] == line_id, "geometry"] = split_line
+        df_l.loc[df_l["line_id"] == line_id, "geometry"] = split_line
 
     # explode the multilinestrings (not recommended, but included for completion)
     # exploding the df should be done at the last step

--- a/scripts/build_osm_network.py
+++ b/scripts/build_osm_network.py
@@ -597,7 +597,13 @@ def create_station_at_equal_bus_locations(
 
 def fix_overpassing_lines(lines, buses, distance_crs, tol=1):
     """
-    Function to snap buses to lines that are within a certain tolerance.
+    Snap buses to lines that are within a certain tolerance.
+    It does this by first buffering the buses by the tolerance distance, 
+    and then performing a spatial join to find all lines that intersect with the buffers. 
+    For each group of lines that intersect with a buffer, the function identifies the points that overpass the line (i.e., are not snapped to the line), 
+    and then snaps those points to the nearest point on the line. 
+    The line is then split at each snapped point, resulting in a new set of lines that are snapped to the buses. 
+    The function returns a GeoDataFrame containing the snapped lines, and the original GeoDataFrame containing the buses.
 
     Parameters
     ----------

--- a/scripts/build_osm_network.py
+++ b/scripts/build_osm_network.py
@@ -618,7 +618,7 @@ def fix_overpassing_lines(lines, buses, distance_crs, tol=1):
 
     df_l = lines.copy()  # can use lines directly without copying
     # drop all columns excpet id and geometry for buses
-    df_p = buses[["id", "geometry"]].copy()
+    df_p = buses.copy()
 
     # change crs to distance based
     df_l = df_l.to_crs(distance_crs)

--- a/scripts/build_osm_network.py
+++ b/scripts/build_osm_network.py
@@ -615,6 +615,8 @@ def fix_overpassing_lines(lines, buses, distance_crs, tol=1):
     lines : GeoDataFrame
         GeoDataFrame containing the lines
     """
+    if lines.empty:
+        return lines, buses
 
     df_l = lines.copy()  # can use lines directly without copying
     # drop all columns except id and geometry for buses
@@ -691,7 +693,9 @@ def fix_overpassing_lines(lines, buses, distance_crs, tol=1):
     df_l = df_l.explode(index_parts=True).reset_index()
 
     # revise line_id to account for part index
-    df_l[line_id_str] = df_l[line_id_str] + "_" + df_l["level_1"].astype(str)
+    df_l[line_id_str] = (
+        df_l[line_id_str].astype(str) + "_" + df_l["level_1"].astype(str)
+    )
     df_l.drop(columns=["level_0", "level_1"], inplace=True)
 
     # update line endings (included for completion, the scope of the function should be limited to fixing overpassing lines)

--- a/scripts/build_osm_network.py
+++ b/scripts/build_osm_network.py
@@ -597,13 +597,15 @@ def create_station_at_equal_bus_locations(
 
 def fix_overpassing_lines(lines, buses, distance_crs, tol=1):
     """
-    Snap buses to lines that are within a certain tolerance.
-    It does this by first buffering the buses by the tolerance distance, 
-    and then performing a spatial join to find all lines that intersect with the buffers. 
-    For each group of lines that intersect with a buffer, the function identifies the points that overpass the line (i.e., are not snapped to the line), 
-    and then snaps those points to the nearest point on the line. 
-    The line is then split at each snapped point, resulting in a new set of lines that are snapped to the buses. 
-    The function returns a GeoDataFrame containing the snapped lines, and the original GeoDataFrame containing the buses.
+    Snap buses to lines that are within a certain tolerance. It does this by
+    first buffering the buses by the tolerance distance, and then performing a
+    spatial join to find all lines that intersect with the buffers. For each
+    group of lines that intersect with a buffer, the function identifies the
+    points that overpass the line (i.e., are not snapped to the line), and then
+    snaps those points to the nearest point on the line. The line is then split
+    at each snapped point, resulting in a new set of lines that are snapped to
+    the buses. The function returns a GeoDataFrame containing the snapped
+    lines, and the original GeoDataFrame containing the buses.
 
     Parameters
     ----------

--- a/scripts/build_osm_network.py
+++ b/scripts/build_osm_network.py
@@ -617,7 +617,7 @@ def fix_overpassing_lines(lines, buses, distance_crs, tol=1):
     """
 
     df_l = lines.copy()  # can use lines directly without copying
-    # drop all columns excpet id and geometry for buses
+    # drop all columns except id and geometry for buses
     df_p = buses.copy()
 
     # change crs to distance based
@@ -641,7 +641,7 @@ def fix_overpassing_lines(lines, buses, distance_crs, tol=1):
         # number of points that intersect with the line
         num_points = len(group)
 
-        # get the indeces of the points that intersect with the line
+        # get the indices of the points that intersect with the line
         points_indexes = group["index_right"].tolist()
 
         # get the geometries of the points that intersect with the line
@@ -668,13 +668,13 @@ def fix_overpassing_lines(lines, buses, distance_crs, tol=1):
         # replace the line with the split line
         df_l.loc[df_l["id"] == line_id, "geometry"] = split_line
 
-    # explode the multilinestrings (not recommended, but inculded for completion)
+    # explode the multilinestrings (not recommended, but included for completion)
     # exploding the df should be done at the last step
     # if an operation requires separate lines, it should be done using df.explode().apply(your_function)
     # which is a lot more memory efficient
     df_l = df_l.explode(index_parts=False)
 
-    # update line endings (inculded for completion, the scope of the function should be limited to fixing overpassing lines)
+    # update line endings (included for completion, the scope of the function should be limited to fixing overpassing lines)
     # commented out due to errors in the bus conversion function
     # df_l = line_endings_to_bus_conversion(df_l)
 

--- a/scripts/build_osm_network.py
+++ b/scripts/build_osm_network.py
@@ -659,10 +659,16 @@ def fix_overpassing_lines(lines, buses, distance_crs, tol=1):
         ]
 
         # reflect the points in the line to create a bisector
-        reflected_points_list = [Point([2 * nearest_point.x - point.x, 2 * nearest_point.y - point.y]) for point, nearest_point in zip(multi_points, nearest_points_list)]
+        reflected_points_list = [
+            Point([2 * nearest_point.x - point.x, 2 * nearest_point.y - point.y])
+            for point, nearest_point in zip(multi_points, nearest_points_list)
+        ]
 
         # create perpendicular lines from the points that intersect with the line to the nearest points on the line
-        perpendicular_lines = [LineString([point, reflected_point]) for point, reflected_point in zip(multi_points, reflected_points_list)]
+        perpendicular_lines = [
+            LineString([point, reflected_point])
+            for point, reflected_point in zip(multi_points, reflected_points_list)
+        ]
 
         # split the line geom with the perpendicular lines using difference
         split_line = line_geom.difference(MultiLineString(perpendicular_lines))


### PR DESCRIPTION
#445 

Basically, the function fix_overpassing_lines now runs at least 800 times faster. For US lines, this would take 5.8 hours but now takes 22 seconds. The fix_overpassing_lines function is responsible for snapping buses that are in close proximity to lines.
Notebook available here: https://github.com/mnm-matin/pypsa-africa/blob/notebook_stash/lines_pr.ipynb

This was possible by leveraging geopandas spatial join. 
In short:
i) We add a small radius (buffer) to each point
ii) Use the spatial join to find lines that would interect the point
iii) Then group by the lines to find which points would intersect with each line
iv) the rest is about splitting those lines into MultiLineString by drawing perpendiculars from the point to the line
v) Exploding the dataframe using .explode() to convert MultiLineString into separate LineStrings

Notes:
- Some architectural changes are required, such as the following
- It is good practices to explode the dataframe at the very last steps of pre-processing. 
- Line endings should be converted to buses outside of this function
- Buses should not be returned as they are not changed

Small Caveat: Currently, each line in the MultiLineString ends at the perpendicular intersection point. This should be replaced with the actual point, except if a point intersects the starting point of the line. Not a difficult thing to do, but should have little impact on the actual network. The impact of this entire function on the US network is also questionable and should be investigated further.

Notebook for development:
https://github.com/mnm-matin/pypsa-africa/blob/notebook_stash/lines_pr.ipynb
