### PR TITLE
Fixed float parsing in clean_osm_data.py

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -19,7 +19,7 @@ E.g. if a new rule becomes available describe how to use it `snakemake -j1 run_t
 **Minor Changes and bug-fixing**
 
 * Remove unused `countries_codes` argument from `load_GDP` function in `build_shapes.py` script, which was not being called as intended with positional arguments `PR #1069 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1069>`__
-* Fixed problematic float parsing (`_parse_float`) in `clean_osm_data.py` to make sure all OSM lines are correctly accounted for
+* Fixed problematic float parsing (`_parse_float`) in `clean_osm_data.py` to make sure all OSM lines are correctly accounted for `PR #1089 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1089>`__
 
 
 PyPSA-Earth 0.4.0

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -19,6 +19,7 @@ E.g. if a new rule becomes available describe how to use it `snakemake -j1 run_t
 **Minor Changes and bug-fixing**
 
 * Remove unused `countries_codes` argument from `load_GDP` function in `build_shapes.py` script, which was not being called as intended with positional arguments `PR #1069 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1069>`__
+* Fixed problematic float parsing (`_parse_float`) in `clean_osm_data.py` to make sure all OSM lines are correctly accounted for
 
 
 PyPSA-Earth 0.4.0

--- a/scripts/clean_osm_data.py
+++ b/scripts/clean_osm_data.py
@@ -551,12 +551,10 @@ def fill_circuits(df):
         return len_f, len_c, isna_c, len_cab, isna_cab
 
     def _parse_float(x, ret_def=0.0):
-        if isinstance(x, (int, float)):
+        try:
             return float(x)
-        str_x = str(x)
-        if str_x.isnumeric():
-            return float(str_x)
-        return ret_def
+        except:
+            return ret_def
 
     # cables requirement for circuits calculation
     cables_req = {


### PR DESCRIPTION
# Closes #1087 .

## Changes proposed in this Pull Request

Changes `_parse_float` to use try/except instead of trying to detect the type and return based on that.  The previous function did not accept inputs such as "3.0" because the python `.isnumeric()` function will return false.  

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
