### PR TITLE
Update bundle_config.yaml including a dedicated European cutout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,8 @@ jobs:
         key: data-cutouts-${{ env.WEEK }}-${{ env.CACHE_NUMBER }}
 
 
-    - name: Conda list
-      run: conda list
+    - name: Micromamba list
+      run: micromamba list
 
     - name: Run Test
       run: make test

--- a/configs/bundle_config.yaml
+++ b/configs/bundle_config.yaml
@@ -281,6 +281,18 @@ databundles:
     disable_by_opt:
       build_cutout: [all]
 
+  # cutouts bundle of the cutouts folder for the northern hemisphere
+  # Note: this includes nearly the entire northern emisphere [long +-180, lat 1-85]. Size about 81GB (zipped)
+  #bundle_cutouts_northern_hemisphere:
+  #  countries: [NorthAmerica, Europe]
+  #  category: cutouts
+  #  destination: "cutouts"
+  #  urls:
+  #    gdrive: https://drive.google.com/file/d/1Ew7rQT0VNBqJW1AUrOrOP2IJKSJS7Uoy/view?usp=sharing
+  #  output: [cutouts/cutout-2013-era5.nc]
+  #  disable_by_opt:
+  #    build_cutout: [all]
+
   # cutouts bundle of the cutouts folder for the Asian continent, except Russia
   # Size about 30GB (zipped)
   bundle_cutouts_asia:

--- a/configs/bundle_config.yaml
+++ b/configs/bundle_config.yaml
@@ -269,13 +269,14 @@ databundles:
       build_cutout: [all]
 
   # cutouts bundle of the cutouts folder for the European continent
-  # Note: this includes nearly the entire north emisphere [long +-180, lat 1-85]. Size about 81GB (zipped)
+  # Coordinate bounds: [long -32 to 60, lat 1.5-74]
+  # Size about 17 GB (zipped)
   bundle_cutouts_europe:
     countries: [Europe]
     category: cutouts
     destination: "cutouts"
     urls:
-      gdrive: https://drive.google.com/file/d/1Ew7rQT0VNBqJW1AUrOrOP2IJKSJS7Uoy/view?usp=sharing
+      gdrive: https://drive.google.com/file/d/17QS7qkuCiyj95Pr-ZQRl3qgp5CQE6HTy/view?usp=drive_link
     output: [cutouts/cutout-2013-era5.nc]
     disable_by_opt:
       build_cutout: [all]

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -24,7 +24,7 @@ E.g. if a new rule becomes available describe how to use it `make test` and in o
 
 * Include a dedicated cutout for North America in bundle_config.yaml `PR #1121 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1121>`_
 
-* Include a dedicated cutout for Europe in bundle_config.yaml `PR #1125 https://github.com/pypsa-meets-earth/pypsa-earth/pull/1125`_
+* Include a dedicated cutout for Europe in bundle_config.yaml `PR #1125 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1125>`_
 
 PyPSA-Earth 0.4.1
 =================

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -24,6 +24,7 @@ E.g. if a new rule becomes available describe how to use it `make test` and in o
 
 * Include a dedicated cutout for North America in bundle_config.yaml `PR #1121 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1121>`_
 
+* Include a dedicated cutout for Europe in bundle_config.yaml `PR #1125 https://github.com/pypsa-meets-earth/pypsa-earth/pull/1125`_
 
 PyPSA-Earth 0.4.1
 =================


### PR DESCRIPTION
# Closes # (if applicable).

If a user chooses any country in Europe in the configuration files, he/she needs to download a cutout of more than 80 GB. The cutout in fact includes the entire northern hemisphere, as shown below

```
Dimensions:           (x: 1340, y: 287, time: 8760)
Coordinates:
  * x                 (x) float64 -180.0 -179.7 -179.4 ... 179.4 179.4 179.7
  * y                 (y) float64 1.5 1.8 2.1 2.4 2.7 ... 86.4 86.7 87.0 87.3
  * time              (time) datetime64[ns] 2013-01-01 ... 2013-12-31T23:00:00
    lon               (x) float64 ...
    lat               (y) float64 ...
Data variables: (12/13)
    height            (y, x) float32 ...
    wnd100m           (time, y, x) float32 ...
    wnd_azimuth       (time, y, x) float32 ...
    roughness         (time, y, x) float32 ...
    influx_toa        (time, y, x) float32 ...
    influx_direct     (time, y, x) float32 ...
    ...                ...
    albedo            (time, y, x) float32 ...
    solar_altitude    (time, y, x) float64 ...
    solar_azimuth     (time, y, x) float64 ...
    temperature       (time, y, x) float32 ...
    soil temperature  (time, y, x) float32 ...
    runoff            (time, y, x) float32 ...
Attributes:
    module:             era5
    prepared_features:  ['temperature', 'height', 'wind', 'influx', 'runoff']
    chunksize_time:     100
    dx:                 0.3
    dy:                 0.3
    Conventions:        CF-1.6
    history:            2023-07-21 19:40:32 GMT by grib_to_netcdf-2.25.1: /op...)
{'zlib': True, 'szip': False, 'zstd': False, 'bzip2': False, 'blosc': False, 'shuffle': True, 'complevel': 9, 'fletcher32': False, 'contiguous': False, 'chunksizes': (876, 29, 134), 'preferred_chunks': {'time': 876, 'y': 29, 'x': 134}, 'source': '/Users/fabriziofinozzi/Downloads/cutout-2013-era5.nc', 'original_shape': (8760, 287, 1340), 'dtype': dtype('float32'), '_FillValue': nan, 'coordinates': 'lon lat'}

```

Using `atlite` and the code below, @danielelerede-oet and I managed to crop the above mentioned cutout to the boundaries `long -32, 60` and `lat 1.5, 74`

```
import pathlib
import atlite
northern_emisphere_cutout_path = pathlib.Path("cutout-2013-era5.nc")
northern_emisphere_cutout = atlite.Cutout(
    path=northern_emisphere_cutout_path
)
print(northern_emisphere_cutout.data)

min_x = -32.0
max_x = 60.0
min_y = 1.5 
max_y = 74

bounds = [min_x, min_y, max_x, max_y]

cropped_ds = northern_emisphere_cutout.sel(bounds=bounds)

print(cropped_ds.data)

cropped_ds.to_file(fn="europe_cutout-2013-era5.nc")
```

The area enclosed by these coordinates is shown below
![Screenshot 2024-10-02 at 18 21 16](https://github.com/user-attachments/assets/d26f6ec3-d572-4192-80e8-de6b9b3ea618)

**Please note**: the cutout has been zipped, using `pypsa-earth/scripts/non_workflow/zip_folder`


## Changes proposed in this Pull Request


## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [x] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
