### PR TITLE
Fix databundle earth

### DIFF
--- a/configs/bundle_config.yaml
+++ b/configs/bundle_config.yaml
@@ -147,6 +147,11 @@ databundles:
     - data/gebco/GEBCO_2021_TID.nc
     - data/copernicus/PROBAV_LC100_global_v3.0.1_2019-nrt_Discrete-Classification-map_EPSG-4326.tif
     - data/ssp2-2.6/2030/era5_2013/Africa.nc
+    - data/ssp2-2.6/2030/era5_2013/Asia.nc
+    - data/ssp2-2.6/2030/era5_2013/Europe.nc
+    - data/ssp2-2.6/2030/era5_2013/NorthAmerica.nc
+    - data/ssp2-2.6/2030/era5_2013/SouthAmerica.nc
+    - data/ssp2-2.6/2030/era5_2013/Oceania.nc
 
   # resources bundle containing the resources folder for Africa only
   bundle_natura_earth:

--- a/configs/bundle_config.yaml
+++ b/configs/bundle_config.yaml
@@ -152,6 +152,9 @@ databundles:
     - data/ssp2-2.6/2030/era5_2013/NorthAmerica.nc
     - data/ssp2-2.6/2030/era5_2013/SouthAmerica.nc
     - data/ssp2-2.6/2030/era5_2013/Oceania.nc
+    - data/hydrobasins/hybas_world_lev04_v1c.shp
+    - data/hydrobasins/hybas_world_lev05_v1c.shp
+    - data/hydrobasins/hybas_world_lev06_v1c.shp
 
   # resources bundle containing the resources folder for Africa only
   bundle_natura_earth:


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request
This PR fixes an issue that prevents snakemake to track non-African demand inputs in the default data configuration

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
