### PR TITLE
Keep cutout in case it still exists

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -289,7 +289,11 @@ rule build_bus_regions:
         "scripts/build_bus_regions.py"
 
 
-def check_and_keep_cutout(config=config):
+def terminate_if_cutout_exists(config=config):
+    """
+    Check if any of the requested cutout files exist.
+    If that's the case, terminate execution to avoid data loss.
+    """
     config_cutouts = [
         d_value["cutout"] for tc, d_value in config["renewable"].items()
     ] + list(config["atlite"]["cutouts"].keys())
@@ -305,7 +309,7 @@ def check_and_keep_cutout(config=config):
 
 
 if config["enable"].get("build_cutout", False):
-    check_and_keep_cutout(config)
+    terminate_if_cutout_exists(config)
 
     rule build_cutout:
         input:

--- a/Snakefile
+++ b/Snakefile
@@ -289,12 +289,11 @@ rule build_bus_regions:
         "scripts/build_bus_regions.py"
 
 
-res_tech_names = list(config["renewable"].keys())
-config_cutouts = [
-    (lambda x: config["renewable"][x]["cutout"])(x) for x in res_tech_names
-] + list(config["atlite"]["cutouts"].keys())
+def check_and_keep_cutout(config=config):
+    config_cutouts = [
+        d_value["cutout"] for tc, d_value in config["renewable"].items()
+    ] + list(config["atlite"]["cutouts"].keys())
 
-if config["enable"].get("build_cutout", False):
     for ct in set(config_cutouts):
         cutout_fl = "cutouts/" + CDIR + ct + ".nc"
         if os.path.exists(cutout_fl):
@@ -303,6 +302,10 @@ if config["enable"].get("build_cutout", False):
                 + cutout_fl
                 + "' still exists and risks to be overwritten. If this is an intended behavior, please move or delete this file and re-run the rule. Otherwise, just disable the `build_cutout` rule in the config file."
             )
+
+
+if config["enable"].get("build_cutout", False):
+    check_and_keep_cutout(config)
 
     rule build_cutout:
         input:

--- a/Snakefile
+++ b/Snakefile
@@ -299,9 +299,9 @@ if config["enable"].get("build_cutout", False):
         cutout_fl = "cutouts/" + CDIR + ct + ".nc"
         if os.path.exists(cutout_fl):
             raise Exception(
-                "A cutout file '"
+                "An option `build_cutout` is enabled, while a cutout file '"
                 + cutout_fl
-                + "' still exists. Stopping to avoid over-writing it"
+                + "' still exists and risks to be overwritten. If this is an intended behavior, please move or delete this file and re-run the rule. Otherwise, just disable the `build_cutout` rule in the config file."
             )
 
     rule build_cutout:

--- a/Snakefile
+++ b/Snakefile
@@ -290,6 +290,24 @@ rule build_bus_regions:
 
 
 if config["enable"].get("build_cutout", False):
+    for technology in cutouts_in_config:
+        cutout_fl = (
+            "cutouts/" + CDIR + config["renewable"][technology]["cutout"] + ".nc"
+        )
+        if os.path.exists(cutout_fl):
+            raise Exception(
+                "A cutout file '"
+                + cutout_fl
+                + "' still exists. Stopping to avoid over-writing it"
+            )
+
+    cutout_fl = "cutouts/" + CDIR + list(config["atlite"]["cutouts"].keys())[0] + ".nc"
+    if os.path.exists(cutout_fl):
+        raise Exception(
+            "A cutout file '"
+            + cutout_fl
+            + "' still exists. Stopping to avoid over-writing it"
+        )
 
     rule build_cutout:
         input:

--- a/Snakefile
+++ b/Snakefile
@@ -289,25 +289,20 @@ rule build_bus_regions:
         "scripts/build_bus_regions.py"
 
 
+res_tech_names = list(config["renewable"].keys())
+config_cutouts = [
+    (lambda x: config["renewable"][x]["cutout"])(x) for x in res_tech_names
+] + list(config["atlite"]["cutouts"].keys())
+
 if config["enable"].get("build_cutout", False):
-    for technology in cutouts_in_config:
-        cutout_fl = (
-            "cutouts/" + CDIR + config["renewable"][technology]["cutout"] + ".nc"
-        )
+    for ct in set(config_cutouts):
+        cutout_fl = "cutouts/" + CDIR + ct + ".nc"
         if os.path.exists(cutout_fl):
             raise Exception(
                 "A cutout file '"
                 + cutout_fl
                 + "' still exists. Stopping to avoid over-writing it"
             )
-
-    cutout_fl = "cutouts/" + CDIR + list(config["atlite"]["cutouts"].keys())[0] + ".nc"
-    if os.path.exists(cutout_fl):
-        raise Exception(
-            "A cutout file '"
-            + cutout_fl
-            + "' still exists. Stopping to avoid over-writing it"
-        )
 
     rule build_cutout:
         input:


### PR DESCRIPTION
The PR aims to avoid accidental over-writing cutout. In case a requested cutout exists, execution is stopped and error thrown.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
