### PR TITLE
fix: remove unused argument from load_GDP

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -18,6 +18,7 @@ E.g. if a new rule becomes available describe how to use it `snakemake -j1 run_t
 
 **Minor Changes and bug-fixing**
 
+* Remove unused `countries_codes` argument from `load_GDP` function in `build_shapes.py` script, which was not being called as intended with positional arguments `PR #1069 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1069>`__
 
 
 PyPSA-Earth 0.4.0

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -604,7 +604,6 @@ def convert_GDP(name_file_nc, year=2015, out_logging=False):
 
 
 def load_GDP(
-    countries_codes,
     year=2015,
     update=False,
     out_logging=False,


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request
Remove unused `countries_codes` argument from `load_GDP` function  in `build_shapes.py` script.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
