### PR TITLE
Fix CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ by
 
 ## Development Status: **Stable and Active**
 
-[![Test workflows](https://github.com/pypsa-meets-earth/pypsa-earth/actions/workflows/test.yaml/badge.svg)](https://github.com/pypsa-meets-earth/pypsa-earth/actions/workflows/ci.yaml)
+[![Test workflows](https://github.com/pypsa-meets-earth/pypsa-earth/actions/workflows/ci.yml/badge.svg)](https://github.com/pypsa-meets-earth/pypsa-earth/actions/workflows/ci.yml)
 [![Documentation Status](https://readthedocs.org/projects/pypsa-earth/badge/?version=latest)](https://pypsa-earth.readthedocs.io/en/latest/?badge=latest)
 ![Size](https://img.shields.io/github/repo-size/pypsa-meets-earth/pypsa-earth)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPLv3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)

--- a/README.md
+++ b/README.md
@@ -15,9 +15,7 @@ by
 
 ## Development Status: **Stable and Active**
 
-[![Status Linux](https://github.com/pypsa-meets-earth/pypsa-earth/actions/workflows/ci-linux.yaml/badge.svg?branch=main&event=push)](https://github.com/pypsa-meets-earth/pypsa-earth/actions/workflows/ci-linux.yaml)
-[![Status Mac](https://github.com/pypsa-meets-earth/pypsa-earth/actions/workflows/ci-mac.yaml/badge.svg?branch=main&event=push)](https://github.com/pypsa-meets-earth/pypsa-earth/actions/workflows/ci-mac.yaml)
-[![Status Windows](https://github.com/pypsa-meets-earth/pypsa-earth/actions/workflows/ci-windows.yaml/badge.svg?branch=main&event=push)](https://github.com/pypsa-meets-earth/pypsa-earth/actions/workflows/ci-windows.yaml)
+[![Test workflows](https://github.com/pypsa-meets-earth/pypsa-earth/actions/workflows/test.yaml/badge.svg)](https://github.com/pypsa-meets-earth/pypsa-earth/actions/workflows/ci.yaml)
 [![Documentation Status](https://readthedocs.org/projects/pypsa-earth/badge/?version=latest)](https://pypsa-earth.readthedocs.io/en/latest/?badge=latest)
 ![Size](https://img.shields.io/github/repo-size/pypsa-meets-earth/pypsa-earth)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPLv3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,17 +14,9 @@ Welcome to the PyPSA-Earth documentation!
 .. image:: https://img.shields.io/github/v/release/pypsa-meets-earth/pypsa-earth?include_prereleases
     :alt: GitHub release (latest by date including pre-releases)
 
-.. image:: https://github.com/pypsa-meets-earth/pypsa-earth/actions/workflows/ci-linux.yaml/badge.svg
-    :target: https://github.com/pypsa-meets-earth/pypsa-earth/actions
-    :alt: CI Linux
-
-.. image:: https://github.com/pypsa-meets-earth/pypsa-earth/actions/workflows/ci-mac.yaml/badge.svg
-    :target: https://github.com/pypsa-meets-earth/pypsa-earth/actions
-    :alt: CI Mac
-
-.. image:: https://github.com/pypsa-meets-earth/pypsa-earth/actions/workflows/ci-windows.yaml/badge.svg
-    :target: https://github.com/pypsa-meets-earth/pypsa-earth/actions
-    :alt: CI Windows
+.. image:: https://github.com/pypsa-meets-earth/pypsa-earth/actions/workflows/test.yaml/badge.svg
+    :target: https://github.com/pypsa-meets-earth/pypsa-earth/actions/workflows/ci.yaml
+    :alt: CI
 
 .. image:: https://readthedocs.org/projects/pypsa-earth/badge/?version=latest
     :target: https://pypsa-earth.readthedocs.io/en/latest/?badge=latest

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,8 +14,8 @@ Welcome to the PyPSA-Earth documentation!
 .. image:: https://img.shields.io/github/v/release/pypsa-meets-earth/pypsa-earth?include_prereleases
     :alt: GitHub release (latest by date including pre-releases)
 
-.. image:: https://github.com/pypsa-meets-earth/pypsa-earth/actions/workflows/test.yaml/badge.svg
-    :target: https://github.com/pypsa-meets-earth/pypsa-earth/actions/workflows/ci.yaml
+.. image:: https://github.com/pypsa-meets-earth/pypsa-earth/actions/workflows/ci.yml/badge.svg
+    :target: https://github.com/pypsa-meets-earth/pypsa-earth/actions/workflows/ci.yml
     :alt: CI
 
 .. image:: https://readthedocs.org/projects/pypsa-earth/badge/?version=latest


### PR DESCRIPTION
Fixes display of CI badges.

## Changes proposed in this Pull Request

OS-specific badges replaced by a single CI one to account for the changed structure of CI workflow.


## Checklist

- [ ] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
