### PR TITLE
Update default year for IRENA RES scaling

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -179,7 +179,7 @@ electricity:
 
   estimate_renewable_capacities:
     stats: "irena" # False, = greenfield expansion, 'irena' uses IRENA stats to add expansion limits
-    year: 2020 # Reference year, available years for IRENA stats are 2000 to 2020
+    year: 2023 # Reference year, available years for IRENA stats are 2000 to 2023
     p_nom_min: 1 # any float, scales the minimum expansion acquired from stats, i.e. 110% of <years>'s capacities => p_nom_min: 1.1
     p_nom_max: false # sets the expansion constraint, False to deactivate this option and use estimated renewable potentials determine by the workflow, float scales the p_nom_min factor accordingly
     technology_mapping:

--- a/doc/configtables/electricity.csv
+++ b/doc/configtables/electricity.csv
@@ -26,7 +26,7 @@ conventional_carriers,--,"Any subset of {nuclear, oil, OCGT, CCGT, coal, lignite
 renewable_carriers,--, "Any subset of {solar, onwind, offwind-ac, offwind-dc, hydro}", "List of renewable power plants to include in the model from ``resources/powerplants.csv``."
 estimate_renewable_capacities,,,
 -- stats,, "{""irena"" or False}", "Defines which database to use, currently only ""irena"" is available. ""irena"" uses IRENA stats to add expansion limits. ``False`` enables greenfield expansion."
--- year,, "Any year beetween 2000 and 2020", "Reference year for renewable capacities. Available years for IRENA stats are from 2000 to 2020."
+-- year,, "Any year beetween 2000 and 2023", "Reference year for renewable capacities. Available years for IRENA stats are from 2000 to 2023."
 -- p_nom_min,,float,"Scales the minimum expansion acquired from stats. For example, 110% of <years>'s capacities is obtained with p_nom_min: 1.1."
 -- p_nom_max,,float or ``False``,"sets the expansion constraint, False to deactivate this option and use estimated renewable potentials determine by the workflow, float scales the p_nom_min factor accordingly."
 -- technology_mapping,,, "Maps the technologies defined in ppm.data.Capacity_stats with the carriers in PyPSA-Earth."

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -20,6 +20,8 @@ E.g. if a new rule becomes available describe how to use it `make test` and in o
 
 **Minor Changes and bug-fixing**
 
+* The default configuration for `electricity:estimate_renewable_capacities:year` was updated from 2020 to 2023. `PR #1106 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1106>`_
+
 
 PyPSA-Earth 0.4.1
 =================


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR updates the default year for RES capacity estimation based on the latest IRENA data (`electricity:estimate_renewable_capacities:year`), that happens in `add_electricity.py`. Additionally, the configuration table and the corresponding comment in `config.default.yaml` have been adjusted accordingly.

The IRENA data used in powerplantmatching now includes information up to 2023 (https://github.com/PyPSA/powerplantmatching/blob/9a63ed0363e748a6967673c00cb2a6dd7d6c80c4/powerplantmatching/package_data/config.yaml#L64). For the case of Brazil this update entails significant changes in capacity (onshore wind: 17.2 GW -> 29.1 GW; solar: 8.4 GW -> 37.4 GW).


## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
