### PR TITLE
Fix bug to run the cluster wildcard `min`

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -53,7 +53,7 @@ ATLITE_NPROCESSES = config["atlite"].get("nprocesses", 4)
 
 wildcard_constraints:
     simpl="[a-zA-Z0-9]*|all",
-    clusters="[0-9]+(m|flex|min)?|all",
+    clusters="[0-9]+(m|flex)?|all|min",
     ll="(v|c)([0-9\.]+|opt|all)|all",
     opts="[-+a-zA-Z0-9\.]*",
     unc="[-+a-zA-Z0-9\.]*",

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -24,6 +24,8 @@ E.g. if a new rule becomes available describe how to use it `snakemake -j1 run_t
 
 **Minor Changes and bug-fixing**
 
+* Minor bug-fixing to run the cluster wildcard min `PR #1019 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1019>`__
+
 * Add option to adjust load scale for each individual countries `PR #1006 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1006>`__
 
 * Minor bug-fixing to get the generalised line types work for DC lines and AC lines. `PR #1008 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1008>`__ , `PR #1011 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1011>`__ and `PR #1013 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1013>`__

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -691,6 +691,8 @@ if __name__ == "__main__":
         "exclude_carriers", []
     )
     aggregate_carriers = set(n.generators.carrier) - set(exclude_carriers)
+
+    n.determine_network_topology()
     if snakemake.wildcards.clusters.endswith("m"):
         n_clusters = int(snakemake.wildcards.clusters[:-1])
         aggregate_carriers = snakemake.params.electricity.get("conventional_carriers")
@@ -699,9 +701,7 @@ if __name__ == "__main__":
     elif snakemake.wildcards.clusters == "all":
         n_clusters = len(n.buses)
     elif snakemake.wildcards.clusters == "min":
-        m = n.copy()
-        m.determine_network_topology()
-        n_clusters = m.buses.groupby(["country", "sub_network"]).size().count()
+        n_clusters = n.buses.groupby(["country", "sub_network"]).size().count()
     else:
         n_clusters = int(snakemake.wildcards.clusters)
         aggregate_carriers = None

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -699,7 +699,9 @@ if __name__ == "__main__":
     elif snakemake.wildcards.clusters == "all":
         n_clusters = len(n.buses)
     elif snakemake.wildcards.clusters == "min":
-        n_clusters = n.buses.groupby(["country", "sub_network"]).size().count()
+        m = n.copy()
+        m.determine_network_topology()
+        n_clusters = m.buses.groupby(["country", "sub_network"]).size().count()
     else:
         n_clusters = int(snakemake.wildcards.clusters)
         aggregate_carriers = None


### PR DESCRIPTION
Its a minor bugfix so that the cluster wildcard option `min` can be run on snakemake without error
- In Snakefile, `min` doesn't require any number, similar to `all`
- In cluster_network.py, the number of network after `determine_network_topology()` is always larger than the original n_cluster. A network copy is made to count that, but better suggestion is appreciated.


## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
