### PR TITLE
revise set_lines_ids with cKDTree

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -22,6 +22,8 @@ E.g. if a new rule becomes available describe how to use it `snakemake -j1 run_t
 
 * Drop code-dependency from vresutil `PR #803 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/803>`__
 
+* Revise set_lines_ids with cKDTree by scipy `PR #806 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/806>`__
+
 PyPSA-Earth 0.2.2
 =================
 

--- a/scripts/build_osm_network.py
+++ b/scripts/build_osm_network.py
@@ -110,7 +110,7 @@ def set_substations_ids(buses, distance_crs, tol=2000):
                 buses.loc[buses.index[close_nodes], "station_id"] = sub_id
 
 
-def set_lines_ids(lines, buses, distance_crs):
+def set_lines_ids(lines, buses):
     """
     Function to set line buses ids to the closest bus in the list.
     """
@@ -120,11 +120,8 @@ def set_lines_ids(lines, buses, distance_crs):
     lines["bus0"] = -1
     lines["bus1"] = -1
 
-    busesepsg = buses.to_crs(distance_crs)
-    linesepsg = lines.to_crs(distance_crs)
-
-    for key, lines_sel in linesepsg.groupby(["voltage", "dc"]):
-        buses_sel = busesepsg.query(f"voltage == {key[0]} and dc == {key[1]}")
+    for key, lines_sel in lines.groupby(["voltage", "dc"]):
+        buses_sel = buses.query(f"voltage == {key[0]} and dc == {key[1]}")
 
         # find the closest node of the bus0 of the line
         bus0_points = np.array(
@@ -530,7 +527,7 @@ def merge_stations_lines_by_station_id_and_voltage(
     logger.info("Stage 3c/4: Specify the bus ids of the line endings")
 
     # set the bus ids to the line dataset
-    lines, buses = set_lines_ids(lines, buses, distance_crs)
+    lines, buses = set_lines_ids(lines, buses)
 
     # drop lines starting and ending in the same node
     lines.drop(lines[lines["bus0"] == lines["bus1"]].index, inplace=True)
@@ -577,7 +574,7 @@ def create_station_at_equal_bus_locations(
     set_substations_ids(buses, distance_crs, tol=tol)
 
     # set the bus ids to the line dataset
-    lines, buses = set_lines_ids(lines, buses, distance_crs)
+    lines, buses = set_lines_ids(lines, buses)
 
     # update line endings
     lines = line_endings_to_bus_conversion(lines)


### PR DESCRIPTION
# Closes #806

## Changes proposed in this Pull Request
This PR revise the implementation of set_lines_ids with cKDTree.
Performance speed increases by a factor 10 in the Nigeria case (0.12s vs 1.2s in the standard implementation).
For US, 26s are required vs about 12min in the previous formulation.
Performance speed is expected to be significant with the problem size.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [x] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
