### PR TITLE
Add a quick fix for underwater_fraction calculations

### DIFF
--- a/scripts/augmented_line_connections.py
+++ b/scripts/augmented_line_connections.py
@@ -169,8 +169,10 @@ if __name__ == "__main__":
             lifetime=costs.at["HVAC overhead", "lifetime"],
         )
 
-        _set_dc_underwater_fraction(n.links, snakemake.input.regions_offshore)
-        _set_dc_underwater_fraction(n.lines, snakemake.input.regions_offshore)
+        # TODO There is a need to add calculations of `underwater_fraction`
+        # considering only lines added during augmentation
+        # _set_dc_underwater_fraction(n.links, snakemake.input.regions_offshore)
+        # _set_dc_underwater_fraction(n.lines, snakemake.input.regions_offshore)
 
     n.meta = dict(snakemake.config, **dict(wildcards=dict(snakemake.wildcards)))
     n.export_to_netcdf(snakemake.output.network)


### PR DESCRIPTION
# Closes #765 

Remove re-calculation of underwater_fraction after augmentation to fix problems which can arise for networks with HVDC lines due to empty `n.links.geometry` after simplification.

Augmentation of networks with HVDC part should be anyway improved which may be tracked in #765. 

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
