### PR TITLE
explicitly specify the micromamba version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Setup micromamba
       uses: mamba-org/setup-micromamba@v1
       with:
-        micromamba-version: '1.5.9-1
+        micromamba-version: '1.5.9-1'
         environment-file: envs/environment.yaml
         log-level: debug
         init-shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Setup micromamba
       uses: mamba-org/setup-micromamba@v1
       with:
-        micromamba-version: latest
+        micromamba-version: '2.0.0-0'
         environment-file: envs/environment.yaml
         log-level: debug
         init-shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Setup micromamba
       uses: mamba-org/setup-micromamba@v1
       with:
-        micromamba-version: '1.5.9'
+        micromamba-version: '1.5.9-1
         environment-file: envs/environment.yaml
         log-level: debug
         init-shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Setup micromamba
       uses: mamba-org/setup-micromamba@v1
       with:
-        micromamba-version: '2.0.0-0'
+        micromamba-version: '1.5.9'
         environment-file: envs/environment.yaml
         log-level: debug
         init-shell: bash


### PR DESCRIPTION
# Closes # (if applicable).

Fix

```
  /home/runner/micromamba-bin/micromamba list -r /home/runner/micromamba -n pypsa-earth
  critical libmamba Error parsing MatchSpec "pypsa[version='>=0.24,',build='<0.25']": Error setting attribute "version" to value ">=0.24,": Version spec "" is an incorrect expression"
  List of packages in environment: "/home/runner/micromamba/envs/pypsa-earth"
```

As explained [here](https://github.com/mamba-org/micromamba-releases/issues/58#issuecomment-2377204498), setting the micromamba version explicitly fixes the problem.

## Changes proposed in this Pull Request


## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [x] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
