### PR TITLE
config: link to new (cropped) cutout for north america

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,67 +191,10 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
 <table>
 <tr>
     <td align="center">
-        <a href="https://github.com/FabianHofmann">
-            <img src="https://avatars.githubusercontent.com/u/19226431?v=4" width="100;" alt="FabianHofmann"/>
+        <a href="https://github.com/finozzifa">
+            <img src="https://avatars.githubusercontent.com/u/167071962?v=4" width="100;" alt="finozzifa"/>
             <br />
-            <sub><b>Fabian Hofmann</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/fneum">
-            <img src="https://avatars.githubusercontent.com/u/29101152?v=4" width="100;" alt="fneum"/>
-            <br />
-            <sub><b>Fabian Neumann</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/ekatef">
-            <img src="https://avatars.githubusercontent.com/u/30229437?v=4" width="100;" alt="ekatef"/>
-            <br />
-            <sub><b>Ekaterina</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/euronion">
-            <img src="https://avatars.githubusercontent.com/u/42553970?v=4" width="100;" alt="euronion"/>
-            <br />
-            <sub><b>Euronion</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/Justus-coded">
-            <img src="https://avatars.githubusercontent.com/u/44394641?v=4" width="100;" alt="Justus-coded"/>
-            <br />
-            <sub><b>Justus Ilemobayo</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/mnm-matin">
-            <img src="https://avatars.githubusercontent.com/u/45293386?v=4" width="100;" alt="mnm-matin"/>
-            <br />
-            <sub><b>Mnm-matin</b></sub>
-        </a>
-    </td></tr>
-<tr>
-    <td align="center">
-        <a href="https://github.com/martacki">
-            <img src="https://avatars.githubusercontent.com/u/53824825?v=4" width="100;" alt="martacki"/>
-            <br />
-            <sub><b>Martha Frysztacki</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/LukasFrankenQ">
-            <img src="https://avatars.githubusercontent.com/u/55196140?v=4" width="100;" alt="LukasFrankenQ"/>
-            <br />
-            <sub><b>Lukas Franken</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/pz-max">
-            <img src="https://avatars.githubusercontent.com/u/61968949?v=4" width="100;" alt="pz-max"/>
-            <br />
-            <sub><b>Max Parzen</b></sub>
+            <sub><b>Finozzifa</b></sub>
         </a>
     </td>
     <td align="center">
@@ -262,39 +205,17 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
         </a>
     </td>
     <td align="center">
-        <a href="https://github.com/koen-vg">
-            <img src="https://avatars.githubusercontent.com/u/74298901?v=4" width="100;" alt="koen-vg"/>
+        <a href="https://github.com/ekatef">
+            <img src="https://avatars.githubusercontent.com/u/30229437?v=4" width="100;" alt="ekatef"/>
             <br />
-            <sub><b>Koen Van Greevenbroek</b></sub>
+            <sub><b>Ekaterina</b></sub>
         </a>
     </td>
     <td align="center">
-        <a href="https://github.com/hazemakhalek">
-            <img src="https://avatars.githubusercontent.com/u/87850910?v=4" width="100;" alt="hazemakhalek"/>
+        <a href="https://github.com/pz-max">
+            <img src="https://avatars.githubusercontent.com/u/61968949?v=4" width="100;" alt="pz-max"/>
             <br />
-            <sub><b>Hazem</b></sub>
-        </a>
-    </td></tr>
-<tr>
-    <td align="center">
-        <a href="https://github.com/energyLS">
-            <img src="https://avatars.githubusercontent.com/u/89515385?v=4" width="100;" alt="energyLS"/>
-            <br />
-            <sub><b>EnergyLS</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/AnasAlgarei">
-            <img src="https://avatars.githubusercontent.com/u/101210563?v=4" width="100;" alt="AnasAlgarei"/>
-            <br />
-            <sub><b>AnasAlgarei</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/yerbol-akhmetov">
-            <img src="https://avatars.githubusercontent.com/u/113768325?v=4" width="100;" alt="yerbol-akhmetov"/>
-            <br />
-            <sub><b>Yerbol Akhmetov</b></sub>
+            <sub><b>Max Parzen</b></sub>
         </a>
     </td>
     <td align="center">
@@ -305,10 +226,39 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
         </a>
     </td>
     <td align="center">
+        <a href="https://github.com/yerbol-akhmetov">
+            <img src="https://avatars.githubusercontent.com/u/113768325?v=4" width="100;" alt="yerbol-akhmetov"/>
+            <br />
+            <sub><b>Yerbol Akhmetov</b></sub>
+        </a>
+    </td></tr>
+<tr>
+    <td align="center">
         <a href="https://github.com/GbotemiB">
             <img src="https://avatars.githubusercontent.com/u/48842684?v=4" width="100;" alt="GbotemiB"/>
             <br />
             <sub><b>Emmanuel Bolarinwa</b></sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/mnm-matin">
+            <img src="https://avatars.githubusercontent.com/u/45293386?v=4" width="100;" alt="mnm-matin"/>
+            <br />
+            <sub><b>Mnm-matin</b></sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/hazemakhalek">
+            <img src="https://avatars.githubusercontent.com/u/87850910?v=4" width="100;" alt="hazemakhalek"/>
+            <br />
+            <sub><b>Hazem</b></sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/energyLS">
+            <img src="https://avatars.githubusercontent.com/u/89515385?v=4" width="100;" alt="energyLS"/>
+            <br />
+            <sub><b>EnergyLS</b></sub>
         </a>
     </td>
     <td align="center">
@@ -317,13 +267,20 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
             <br />
             <sub><b>Thomas Kouroughli</b></sub>
         </a>
-    </td></tr>
-<tr>
+    </td>
     <td align="center">
         <a href="https://github.com/GridGrapher">
             <img src="https://avatars.githubusercontent.com/u/127969728?v=4" width="100;" alt="GridGrapher"/>
             <br />
             <sub><b>GridGrapher</b></sub>
+        </a>
+    </td></tr>
+<tr>
+    <td align="center">
+        <a href="https://github.com/martacki">
+            <img src="https://avatars.githubusercontent.com/u/53824825?v=4" width="100;" alt="martacki"/>
+            <br />
+            <sub><b>Martha Frysztacki</b></sub>
         </a>
     </td>
     <td align="center">
@@ -355,10 +312,10 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
         </a>
     </td>
     <td align="center">
-        <a href="https://github.com/finozzifa">
-            <img src="https://avatars.githubusercontent.com/u/167071962?v=4" width="100;" alt="finozzifa"/>
+        <a href="https://github.com/euronion">
+            <img src="https://avatars.githubusercontent.com/u/42553970?v=4" width="100;" alt="euronion"/>
             <br />
-            <sub><b>Finozzifa</b></sub>
+            <sub><b>Euronion</b></sub>
         </a>
     </td></tr>
 <tr>
@@ -367,6 +324,20 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
             <img src="https://avatars.githubusercontent.com/u/124347782?v=4" width="100;" alt="cpschau"/>
             <br />
             <sub><b>Cschau</b></sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/LukasFrankenQ">
+            <img src="https://avatars.githubusercontent.com/u/55196140?v=4" width="100;" alt="LukasFrankenQ"/>
+            <br />
+            <sub><b>Lukas Franken</b></sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/AnasAlgarei">
+            <img src="https://avatars.githubusercontent.com/u/101210563?v=4" width="100;" alt="AnasAlgarei"/>
+            <br />
+            <sub><b>AnasAlgarei</b></sub>
         </a>
     </td>
     <td align="center">
@@ -389,6 +360,14 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
             <br />
             <sub><b>Carlos Fernandez</b></sub>
         </a>
+    </td></tr>
+<tr>
+    <td align="center">
+        <a href="https://github.com/koen-vg">
+            <img src="https://avatars.githubusercontent.com/u/74298901?v=4" width="100;" alt="koen-vg"/>
+            <br />
+            <sub><b>Koen Van Greevenbroek</b></sub>
+        </a>
     </td>
     <td align="center">
         <a href="https://github.com/asolavi">
@@ -403,8 +382,7 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
             <br />
             <sub><b>Stephen J Lee</b></sub>
         </a>
-    </td></tr>
-<tr>
+    </td>
     <td align="center">
         <a href="https://github.com/rsparks3">
             <img src="https://avatars.githubusercontent.com/u/30065966?v=4" width="100;" alt="rsparks3"/>
@@ -425,7 +403,8 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
             <br />
             <sub><b>Juli-a-ko</b></sub>
         </a>
-    </td>
+    </td></tr>
+<tr>
     <td align="center">
         <a href="https://github.com/squoilin">
             <img src="https://avatars.githubusercontent.com/u/4547840?v=4" width="100;" alt="squoilin"/>
@@ -446,8 +425,7 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
             <br />
             <sub><b>Pietro Monticone</b></sub>
         </a>
-    </td></tr>
-<tr>
+    </td>
     <td align="center">
         <a href="https://github.com/Netotse">
             <img src="https://avatars.githubusercontent.com/u/89367243?v=4" width="100;" alt="Netotse"/>
@@ -468,7 +446,8 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
             <br />
             <sub><b>Jess</b></sub>
         </a>
-    </td>
+    </td></tr>
+<tr>
     <td align="center">
         <a href="https://github.com/jarry7">
             <img src="https://avatars.githubusercontent.com/u/27745389?v=4" width="100;" alt="jarry7"/>
@@ -484,13 +463,19 @@ The documentation is available here: [documentation](https://pypsa-earth.readthe
         </a>
     </td>
     <td align="center">
+        <a href="https://github.com/FabianHofmann">
+            <img src="https://avatars.githubusercontent.com/u/19226431?v=4" width="100;" alt="FabianHofmann"/>
+            <br />
+            <sub><b>Fabian Hofmann</b></sub>
+        </a>
+    </td>
+    <td align="center">
         <a href="https://github.com/EmreYorat">
             <img src="https://avatars.githubusercontent.com/u/93644024?v=4" width="100;" alt="EmreYorat"/>
             <br />
             <sub><b>EmreYorat</b></sub>
         </a>
-    </td></tr>
-<tr>
+    </td>
     <td align="center">
         <a href="https://github.com/AndreCNF">
             <img src="https://avatars.githubusercontent.com/u/19359510?v=4" width="100;" alt="AndreCNF"/>

--- a/configs/bundle_config.yaml
+++ b/configs/bundle_config.yaml
@@ -256,16 +256,29 @@ databundles:
   #     build_cutout: [all]
 
   # cutouts bundle of the cutouts folder for the North American continent
-  # Note: this includes nearly the entire north emisphere [long +-180, lat 1-85]. Size about 81GB (zipped)
+  # Coordinate bounds: [long -172 to -47, lat 1.5-74]
+  # Size about 25 GB (zipped)
   bundle_cutouts_northamerica:
-    countries: [NorthAmerica, Europe]
+    countries: [NorthAmerica]
+    category: cutouts
+    destination: "cutouts"
+    urls:
+      gdrive: https://drive.google.com/file/d/1W0rEa7SrAUjqREycKSbl1dkylj_-xmpT/view?usp=drive_link
+    output: [cutouts/cutout-2013-era5.nc]
+    disable_by_opt:
+      build_cutout: [all]
+
+  # cutouts bundle of the cutouts folder for the European continent
+  # Note: this includes nearly the entire north emisphere [long +-180, lat 1-85]. Size about 81GB (zipped)
+  bundle_cutouts_europe:
+    countries: [Europe]
     category: cutouts
     destination: "cutouts"
     urls:
       gdrive: https://drive.google.com/file/d/1Ew7rQT0VNBqJW1AUrOrOP2IJKSJS7Uoy/view?usp=sharing
-    output: [cutouts/cutout-2013-era5.nc]
+    output: [ cutouts/cutout-2013-era5.nc ]
     disable_by_opt:
-      build_cutout: [all]
+      build_cutout: [ all ]
 
   # cutouts bundle of the cutouts folder for the Asian continent, except Russia
   # Size about 30GB (zipped)

--- a/configs/bundle_config.yaml
+++ b/configs/bundle_config.yaml
@@ -276,9 +276,9 @@ databundles:
     destination: "cutouts"
     urls:
       gdrive: https://drive.google.com/file/d/1Ew7rQT0VNBqJW1AUrOrOP2IJKSJS7Uoy/view?usp=sharing
-    output: [ cutouts/cutout-2013-era5.nc ]
+    output: [cutouts/cutout-2013-era5.nc]
     disable_by_opt:
-      build_cutout: [ all ]
+      build_cutout: [all]
 
   # cutouts bundle of the cutouts folder for the Asian continent, except Russia
   # Size about 30GB (zipped)

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -20,6 +20,8 @@ E.g. if a new rule becomes available describe how to use it `make test` and in o
 
 **Minor Changes and bug-fixing**
 
+* Include a dedicated cutout for North America in bundle_config.yaml `PR #1121 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1121>`_
+
 
 PyPSA-Earth 0.4.1
 =================


### PR DESCRIPTION
# Closes # (if applicable).

If a user chooses any country of North America in the configuration files, he/she needs to download a cutout of more than 80 GB. The cutout in fact includes the entire northern hemisphere, as shown below

```
Dimensions:           (x: 1340, y: 287, time: 8760)
Coordinates:
  * x                 (x) float64 -180.0 -179.7 -179.4 ... 179.4 179.4 179.7
  * y                 (y) float64 1.5 1.8 2.1 2.4 2.7 ... 86.4 86.7 87.0 87.3
  * time              (time) datetime64[ns] 2013-01-01 ... 2013-12-31T23:00:00
    lon               (x) float64 ...
    lat               (y) float64 ...
Data variables: (12/13)
    height            (y, x) float32 ...
    wnd100m           (time, y, x) float32 ...
    wnd_azimuth       (time, y, x) float32 ...
    roughness         (time, y, x) float32 ...
    influx_toa        (time, y, x) float32 ...
    influx_direct     (time, y, x) float32 ...
    ...                ...
    albedo            (time, y, x) float32 ...
    solar_altitude    (time, y, x) float64 ...
    solar_azimuth     (time, y, x) float64 ...
    temperature       (time, y, x) float32 ...
    soil temperature  (time, y, x) float32 ...
    runoff            (time, y, x) float32 ...
Attributes:
    module:             era5
    prepared_features:  ['temperature', 'height', 'wind', 'influx', 'runoff']
    chunksize_time:     100
    dx:                 0.3
    dy:                 0.3
    Conventions:        CF-1.6
    history:            2023-07-21 19:40:32 GMT by grib_to_netcdf-2.25.1: /op...)
{'zlib': True, 'szip': False, 'zstd': False, 'bzip2': False, 'blosc': False, 'shuffle': True, 'complevel': 9, 'fletcher32': False, 'contiguous': False, 'chunksizes': (876, 29, 134), 'preferred_chunks': {'time': 876, 'y': 29, 'x': 134}, 'source': '/Users/fabriziofinozzi/Downloads/cutout-2013-era5.nc', 'original_shape': (8760, 287, 1340), 'dtype': dtype('float32'), '_FillValue': nan, 'coordinates': 'lon lat'}

```

Using `atlite` and the code below, @davide-f and I managed to crop the above mentioned cutout to the boundaries `long -172, -47` and `lat 1.5, 74`

```
import pathlib
import atlite
northern_emisphere_cutout_path = pathlib.Path("cutout-2013-era5.nc")
northern_emisphere_cutout = atlite.Cutout(
    path=northern_emisphere_cutout_path
)
print(northern_emisphere_cutout.data)

min_x = -172.0
max_x = -47.0
min_y = 1.5 
max_y = 74

bounds = [min_x, min_y, max_x, max_y]

cropped_ds = northern_emisphere_cutout.sel(bounds=bounds)

print(cropped_ds.data)

cropped_ds.to_file(fn="north_america_cutout-2013-era5.nc")
```

The area enclosed by these coordinates is shown below
![Screenshot 2024-09-27 at 17 31 34](https://github.com/user-attachments/assets/6dceda5e-b9c0-4f35-abbe-e84c848f8fc5)

The resulting cutout has the following properties

```
Dimensions:           (x: 477, y: 242, time: 8760)
Coordinates:
  * x                 (x) float64 -171.9 -171.9 -171.6 ... -47.7 -47.4 -47.1
  * y                 (y) float64 1.5 1.8 2.1 2.4 2.7 ... 72.9 73.2 73.5 73.8
  * time              (time) datetime64[ns] 2013-01-01 ... 2013-12-31T23:00:00
    lon               (x) float64 ...
    lat               (y) float64 ...
Data variables: (12/13)
    height            (y, x) float32 ...
    wnd100m           (time, y, x) float32 ...
    wnd_azimuth       (time, y, x) float32 ...
    roughness         (time, y, x) float32 ...
    influx_toa        (time, y, x) float32 ...
    influx_direct     (time, y, x) float32 ...
    ...                ...
    albedo            (time, y, x) float32 ...
    solar_altitude    (time, y, x) float64 ...
    solar_azimuth     (time, y, x) float64 ...
    temperature       (time, y, x) float32 ...
    soil temperature  (time, y, x) float32 ...
    runoff            (time, y, x) float32 ...
Attributes:
    module:             era5
    prepared_features:  ['runoff', 'height', 'temperature', 'wind', 'influx']
    chunksize_time:     100
    dx:                 0.3
    dy:                 0.3
    Conventions:        CF-1.6
    history:            2023-07-25 22:57:33 GMT by grib_to_netcdf-2.25.1: /op...)
{'zlib': True, 'szip': False, 'zstd': False, 'bzip2': False, 'blosc': False, 'shuffle': True, 'complevel': 9, 'fletcher32': False, 'contiguous': False, 'chunksizes': (1252, 35, 69), 'preferred_chunks': {'time': 1252, 'y': 35, 'x': 69}, 'source': '/Users/fabriziofinozzi/Downloads/north_america_cutout-2013-era5.nc', 'original_shape': (8760, 242, 477), 'dtype': dtype('float32'), '_FillValue': nan, 'coordinates': 'lon lat'}
```

**Please note**: the cutout has been zipped, using `pypsa-earth/scripts/non_workflow/zip_folder`


## Changes proposed in this Pull Request


## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [x] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
