### PR TITLE
Fix bug in powerplant data processing

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -22,6 +22,7 @@ E.g. if a new rule becomes available describe how to use it `snakemake -j1 run_t
 * Fixed problematic float parsing (`_parse_float`) in `clean_osm_data.py` to make sure all OSM lines are correctly accounted for `PR #1089 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1089>`__
 
 * Fix minor bug for advanced csp implementation `PR #1076 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1076>`__
+* Fix minor bug in `build_powerplants.py` where the gas technology assignment incorrectly introduced NaN values for all powerplant technologies. `PR #1102 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1102>`__
 
 
 PyPSA-Earth 0.4.0

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -285,10 +285,8 @@ def replace_natural_gas_technology(df: pd.DataFrame):
     unique_tech_with_ng = df.loc[fueltype, "Technology"].unique()
     unknown_techs = np.setdiff1d(unique_tech_with_ng, ["CCGT", "OCGT"])
     if len(unknown_techs) > 0:
-        df.Technology.where(
-            fueltype,
-            df["Technology"].map({t: "CCGT" for t in unknown_techs}),
-            inplace=True,
+        df.loc[fueltype, "Technology"] = df.loc[fueltype, "Technology"].replace(
+            {t: "CCGT" for t in unknown_techs}
         )
     df["Fueltype"] = np.where(fueltype, df["Technology"], df["Fueltype"])
     return df


### PR DESCRIPTION
# Closes # (if applicable).
Not sure but maybe related to #1081 
## Changes proposed in this Pull Request
In the build_powerplants function, the process of filling unknown natural gas (NG) technologies in the powerplant data retrieved from PowerPlantMatching using the default value 'CCGT'—via the replace_natural_gas_technology function—was inadvertently leading to the insertion of unwanted NaN values for all powerplant technologies, not just natural gas. This issue was identified when running the model for Brazil, where all hydro plants were mistakenly categorized as run-of-river plants due to the implementation in `add_electricity`.
https://github.com/pypsa-meets-earth/pypsa-earth/blob/09af96e7b25cbc17449053a24da4ff7e760dff60/scripts/add_electricity.py#L480).
This PR resolves that bug.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [x] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
