### PR TITLE
Quick fix for to adapt base_network for changes in voltage rebase

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -126,7 +126,7 @@ load_options:
 
 electricity:
   base_voltage: 380.
-  voltages: [220., 300., 380.]
+  voltages: [132., 220., 300., 380., 500., 750.]
   co2limit: 7.75e+7  # European default, 0.05 * 3.1e9*0.5, needs to be adjusted for Africa
   co2base: 1.487e+9  # European default, adjustment to Africa necessary
   agg_p_nom_limits: data/agg_p_nom_minmax.csv

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -140,7 +140,7 @@ load_options:
 
 electricity:
   base_voltage: 380.
-  voltages: [220., 300., 380.]
+  voltages: [132., 220., 300., 380., 500., 750.]
   co2limit: 1.487e+9
   co2base: 1.487e+9
   agg_p_nom_limits: data/agg_p_nom_minmax.csv

--- a/doc/configtables/electricity.csv
+++ b/doc/configtables/electricity.csv
@@ -1,6 +1,6 @@
 ,Unit,Values,Description
 base_voltage, kV, float, "Base voltage to which all lines are simplified/aggregated. Simplification preserves transmission capacities."
-voltages, kV, "Any subset of {220., 300., 380.}", "Voltage levels considered."
+voltages, kV, "A subset of 'standard' voltages considered to map OSM-extracted voltages into 'standard' linetypes."
 co2limit,:math:`t_{CO_2-eq}/a`, float, "Cap on system total annual carbon dioxide equivalent emissions."
 co2base,:math:`t_{CO_2-eq}/a`, float, "Reference value of system total annual carbon dioxide equivalent emissions. Used only if relative emission reduction target is specified in ``{opts}`` wildcard."
 automatic_emission, bool, "{True, False}", "True: Emissions are obtained from automatic emission extraction procedure. False: Emissions are obtained manually"

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -22,9 +22,9 @@ E.g. if a new rule becomes available describe how to use it `snakemake -j1 run_t
 
 **Minor Changes and bug-fixing**
 
-* Minor bug-fixing for GADM_ID format naming. `PR #980 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/980>`__, `PR #986 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/986>`__ and `PR #989 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/989>`__
+* Minor bug-fixing to get the generalised line types work for DC lines. `PR #1008 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1008>`__
 
-* Keep data on the original voltage value when rebasing voltages to the standard values and adjust the transmission capacity accordingly. `PR #898 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/978>`__
+* Minor bug-fixing for GADM_ID format naming. `PR #980 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/980>`__, `PR #986 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/986>`__ and `PR #989 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/989>`__
 
 * Fix download_osm_data compatibility for earth-osm v2.1. `PR #954 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/954>`__ and `PR #988 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/988>`__
 

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -522,7 +522,7 @@ def base_network(
         lines_dc = _set_electrical_parameters_links(links_config, lines_dc)
         # parse line information into p_nom required for converters
         lines_dc["p_nom"] = lines_dc.apply(
-            lambda x: x["v_nom_original"] * n.line_types.i_nom[x["type"]],
+            lambda x: x["v_nom"] * n.line_types.i_nom[x["type"]],
             axis=1,
             result_type="reduce",
         )


### PR DESCRIPTION
Needed to make `base_network` functional for networks with DC lines.

## Changes proposed in this Pull Request

Adapt a workflow to the networks with DC lines after changes introduced by #999 and #978.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
