### PR TITLE
lifetime computation in add_electricity.py

### DIFF
--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -432,8 +432,9 @@ def attach_conventional_generators(
         efficiency=ppl.efficiency,
         marginal_cost=ppl.marginal_cost,
         capital_cost=ppl.capital_cost,
-        build_year=ppl.datein.fillna(0).astype(int),
-        lifetime=(ppl.dateout - ppl.datein).fillna(np.inf),
+        build_year=ppl.datein.fillna(0).astype(int),        
+        lifetime=(ppl.dateout.replace(' ', '0')
+                  .apply(lambda x: int(x) if pd.notna(x) else 0) - ppl.datein),
     )
 
     for carrier in conventional_config:

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -432,9 +432,11 @@ def attach_conventional_generators(
         efficiency=ppl.efficiency,
         marginal_cost=ppl.marginal_cost,
         capital_cost=ppl.capital_cost,
-        build_year=ppl.datein.fillna(0).astype(int),        
-        lifetime=(ppl.dateout.replace(' ', '0')
-                  .apply(lambda x: int(x) if pd.notna(x) else 0) - ppl.datein),
+        build_year=ppl.datein.fillna(0).astype(int),
+        lifetime=(
+            ppl.dateout.replace(" ", "0").apply(lambda x: int(x) if pd.notna(x) else 0)
+            - ppl.datein
+        ),
     )
 
     for carrier in conventional_config:


### PR DESCRIPTION
## Changes proposed in this Pull Request
Unlike the earlier version, this one introduces a check for NaN values directly within the apply function and replaces them with 0 instead of filling with np.inf after the operation (might be especially useful if working with a powerplants.csv originated from a custom_powerplants.csv file). It also doesn't simply replace spaces with 0 but explicitly ensures that any resulting value is numeric before the subtraction.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
