### PR TITLE
Add a cutout for Asia

### DIFF
--- a/configs/bundle_config.yaml
+++ b/configs/bundle_config.yaml
@@ -311,6 +311,19 @@ databundles:
     disable_by_opt:
       build_cutout: [all]
 
+  # cutouts bundle of the cutouts folder for the Asian continent, except Russia
+  # Size about 30GB (zipped)
+  bundle_cutouts_asia:
+    countries: ["KVR", "WAS", "FEAR", "SEAR", "CASR", "SASR", "ASEAN", "MEAR"]
+    category: cutouts
+    destination: "cutouts"
+    urls:
+      # zenodo:
+      gdrive: https://drive.google.com/file/d/11-Ax9tVks7oPjrZwG5v3C0x4OmMT_Pv8/view?usp=sharing
+    output: [cutouts/cutout-2013-era5.nc]
+    disable_by_opt:
+      build_cutout: [all]
+
   # # cutouts bundle of the cutouts folder for the entire globe [long +-180, lat +-89.9]
   # # commented by default to avoid downloading by mistake. Size about 170GB (zipped)
   # bundle_cutouts_earth:

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -30,6 +30,8 @@ E.g. if a new rule becomes available describe how to use it `snakemake -j1 run_t
 
 * Bug fixing to restore Africa execution and improve performances `PR #817 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/817>`__
 
+* Add Asian cutout `PR #826 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/826>`__
+
 PyPSA-Earth 0.2.2
 =================
 


### PR DESCRIPTION
This PR partially addresses #795

A cutout for Asia is added, Russia has not been to keep a cutout size moderate.


## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
