### PR TITLE
Improve equivalent transformation calculations in base.nc

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -18,6 +18,8 @@ E.g. if a new rule becomes available describe how to use it `snakemake -j1 run_t
 
 **Minor Changes and bug-fixing**
 
+* Keep data on the original voltage value when rebasing voltages to the standard values and adjust the transmission capacity accordingly. `PR #898 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/978>`__
+
 
 PyPSA-Earth 0.3.0
 =================

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -496,8 +496,15 @@ def base_network(
     lines_dc = lines[lines.tag_frequency.astype(float) == 0].copy()
 
     lines_ac = _set_electrical_parameters_lines(lines_config, voltages_config, lines_ac)
+    lines_ac.num_parallel = lines_ac.num_parallel * (
+        lines_ac.v_nom_original / lines_ac.v_nom
+    )
+
     lines_dc = _set_electrical_parameters_dc_lines(
         lines_config, voltages_config, lines_dc
+    )
+    lines_dc.num_parallel = lines_dc.num_parallel * (
+        lines_dc.v_nom_original / lines_dc.v_nom
     )
 
     transformers = _set_electrical_parameters_transformers(

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -527,7 +527,7 @@ def base_network(
         lines_dc = _set_electrical_parameters_links(links_config, lines_dc)
         # parse line information into p_nom required for converters
         lines_dc["p_nom"] = lines_dc.apply(
-            lambda x: x["v_nom"] * n.line_types.i_nom[x["type"]],
+            lambda x: x["v_nom_original"] * n.line_types.i_nom[x["type"]],
             axis=1,
             result_type="reduce",
         )

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -451,6 +451,8 @@ def _rebase_voltage_to_config(base_network_config, voltages_config, component):
     config : dictionary (by snakemake)
     component : dataframe
     """
+    component["v_nom_original"] = component["v_nom"]
+
     v_min = (
         base_network_config["min_voltage_rebase_voltage"] / 1000
     )  # min. filtered value in dataset


### PR DESCRIPTION
A suggestion on a possible to partially address #862 and #887 to decrease errors introduced by `base.nc`.

## Changes proposed in this Pull Request

Currently, we are using voltage rebase in `base.nc` which purpose is to map all the voltages to a few "standard" values. However, information on the original voltage is lost during this rebase transformation.

The suggestion is:
1) keep the original voltage before mapping the voltage;
2) adjust `num_parallel` for the lines after the voltage rebase to compensate an effect of the voltage increase on the transmission capacity introduced during rebase.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
