### PR TITLE
Add a zenodo link to natura.tiff

### DIFF
--- a/configs/bundle_config.yaml
+++ b/configs/bundle_config.yaml
@@ -190,7 +190,7 @@ databundles:
     category: natura
     destination: "data/natura/"
     urls:
-      # zenodo:
+      zenodo: https://sandbox.zenodo.org/records/13539/files/natura_wpda_CC0.zip?download=1
       gdrive: https://drive.google.com/file/d/1H-Y7p8UgnbEzJgo9qPc54BpDXS8loX7Y/view?usp=drive_link
     output:
     - data/natura/natura.tiff


### PR DESCRIPTION
## Changes proposed in this Pull Request

Adds zenodo link to natura.tiff source file to keep bundle config consistent, as all other urls normally provide two sources.

Note that the zenodo link to natura.tiff has been previously erroneously placed under the cutout for North America which has been fixed by #1055.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
