### PR TITLE
Bugfix for load clustering

### DIFF
--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -251,6 +251,7 @@ def distribute_clusters(
             n.loads_t.p_set.mean()
             .groupby(n.loads.bus)
             .sum()
+            .reindex(n.buses.index, fill_value=0.0)
             .groupby([n.buses.country, n.buses.sub_network])
             .sum()
             .pipe(normed)
@@ -648,7 +649,7 @@ if __name__ == "__main__":
 
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
         snakemake = mock_snakemake(
-            "cluster_network", network="elec", simpl="", clusters="10"
+            "cluster_network", network="elec", simpl="", clusters="110"
         )
         sets_path_to_root("pypsa-earth")
     configure_logging(snakemake)


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request
Running PyPSA-Earth on the coutries of PyPSA-Eur lead to an error due to a missing combination of ("BE", 70) [country and subnetwork] during the clustering by load process (the default).
This PR fixes this issue.
No release_note needed

## Checklist

- [ ] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
