### PR TITLE
Use absolute path for `config.default.yaml` in `_helpers.py`

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -26,6 +26,8 @@ E.g. if a new rule becomes available describe how to use it `make test` and in o
 
 * Include a dedicated cutout for Europe in bundle_config.yaml `PR #1125 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1125>`_
 
+* Use absolute path for `config.default.yaml` in `_helpers.py` for facilitate smooth module import `PR #1137 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1137>`_
+
 PyPSA-Earth 0.4.1
 =================
 

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -36,13 +36,11 @@ REGION_COLS = ["geometry", "name", "x", "y", "country"]
 # filename of the regions definition config file
 REGIONS_CONFIG = "regions_definition_config.yaml"
 
-# prefix when running pypsa-earth rules in different directories (if running in pypsa-earth directory PREFIX='.')
+# prefix when running pypsa-earth rules in different directories (if running in pypsa-earth as subworkflow)
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
-RUN_DIR = os.path.abspath(os.getcwd())
-PREFIX = os.path.relpath(BASE_DIR, RUN_DIR)
 
 # absolute path to config.default.yaml
-CONFIG_DEFAULT_PATH = os.path.join(PREFIX, "config.default.yaml")
+CONFIG_DEFAULT_PATH = os.path.join(BASE_DIR, "config.default.yaml")
 
 
 def check_config_version(config, fp_config=CONFIG_DEFAULT_PATH):

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -36,8 +36,13 @@ REGION_COLS = ["geometry", "name", "x", "y", "country"]
 # filename of the regions definition config file
 REGIONS_CONFIG = "regions_definition_config.yaml"
 
+# absolute path to base directory (pypsa-earth)
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 
-def check_config_version(config, fp_config="config.default.yaml"):
+# absolute path to config.default.yaml
+CONFIG_DEFAULT_PATH = os.path.join(BASE_DIR, 'config.default.yaml')
+
+def check_config_version(config, fp_config=CONFIG_DEFAULT_PATH):
     """
     Check that a version of the local config.yaml matches to the actual config
     version as defined in config.default.yaml.

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -93,7 +93,7 @@ def handle_exception(exc_type, exc_value, exc_traceback):
 
 
 def copy_default_files():
-    fn = Path("config.yaml")
+    fn = Path(os.path.join(BASE_DIR, "config.yaml"))
     if not fn.exists():
         fn.write_text(
             "# Write down config entries differing from config.default.yaml\n\nrun: {}"

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -40,7 +40,8 @@ REGIONS_CONFIG = "regions_definition_config.yaml"
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 
 # absolute path to config.default.yaml
-CONFIG_DEFAULT_PATH = os.path.join(BASE_DIR, 'config.default.yaml')
+CONFIG_DEFAULT_PATH = os.path.join(BASE_DIR, "config.default.yaml")
+
 
 def check_config_version(config, fp_config=CONFIG_DEFAULT_PATH):
     """

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -36,11 +36,13 @@ REGION_COLS = ["geometry", "name", "x", "y", "country"]
 # filename of the regions definition config file
 REGIONS_CONFIG = "regions_definition_config.yaml"
 
-# absolute path to base directory (pypsa-earth)
+# prefix when running pypsa-earth rules in different directories (if running in pypsa-earth directory PREFIX='.')
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+RUN_DIR = os.path.abspath(os.getcwd())
+PREFIX = os.path.relpath(BASE_DIR, RUN_DIR)
 
 # absolute path to config.default.yaml
-CONFIG_DEFAULT_PATH = os.path.join(BASE_DIR, "config.default.yaml")
+CONFIG_DEFAULT_PATH = os.path.join(PREFIX, "config.default.yaml")
 
 
 def check_config_version(config, fp_config=CONFIG_DEFAULT_PATH):

--- a/scripts/build_demand_profiles.py
+++ b/scripts/build_demand_profiles.py
@@ -50,7 +50,7 @@ import pandas as pd
 import pypsa
 import scipy.sparse as sparse
 import xarray as xr
-from _helpers import configure_logging, create_logger, read_csv_nafix, read_osm_config
+from _helpers import configure_logging, create_logger, read_csv_nafix, read_osm_config, PREFIX
 from shapely.prepared import prep
 from shapely.validation import make_valid
 
@@ -121,7 +121,7 @@ def get_load_paths_gegis(ssp_parentfolder, config):
     for continent in region_load:
         sel_ext = ".nc"
         for ext in [".nc", ".csv"]:
-            load_path = os.path.join(str(load_dir), str(continent) + str(ext))
+            load_path = os.path.join(PREFIX, str(load_dir), str(continent) + str(ext))
             if os.path.exists(load_path):
                 sel_ext = ext
                 break

--- a/scripts/build_demand_profiles.py
+++ b/scripts/build_demand_profiles.py
@@ -50,7 +50,13 @@ import pandas as pd
 import pypsa
 import scipy.sparse as sparse
 import xarray as xr
-from _helpers import configure_logging, create_logger, read_csv_nafix, read_osm_config, BASE_DIR
+from _helpers import (
+    BASE_DIR,
+    configure_logging,
+    create_logger,
+    read_csv_nafix,
+    read_osm_config,
+)
 from shapely.prepared import prep
 from shapely.validation import make_valid
 

--- a/scripts/build_demand_profiles.py
+++ b/scripts/build_demand_profiles.py
@@ -50,7 +50,7 @@ import pandas as pd
 import pypsa
 import scipy.sparse as sparse
 import xarray as xr
-from _helpers import configure_logging, create_logger, read_csv_nafix, read_osm_config, PREFIX
+from _helpers import configure_logging, create_logger, read_csv_nafix, read_osm_config, BASE_DIR
 from shapely.prepared import prep
 from shapely.validation import make_valid
 
@@ -121,7 +121,7 @@ def get_load_paths_gegis(ssp_parentfolder, config):
     for continent in region_load:
         sel_ext = ".nc"
         for ext in [".nc", ".csv"]:
-            load_path = os.path.join(PREFIX, str(load_dir), str(continent) + str(ext))
+            load_path = os.path.join(BASE_DIR, str(load_dir), str(continent) + str(ext))
             if os.path.exists(load_path):
                 sel_ext = ext
                 break

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -202,7 +202,7 @@ import numpy as np
 import pandas as pd
 import progressbar as pgb
 import xarray as xr
-from _helpers import configure_logging, create_logger, BASE_DIR
+from _helpers import BASE_DIR, configure_logging, create_logger
 from add_electricity import load_powerplants
 from dask.distributed import Client
 from pypsa.geo import haversine

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -202,7 +202,7 @@ import numpy as np
 import pandas as pd
 import progressbar as pgb
 import xarray as xr
-from _helpers import configure_logging, create_logger
+from _helpers import configure_logging, create_logger, BASE_DIR
 from add_electricity import load_powerplants
 from dask.distributed import Client
 from pypsa.geo import haversine
@@ -559,7 +559,7 @@ if __name__ == "__main__":
     # filter plants for hydro
     if snakemake.wildcards.technology.startswith("hydro"):
         country_shapes = gpd.read_file(paths.country_shapes)
-        hydrobasins = gpd.read_file(resource["hydrobasins"])
+        hydrobasins = gpd.read_file(os.path.join(BASE_DIR, resource["hydrobasins"]))
         ppls = load_powerplants(snakemake.input.powerplants)
 
         hydro_ppls = ppls[ppls.carrier == "hydro"]

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -19,12 +19,12 @@ import rasterio
 import requests
 import xarray as xr
 from _helpers import (
+    BASE_DIR,
     configure_logging,
     create_logger,
     three_2_two_digits_country,
     two_2_three_digits_country,
     two_digits_2_name_country,
-    BASE_DIR
 )
 from numba import njit
 from numba.core import types
@@ -584,9 +584,7 @@ def convert_GDP(name_file_nc, year=2015, out_logging=False):
     GDP_nc = os.path.join(BASE_DIR, "data", "GDP", name_file_nc)  # Input filepath nc
 
     # path of the tif file
-    GDP_tif = os.path.join(
-        BASE_DIR, "data", "GDP", name_file_tif
-    )  # Input filepath nc
+    GDP_tif = os.path.join(BASE_DIR, "data", "GDP", name_file_tif)  # Input filepath nc
 
     # Check if file exists, otherwise throw exception
     if not os.path.exists(GDP_nc):
@@ -629,9 +627,7 @@ def load_GDP(
 
     # path of the nc file
     name_file_tif = name_file_nc[:-2] + "tif"
-    GDP_tif = os.path.join(
-        BASE_DIR, "data", "GDP", name_file_tif
-    )  # Input filepath tif
+    GDP_tif = os.path.join(BASE_DIR, "data", "GDP", name_file_tif)  # Input filepath tif
 
     if update | (not os.path.exists(GDP_tif)):
         if out_logging:

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -24,6 +24,7 @@ from _helpers import (
     three_2_two_digits_country,
     two_2_three_digits_country,
     two_digits_2_name_country,
+    BASE_DIR
 )
 from numba import njit
 from numba.core import types
@@ -85,7 +86,7 @@ def download_GADM(country_code, update=False, out_logging=False):
     GADM_url = f"https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/{GADM_filename}.gpkg"
 
     GADM_inputfile_gpkg = os.path.join(
-        os.getcwd(),
+        BASE_DIR,
         "data",
         "gadm",
         GADM_filename,
@@ -489,7 +490,7 @@ def download_WorldPop_standard(
         ]
 
     WorldPop_inputfile = os.path.join(
-        os.getcwd(), "data", "WorldPop", WorldPop_filename
+        BASE_DIR, "data", "WorldPop", WorldPop_filename
     )  # Input filepath tif
 
     if not os.path.exists(WorldPop_inputfile) or update is True:
@@ -543,7 +544,7 @@ def download_WorldPop_API(
     WorldPop_filename = f"{two_2_three_digits_country(country_code).lower()}_ppp_{year}_UNadj_constrained.tif"
     # Request to get the file
     WorldPop_inputfile = os.path.join(
-        os.getcwd(), "data", "WorldPop", WorldPop_filename
+        BASE_DIR, "data", "WorldPop", WorldPop_filename
     )  # Input filepath tif
     os.makedirs(os.path.dirname(WorldPop_inputfile), exist_ok=True)
     year_api = int(str(year)[2:])
@@ -580,11 +581,11 @@ def convert_GDP(name_file_nc, year=2015, out_logging=False):
     name_file_tif = name_file_nc[:-2] + "tif"
 
     # path of the nc file
-    GDP_nc = os.path.join(os.getcwd(), "data", "GDP", name_file_nc)  # Input filepath nc
+    GDP_nc = os.path.join(BASE_DIR, "data", "GDP", name_file_nc)  # Input filepath nc
 
     # path of the tif file
     GDP_tif = os.path.join(
-        os.getcwd(), "data", "GDP", name_file_tif
+        BASE_DIR, "data", "GDP", name_file_tif
     )  # Input filepath nc
 
     # Check if file exists, otherwise throw exception
@@ -629,7 +630,7 @@ def load_GDP(
     # path of the nc file
     name_file_tif = name_file_nc[:-2] + "tif"
     GDP_tif = os.path.join(
-        os.getcwd(), "data", "GDP", name_file_tif
+        BASE_DIR, "data", "GDP", name_file_tif
     )  # Input filepath tif
 
     if update | (not os.path.exists(GDP_tif)):

--- a/scripts/download_osm_data.py
+++ b/scripts/download_osm_data.py
@@ -30,7 +30,7 @@ import os
 import shutil
 from pathlib import Path
 
-from _helpers import configure_logging, create_logger, read_osm_config, BASE_DIR
+from _helpers import BASE_DIR, configure_logging, create_logger, read_osm_config
 from earth_osm import eo
 
 logger = create_logger(__name__)
@@ -99,7 +99,9 @@ if __name__ == "__main__":
 
     run = snakemake.config.get("run", {})
     RDIR = run["name"] + "/" if run.get("name") else ""
-    store_path_resources = Path.joinpath(Path(BASE_DIR), "resources", RDIR, "osm", "raw")
+    store_path_resources = Path.joinpath(
+        Path(BASE_DIR), "resources", RDIR, "osm", "raw"
+    )
     store_path_data = Path.joinpath(Path(BASE_DIR), "data", "osm")
     country_list = country_list_to_geofk(snakemake.params.countries)
 

--- a/scripts/download_osm_data.py
+++ b/scripts/download_osm_data.py
@@ -30,7 +30,7 @@ import os
 import shutil
 from pathlib import Path
 
-from _helpers import configure_logging, create_logger, read_osm_config
+from _helpers import configure_logging, create_logger, read_osm_config, BASE_DIR
 from earth_osm import eo
 
 logger = create_logger(__name__)
@@ -99,8 +99,8 @@ if __name__ == "__main__":
 
     run = snakemake.config.get("run", {})
     RDIR = run["name"] + "/" if run.get("name") else ""
-    store_path_resources = Path.joinpath(Path().cwd(), "resources", RDIR, "osm", "raw")
-    store_path_data = Path.joinpath(Path().cwd(), "data", "osm")
+    store_path_resources = Path.joinpath(Path(BASE_DIR), "resources", RDIR, "osm", "raw")
+    store_path_data = Path.joinpath(Path(BASE_DIR), "data", "osm")
     country_list = country_list_to_geofk(snakemake.params.countries)
 
     eo.save_osm_data(

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -65,7 +65,7 @@ import numpy as np
 import pandas as pd
 import pypsa
 import requests
-from _helpers import configure_logging, create_logger, BASE_DIR
+from _helpers import BASE_DIR, configure_logging, create_logger
 from add_electricity import load_costs, update_transmission_costs
 
 idx = pd.IndexSlice
@@ -89,7 +89,10 @@ def download_emission_data():
                 file.write(rq.content)
         file_path = os.path.join(BASE_DIR, "data/co2.zip")
         with ZipFile(file_path, "r") as zipObj:
-            zipObj.extract("v60_CO2_excl_short-cycle_org_C_1970_2018.xls", os.path.join(BASE_DIR, "data"))
+            zipObj.extract(
+                "v60_CO2_excl_short-cycle_org_C_1970_2018.xls",
+                os.path.join(BASE_DIR, "data"),
+            )
         os.remove(file_path)
         return "v60_CO2_excl_short-cycle_org_C_1970_2018.xls"
     except:

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -65,7 +65,7 @@ import numpy as np
 import pandas as pd
 import pypsa
 import requests
-from _helpers import configure_logging, create_logger
+from _helpers import configure_logging, create_logger, BASE_DIR
 from add_electricity import load_costs, update_transmission_costs
 
 idx = pd.IndexSlice
@@ -85,11 +85,11 @@ def download_emission_data():
     try:
         url = "https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/EDGAR/datasets/v60_GHG/CO2_excl_short-cycle_org_C/v60_GHG_CO2_excl_short-cycle_org_C_1970_2018.zip"
         with requests.get(url) as rq:
-            with open("data/co2.zip", "wb") as file:
+            with open(os.path.join(BASE_DIR, "data/co2.zip"), "wb") as file:
                 file.write(rq.content)
-        file_path = "data/co2.zip"
+        file_path = os.path.join(BASE_DIR, "data/co2.zip")
         with ZipFile(file_path, "r") as zipObj:
-            zipObj.extract("v60_CO2_excl_short-cycle_org_C_1970_2018.xls", "data")
+            zipObj.extract("v60_CO2_excl_short-cycle_org_C_1970_2018.xls", os.path.join(BASE_DIR, "data"))
         os.remove(file_path)
         return "v60_CO2_excl_short-cycle_org_C_1970_2018.xls"
     except:
@@ -117,7 +117,7 @@ def emission_extractor(filename, emission_year, country_names):
     """
 
     # data reading process
-    datapath = os.path.join(os.getcwd(), "data", filename)
+    datapath = os.path.join(BASE_DIR, "data", filename)
     df = pd.read_excel(datapath, sheet_name="v6.0_EM_CO2_fossil_IPCC1996", skiprows=8)
     df.columns = df.iloc[0]
     df = df.set_index("Country_code_A3")

--- a/scripts/retrieve_databundle_light.py
+++ b/scripts/retrieve_databundle_light.py
@@ -93,7 +93,7 @@ from _helpers import (
     create_country_list,
     create_logger,
     progress_retrieve,
-    PREFIX
+    BASE_DIR
 )
 from google_drive_downloader import GoogleDriveDownloader as gdd
 from tqdm import tqdm
@@ -144,7 +144,7 @@ def download_and_unzip_zenodo(config, rootpath, hot_run=True, disable_progress=F
     """
     resource = config["category"]
     file_path = os.path.join(rootpath, "tempfile.zip")
-    destination = os.path.join(PREFIX, config["destination"])
+    destination = os.path.join(BASE_DIR, config["destination"])
     url = config["urls"]["zenodo"]
 
     if hot_run:
@@ -189,7 +189,7 @@ def download_and_unzip_gdrive(config, rootpath, hot_run=True, disable_progress=F
     """
     resource = config["category"]
     file_path = os.path.join(rootpath, "tempfile.zip")
-    destination = os.path.join(PREFIX, config["destination"])
+    destination = os.path.join(BASE_DIR, config["destination"])
     url = config["urls"]["gdrive"]
 
     # retrieve file_id from path
@@ -267,7 +267,7 @@ def download_and_unzip_protectedplanet(
     """
     resource = config["category"]
     file_path = os.path.join(rootpath, "tempfile_wpda.zip")
-    destination = os.path.join(PREFIX, config["destination"])
+    destination = os.path.join(BASE_DIR, config["destination"])
     url = config["urls"]["protectedplanet"]
 
     def get_first_day_of_month(date):
@@ -439,7 +439,7 @@ def download_and_unzip_direct(config, rootpath, hot_run=True, disable_progress=F
     True when download is successful, False otherwise
     """
     resource = config["category"]
-    destination = os.path.join(PREFIX, config["destination"])
+    destination = os.path.join(BASE_DIR, config["destination"])
     url = config["urls"]["direct"]
 
     file_path = os.path.join(destination, os.path.basename(url))
@@ -493,7 +493,7 @@ def download_and_unzip_hydrobasins(
     True when download is successful, False otherwise
     """
     resource = config["category"]
-    destination = os.path.join(PREFIX, config["destination"])
+    destination = os.path.join(BASE_DIR, config["destination"])
     url_templ = config["urls"]["hydrobasins"]["base_url"]
     suffix_list = config["urls"]["hydrobasins"]["suffixes"]
 
@@ -544,7 +544,7 @@ def download_and_unzip_post(config, rootpath, hot_run=True, disable_progress=Fal
     True when download is successful, False otherwise
     """
     resource = config["category"]
-    destination = os.path.join(PREFIX, config["destination"])
+    destination = os.path.join(BASE_DIR, config["destination"])
 
     # load data for post method
     postdata = config["urls"]["post"]
@@ -793,8 +793,8 @@ def datafiles_retrivedatabundle(config):
 
 
 def merge_hydrobasins_shape(config_hydrobasin, hydrobasins_level):
-    basins_path = os.path.join(PREFIX, config_hydrobasin["destination"])
-    output_fl = os.path.join(PREFIX, config_hydrobasin["output"][0])
+    basins_path = os.path.join(BASE_DIR, config_hydrobasin["destination"])
+    output_fl = os.path.join(BASE_DIR, config_hydrobasin["output"][0])
 
     files_to_merge = [
         "hybas_{0:s}_lev{1:02d}_v1c.shp".format(suffix, hydrobasins_level)

--- a/scripts/retrieve_databundle_light.py
+++ b/scripts/retrieve_databundle_light.py
@@ -89,11 +89,11 @@ import geopandas as gpd
 import pandas as pd
 import yaml
 from _helpers import (
+    BASE_DIR,
     configure_logging,
     create_country_list,
     create_logger,
     progress_retrieve,
-    BASE_DIR
 )
 from google_drive_downloader import GoogleDriveDownloader as gdd
 from tqdm import tqdm

--- a/scripts/retrieve_databundle_light.py
+++ b/scripts/retrieve_databundle_light.py
@@ -93,6 +93,7 @@ from _helpers import (
     create_country_list,
     create_logger,
     progress_retrieve,
+    PREFIX
 )
 from google_drive_downloader import GoogleDriveDownloader as gdd
 from tqdm import tqdm
@@ -823,9 +824,6 @@ if __name__ == "__main__":
     tutorial = snakemake.params.tutorial
     countries = snakemake.params.countries
     logger.info(f"Retrieving data for {len(countries)} countries.")
-
-    # get prefix (exists only if importing rule as import, else empty string)
-    PREFIX = snakemake.log[0].split("log")[0]
 
     # load enable configuration
     config_enable = snakemake.config["enable"]

--- a/scripts/retrieve_databundle_light.py
+++ b/scripts/retrieve_databundle_light.py
@@ -143,7 +143,7 @@ def download_and_unzip_zenodo(config, rootpath, hot_run=True, disable_progress=F
     """
     resource = config["category"]
     file_path = os.path.join(rootpath, "tempfile.zip")
-    destination = os.path.relpath(config["destination"])
+    destination = os.path.join(PREFIX, config["destination"])
     url = config["urls"]["zenodo"]
 
     if hot_run:
@@ -188,7 +188,7 @@ def download_and_unzip_gdrive(config, rootpath, hot_run=True, disable_progress=F
     """
     resource = config["category"]
     file_path = os.path.join(rootpath, "tempfile.zip")
-    destination = os.path.relpath(config["destination"])
+    destination = os.path.join(PREFIX, config["destination"])
     url = config["urls"]["gdrive"]
 
     # retrieve file_id from path
@@ -266,7 +266,7 @@ def download_and_unzip_protectedplanet(
     """
     resource = config["category"]
     file_path = os.path.join(rootpath, "tempfile_wpda.zip")
-    destination = os.path.relpath(config["destination"])
+    destination = os.path.join(PREFIX, config["destination"])
     url = config["urls"]["protectedplanet"]
 
     def get_first_day_of_month(date):
@@ -438,7 +438,7 @@ def download_and_unzip_direct(config, rootpath, hot_run=True, disable_progress=F
     True when download is successful, False otherwise
     """
     resource = config["category"]
-    destination = os.path.relpath(config["destination"])
+    destination = os.path.join(PREFIX, config["destination"])
     url = config["urls"]["direct"]
 
     file_path = os.path.join(destination, os.path.basename(url))
@@ -492,7 +492,7 @@ def download_and_unzip_hydrobasins(
     True when download is successful, False otherwise
     """
     resource = config["category"]
-    destination = os.path.relpath(config["destination"])
+    destination = os.path.join(PREFIX, config["destination"])
     url_templ = config["urls"]["hydrobasins"]["base_url"]
     suffix_list = config["urls"]["hydrobasins"]["suffixes"]
 
@@ -543,7 +543,7 @@ def download_and_unzip_post(config, rootpath, hot_run=True, disable_progress=Fal
     True when download is successful, False otherwise
     """
     resource = config["category"]
-    destination = os.path.relpath(config["destination"])
+    destination = os.path.join(PREFIX, config["destination"])
 
     # load data for post method
     postdata = config["urls"]["post"]
@@ -792,8 +792,8 @@ def datafiles_retrivedatabundle(config):
 
 
 def merge_hydrobasins_shape(config_hydrobasin, hydrobasins_level):
-    basins_path = config_hydrobasin["destination"]
-    output_fl = config_hydrobasin["output"][0]
+    basins_path = os.path.join(PREFIX, config_hydrobasin["destination"])
+    output_fl = os.path.join(PREFIX, config_hydrobasin["output"][0])
 
     files_to_merge = [
         "hybas_{0:s}_lev{1:02d}_v1c.shp".format(suffix, hydrobasins_level)
@@ -823,6 +823,9 @@ if __name__ == "__main__":
     tutorial = snakemake.params.tutorial
     countries = snakemake.params.countries
     logger.info(f"Retrieving data for {len(countries)} countries.")
+
+    # get prefix (exists only if importing rule as import, else empty string)
+    PREFIX = snakemake.log[0].split("log")[0]
 
     # load enable configuration
     config_enable = snakemake.config["enable"]


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. Here I propose to use absolute path to `config.default.yaml` in `_helpers.py` script. Such change is important while importing PyPSA-Earth rules elsewhere and running then in external directories within another Snakemake. This is helpful for setting workflow. 

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
