### PR TITLE
fix: :bug: Fix IDs of 9 countries, using the smallest geometry that contains them

### DIFF
--- a/configs/osm_config.yaml
+++ b/configs/osm_config.yaml
@@ -367,3 +367,12 @@ iso_to_geofk_dict:
   VC: "central-america"  # Saint Vincent e Grenadine
   KN: "central-america"  # Saint Kitts e Nevis
   GD: "central-america"  # Grenada
+  AW: "central-america",  # Aruba
+  AX: "finland",  # Aland
+  BM: "north-america",  # Bermuda
+  CW: "central-america",  # Curaçao
+  KY: "central-america",  # Cayman Islands
+  HK: "china",  # Hong Kong
+  MO: "china",  # Macau
+  SX: "central-america",  # Sint Maarten
+  TC: "central-america",  # Turks and Caicos Islands

--- a/configs/osm_config.yaml
+++ b/configs/osm_config.yaml
@@ -367,12 +367,12 @@ iso_to_geofk_dict:
   VC: "central-america"  # Saint Vincent e Grenadine
   KN: "central-america"  # Saint Kitts e Nevis
   GD: "central-america"  # Grenada
-  AW: "central-america",  # Aruba
-  AX: "finland",  # Aland
-  BM: "north-america",  # Bermuda
-  CW: "central-america",  # Curaçao
-  KY: "central-america",  # Cayman Islands
-  HK: "china",  # Hong Kong
-  MO: "china",  # Macau
-  SX: "central-america",  # Sint Maarten
-  TC: "central-america",  # Turks and Caicos Islands
+  AW: "central-america"  # Aruba
+  AX: "finland"  # Aland
+  BM: "north-america"  # Bermuda
+  CW: "central-america"  # Curaçao
+  KY: "central-america"  # Cayman Islands
+  HK: "china"  # Hong Kong
+  MO: "china"  # Macau
+  SX: "central-america"  # Sint Maarten
+  TC: "central-america"  # Turks and Caicos Islands


### PR DESCRIPTION
## Changes proposed in this Pull Request

Maps 9 countries' ISO Alpha 2 codes to working IDs. These countries would fail otherwise. The new IDs were chosen via a `geopandas` `contains` operation, selecting the smallest geometry from `get_geom_sitemap` that fully contains the country.

e.g.
```python
# load PyPSA Earth's GeoDataFrame
eo_gdf = get_geom_sitemap()
# find the smallest geometry that contains a country
country = failed_countries[0]
country_aws_gdf = naturalearth_gdf.loc[naturalearth_gdf[COUNTRY_ID_COLUMN] == country]
matches_gdf = eo_gdf.loc[eo_gdf.contains(country_aws_gdf.iloc[0].geometry)]
matches_gdf["area"] = matches_gdf.area
matches_gdf.sort_values(by="area", ascending=True, inplace=True)
matches_gdf
```

## Checklist

- [X] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [X] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.