### PR TITLE
feat: add new cutout for oceania

### DIFF
--- a/configs/bundle_config.yaml
+++ b/configs/bundle_config.yaml
@@ -281,6 +281,19 @@ databundles:
     disable_by_opt:
       build_cutout: [all]
 
+  # cutouts bundle of the cutouts folder for Oceania continent
+  # Coordinate bounds: [min_x = 80, max_x = 180.0, min_y = -50, max_y = 20.]
+  # Size about 19 GB (zipped)
+  bundle_cutouts_oceania:
+    countries: [Oceania]
+    category: cutouts
+    destination: "cutouts"
+    urls:
+      gdrive: https://drive.google.com/file/d/1R8ELkXmW8jBBUFWRY0sbf-T14SJl4EUY/view?usp=sharing
+    output: [cutouts/cutout-2013-era5.nc]
+    disable_by_opt:
+      build_cutout: [all]
+
   # cutouts bundle of the cutouts folder for the northern hemisphere
   # Note: this includes nearly the entire northern emisphere [long +-180, lat 1-85]. Size about 81GB (zipped)
   #bundle_cutouts_northern_hemisphere:

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -32,6 +32,9 @@ E.g. if a new rule becomes available describe how to use it `make test` and in o
 
 * Fix pre-commit docformatter python issue. `PR #1153 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1153>`__
 
+* Include a dedicated cutout for Oceania in bundle_config.yaml `PR #1157 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1157>`_
+
+
 PyPSA-Earth 0.4.1
 =================
 


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request
This PR includes link to be able to download cutout specific to Oceania continent.
The cutout was generated using this cordinates `[min_x = 80., max_x = 180.0, min_y = -50, max_y = 20.]`

Thanks to @davide-f for helping out.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
