### PR TITLE
Fix issue of adding H2 store in `add_extra_components` rule

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -26,6 +26,8 @@ E.g. if a new rule becomes available describe how to use it `make test` and in o
 
 * Include a dedicated cutout for Europe in bundle_config.yaml `PR #1125 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1125>`_
 
+* Fix the mismatch between buses and x, y locations while creating H2 Stores `PR #1134 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1134>`_
+
 PyPSA-Earth 0.4.1
 =================
 

--- a/scripts/add_extra_components.py
+++ b/scripts/add_extra_components.py
@@ -105,7 +105,7 @@ def attach_stores(n, costs, config):
     _add_missing_carriers_from_costs(n, costs, carriers)
 
     buses_i = n.buses.query("carrier == 'AC'").index
-    bus_sub_dict = {k: n.buses[k].values for k in ["x", "y", "country"]}
+    bus_sub_dict = {k: n.buses.loc[buses_i, k].values for k in ["x", "y", "country"]}
 
     if "H2" in carriers:
         h2_buses_i = n.madd("Bus", buses_i + " H2", carrier="H2", **bus_sub_dict)

--- a/scripts/add_extra_components.py
+++ b/scripts/add_extra_components.py
@@ -104,8 +104,8 @@ def attach_stores(n, costs, config):
 
     _add_missing_carriers_from_costs(n, costs, carriers)
 
-    buses_i = n.buses.query("carrier == 'AC'").index
-    bus_sub_dict = {k: n.buses.loc[buses_i, k].values for k in ["x", "y", "country"]}
+    buses_i = n.buses.index
+    bus_sub_dict = {k: n.buses[k].values for k in ["x", "y", "country"]}
 
     if "H2" in carriers:
         h2_buses_i = n.madd("Bus", buses_i + " H2", carrier="H2", **bus_sub_dict)


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. Here I propose to fix the bug related to addition of H2 Store in `add_extra_components.py` script. The issue was found while simulating USA, which had both AC and DC buses. The following error appeared. Which means that for 10 AC buses, it tried to add 12 x, y, country data.
![image](https://github.com/user-attachments/assets/84f6face-e43e-4eb5-82a5-c23afd55e98b)

Based on the current code, `buses_i` only looks for AC buses, while `bus_sub_dict` considers all. In the US model, we had two additional DC buses (10 vs 12).
https://github.com/pypsa-meets-earth/pypsa-earth/blob/b64623d8d3d8127e186dbe3b9a899e326e1bcb72/scripts/add_extra_components.py#L107-L111

In the new version, I propose to add H2 Stores for AC buses only, if it is intended so.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
