### PR TITLE
Fix for earth-osm V0.2.0

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -23,6 +23,8 @@ E.g. if a new rule becomes available describe how to use it `snakemake -j1 run_t
 
 * Minor bug-fixing for GADM_ID format naming. `PR #980 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/980>`__
 
+* Fix download_osm_data compatibility for earth-osm v2.1. `PR #954 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/954>`__
+
 PyPSA-Earth 0.3.0
 =================
 

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -16,7 +16,7 @@ dependencies:
 # - atlite>=0.2.4  # until https://github.com/PyPSA/atlite/issues/244 is not merged
 - dask
 - powerplantmatching>=0.5.7
-- earth-osm
+- earth-osm>=2.1
 - atlite
 
   # Dependencies of the workflow itself

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -16,7 +16,7 @@ dependencies:
 # - atlite>=0.2.4  # until https://github.com/PyPSA/atlite/issues/244 is not merged
 - dask
 - powerplantmatching>=0.5.7
-- earth-osm>=0.1.0, <0.2.0
+- earth-osm
 - atlite
 
   # Dependencies of the workflow itself

--- a/scripts/clean_osm_data.py
+++ b/scripts/clean_osm_data.py
@@ -48,6 +48,9 @@ def prepare_substation_df(df_all_substations):
         }
     )
 
+    # Convert polygons to points
+    df_all_substations["geometry"] = df_all_substations["geometry"].centroid
+
     # Add longitude (lon) and latitude (lat) coordinates in the dataset
     df_all_substations["lon"] = df_all_substations["geometry"].x
     df_all_substations["lat"] = df_all_substations["geometry"].y

--- a/scripts/download_osm_data.py
+++ b/scripts/download_osm_data.py
@@ -126,7 +126,7 @@ if __name__ == "__main__":
     # If the file is empty, it is not created
     # This is a workaround to create empty files for the workflow
 
-    # Rename and move osm files to the resources folder
+    # Rename and move osm files to the resources folder output
     for file in new_files:
         for name in names:
             for f in format:

--- a/scripts/download_osm_data.py
+++ b/scripts/download_osm_data.py
@@ -113,6 +113,7 @@ if __name__ == "__main__":
         update=False,
         mp=True,
         data_dir=store_path_data,
+        out_dir=store_path_data,
         out_format=["csv", "geojson"],
         out_aggregate=True,
     )

--- a/scripts/download_osm_data.py
+++ b/scripts/download_osm_data.py
@@ -113,12 +113,12 @@ if __name__ == "__main__":
         update=False,
         mp=True,
         data_dir=store_path_data,
-        out_dir=store_path_data,
+        out_dir=store_path_resources,
         out_format=["csv", "geojson"],
         out_aggregate=True,
     )
 
-    out_path = Path.joinpath(store_path_data, "out")
+    out_path = Path.joinpath(store_path_resources, "out")
     names = ["generator", "cable", "line", "substation"]
     format = ["csv", "geojson"]
     new_files = os.listdir(out_path)  # list downloaded osm files

--- a/scripts/download_osm_data.py
+++ b/scripts/download_osm_data.py
@@ -106,7 +106,7 @@ if __name__ == "__main__":
     store_path_data = Path.joinpath(Path().cwd(), "data", "osm")
     country_list = country_list_to_geofk(snakemake.params.countries)
 
-    eo.get_osm_data(
+    eo.save_osm_data(
         primary_name="power",
         region_list=country_list,
         feature_list=["substation", "line", "cable", "generator"],
@@ -118,24 +118,23 @@ if __name__ == "__main__":
     )
 
     out_path = Path.joinpath(store_path_data, "out")
-    names = ["generators", "cables", "lines", "substations"]
+    names = ["generator", "cable", "line", "substation"]
     format = ["csv", "geojson"]
+    new_files = os.listdir(out_path)  # list downloaded osm files
 
     # earth-osm (eo) only outputs files with content
     # If the file is empty, it is not created
     # This is a workaround to create empty files for the workflow
-    for name in names:
-        for f in format:
-            filename = Path.joinpath(out_path, f"all_{name}.{f}")
-            # Create file if not exist
-            if not Path.exists(filename):
-                logger.info(f"{filename} does not exist, create empty file")
-                open(filename, "w").close()
-            # Move and rename
-            old_path = Path.joinpath(out_path, f"all_{name}.{f}")
-            new_path = Path.joinpath(store_path_resources, f"all_raw_{name}.{f}")
-            # Create directory if not exist (required for shutil)
-            if not os.path.exists(store_path_resources):
-                os.makedirs(store_path_resources)
-            logger.info(f"Create {old_path} and move to {new_path}")
-            shutil.move(old_path, new_path)
+
+    # Rename and move osm files to the resources folder
+    for file in new_files:
+        for name in names:
+            for f in format:
+                ext = f"{name}.{f}"
+                if ext in file:
+                    new_file_name = Path.joinpath(
+                        store_path_resources, f"all_raw_{name}s.{f}"
+                    )
+                    old_file_name = Path.joinpath(out_path, file)
+                    logger.info(f"Move {old_file_name} to {new_file_name}")
+                    shutil.move(old_file_name, new_file_name)


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request
The changes in this PR address the incompatibility issues of earth-osm 0.2.0 in pypsa-earth framework.

Code changes were made to download_osm_data.py and clean_osm_data.py.

In `download_osm_data.py`, the files are downloaded with different names depending on the country being selected. I restructured the last part of the code to rename the file and move them to the resource folder.

In `clean_osm_data.py`, substations geopandas dataframe have a geometry column which is in polygons and points. I added a centroid method to find the centroid and replace it with the polygons.
You can also read about a follow-up conversation here #936 

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
