### PR TITLE
Convert conventional ppls from generators to link with existing capacity

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1060,6 +1060,7 @@ if not config["custom_data"]["gas_network"]:
 rule prepare_sector_network:
     params:
         costs=config["costs"],
+        electricity=config["electricity"],
     input:
         network=RESDIR
         + "prenetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_presec.nc",

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -516,7 +516,10 @@ sector:
     blue_share: 0.40
     pink_share: 0.05
   coal:
+    spatial_coal: true
     shift_to_elec: true # If true, residential and services demand of coal is shifted to electricity. If false, the final energy demand of coal is disregarded
+  lignite:
+    spatial_lignite: false
 
   international_bunkers: false #Whether or not to count the emissions of international aviation and navigation
 
@@ -673,7 +676,11 @@ sector:
 
   conventional_generation: # generator : carrier
     OCGT: gas
-    #Gen_Test: oil # Just for testing purposes
+    oil: oil
+    coal: coal
+    lignite: lignite
+    biomass: biomass
+  keep_existing_capacities: true
 
 
 solving:

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -664,6 +664,8 @@ def define_spatial(nodes, options):
         spatial.coal.locations = ["Africa"]
         spatial.coal.industry = ["Africa coal for industry"]
 
+    spatial.coal.df = pd.DataFrame(vars(spatial.coal), index=spatial.nodes)
+
     # lignite
 
     spatial.lignite = SimpleNamespace()
@@ -674,6 +676,8 @@ def define_spatial(nodes, options):
     else:
         spatial.lignite.nodes = ["Africa lignite"]
         spatial.lignite.locations = ["Africa"]
+
+    spatial.lignite.df = pd.DataFrame(vars(spatial.lignite), index=spatial.nodes)
 
     return spatial
 
@@ -2707,9 +2711,11 @@ def remove_elec_base_techs(n):
     since they're re-added here using links.
     """
     conventional_generators = options.get("conventional_generation", {})
-    to_remove = list(conventional_generators.keys())
+    to_remove = pd.Index(conventional_generators.keys())
     # remove only conventional_generation carriers present in the network
-    to_remove = pd.Index(n.generators.carrier.unique()).intersection(to_remove)
+    to_remove = pd.Index(
+        snakemake.params.electricity.get("conventional_carriers", [])
+    ).intersection(to_remove)
 
     if to_remove.empty:
         return

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -131,65 +131,6 @@ def add_generation(n, costs):
         n.carriers.loc[carrier, "co2_emissions"] = 0
 
 
-def add_oil(n, costs):
-    """
-    Function to add oil carrier and bus to network.
-
-    If-Statements are required in case oil was already added from config
-    ['sector']['conventional_generation'] Oil is copper plated
-    """
-    # TODO function will not be necessary if conventionals are added using "add_carrier_buses()"
-    # TODO before using add_carrier_buses: remove_elec_base_techs(n), otherwise carriers are added double
-    # spatial.gas = SimpleNamespace()
-
-    # Set the "co2_emissions" of the carrier "oil" to 0, because the emissions of oil usage taken from the spatial.oil.nodes are accounted separately (directly linked to the co2 atmosphere bus). Setting the carrier to 0 here avoids double counting. Be aware to link oil emissions to the co2 atmosphere bus.
-    n.carriers.loc["oil", "co2_emissions"] = 0
-    # print("co2_emissions of oil set to 0 for testing")  # TODO add logger.info
-
-    n.madd(
-        "Bus",
-        spatial.oil.nodes,
-        location=spatial.oil.locations,
-        carrier="oil",
-    )
-
-    # if "Africa oil" not in n.buses.index:
-
-    #     n.add("Bus", "Africa oil", location="Africa", carrier="oil")
-
-    # if "Africa oil Store" not in n.stores.index:
-
-    e_initial = (snakemake.config["fossil_reserves"]).get("oil", 0) * 1e6
-    # could correct to e.g. 0.001 EUR/kWh * annuity and O&M
-    n.madd(
-        "Store",
-        [oil_bus + " Store" for oil_bus in spatial.oil.nodes],
-        bus=spatial.oil.nodes,
-        e_nom_extendable=True,
-        e_cyclic=False,
-        carrier="oil",
-        e_initial=e_initial,
-        marginal_cost=costs.at["oil", "fuel"],
-    )
-
-    # TODO check non-unique generators
-    n.madd(
-        "Generator",
-        spatial.oil.nodes,
-        bus=spatial.oil.nodes,
-        p_nom_extendable=True,
-        carrier="oil",
-        marginal_cost=costs.at["oil", "fuel"],
-    )
-
-
-def add_gas(n, costs):
-
-    gas_nodes = vars(spatial)["gas"].nodes
-
-    add_carrier_buses(n, "gas", gas_nodes)
-
-
 def H2_liquid_fossil_conversions(n, costs):
     """
     Function to add conversions between H2 and liquid fossil Carrier and bus is
@@ -2898,10 +2839,6 @@ if __name__ == "__main__":
     # remove conventional generators built in elec-only model
     remove_elec_base_techs(n)
 
-    # TODO This might be transferred to add_generation, but before apply remove_elec_base_techs(n) from PyPSA-Eur-Sec
-    # add_oil(n, costs)
-
-    # add_gas(n, costs)
     add_generation(n, costs)
 
     add_hydrogen(n, costs)  # TODO add costs

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -659,14 +659,10 @@ def define_spatial(nodes, options):
         spatial.coal.nodes = nodes + " coal"
         spatial.coal.locations = nodes
         spatial.coal.industry = nodes + " coal for industry"
-        if snakemake.config["sector"]["cc"]:
-            spatial.coal.industry_cc = nodes + " coal for industry CC"
     else:
         spatial.coal.nodes = ["Africa coal"]
         spatial.coal.locations = ["Africa"]
         spatial.coal.industry = ["Africa coal for industry"]
-        if snakemake.config["sector"]["cc"]:
-            spatial.coal.industry_cc = ["Africa coal for industry CC"]
 
     # lignite
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -622,8 +622,8 @@ def define_spatial(nodes, options):
     spatial.oil = SimpleNamespace()
 
     if options["oil"]["spatial_oil"]:
-        spatial.oil.nodes = spatial.nodes + " oil"
-        spatial.oil.locations = spatial.nodes
+        spatial.oil.nodes = nodes + " oil"
+        spatial.oil.locations = nodes
     else:
         spatial.oil.nodes = ["Africa oil"]
         spatial.oil.locations = ["Africa"]
@@ -633,13 +633,13 @@ def define_spatial(nodes, options):
     spatial.gas = SimpleNamespace()
 
     if options["gas"]["spatial_gas"]:
-        spatial.gas.nodes = spatial.nodes + " gas"
-        spatial.gas.locations = spatial.nodes
-        spatial.gas.biogas = spatial.nodes + " biogas"
-        spatial.gas.industry = spatial.nodes + " gas for industry"
+        spatial.gas.nodes = nodes + " gas"
+        spatial.gas.locations = nodes
+        spatial.gas.biogas = nodes + " biogas"
+        spatial.gas.industry = nodes + " gas for industry"
         if snakemake.config["sector"]["cc"]:
-            spatial.gas.industry_cc = spatial.nodes + " gas for industry CC"
-        spatial.gas.biogas_to_gas = spatial.nodes + " biogas to gas"
+            spatial.gas.industry_cc = nodes + " gas for industry CC"
+        spatial.gas.biogas_to_gas = nodes + " biogas to gas"
     else:
         spatial.gas.nodes = ["Africa gas"]
         spatial.gas.locations = ["Africa"]
@@ -650,6 +650,34 @@ def define_spatial(nodes, options):
         spatial.gas.biogas_to_gas = ["Africa biogas to gas"]
 
     spatial.gas.df = pd.DataFrame(vars(spatial.gas), index=spatial.nodes)
+
+    # coal
+
+    spatial.coal = SimpleNamespace()
+
+    if options["coal"]["spatial_coal"]:
+        spatial.coal.nodes = nodes + " coal"
+        spatial.coal.locations = nodes
+        spatial.coal.industry = nodes + " coal for industry"
+        if snakemake.config["sector"]["cc"]:
+            spatial.coal.industry_cc = nodes + " coal for industry CC"
+    else:
+        spatial.coal.nodes = ["Africa coal"]
+        spatial.coal.locations = ["Africa"]
+        spatial.coal.industry = ["Africa coal for industry"]
+        if snakemake.config["sector"]["cc"]:
+            spatial.coal.industry_cc = ["Africa coal for industry CC"]
+
+    # lignite
+
+    spatial.lignite = SimpleNamespace()
+
+    if options["lignite"]["spatial_lignite"]:
+        spatial.lignite.nodes = nodes + " lignite"
+        spatial.lignite.locations = nodes
+    else:
+        spatial.lignite.nodes = ["Africa lignite"]
+        spatial.lignite.locations = ["Africa"]
 
     return spatial
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -622,8 +622,8 @@ def define_spatial(nodes, options):
         spatial.biomass.industry = nodes + " solid biomass for industry"
         spatial.biomass.industry_cc = nodes + " solid biomass for industry CC"
     else:
-        spatial.biomass.nodes = ["Africa solid biomass"]
-        spatial.biomass.locations = ["Africa"]
+        spatial.biomass.nodes = ["Earth solid biomass"]
+        spatial.biomass.locations = ["Earth"]
         spatial.biomass.industry = ["solid biomass for industry"]
         spatial.biomass.industry_cc = ["solid biomass for industry CC"]
 
@@ -641,7 +641,7 @@ def define_spatial(nodes, options):
         # spatial.co2.y = (n.buses.loc[list(nodes)].y.values,)
     else:
         spatial.co2.nodes = ["co2 stored"]
-        spatial.co2.locations = ["Africa"]
+        spatial.co2.locations = ["Earth"]
         spatial.co2.vents = ["co2 vent"]
         # spatial.co2.x = (0,)
         # spatial.co2.y = 0
@@ -656,8 +656,8 @@ def define_spatial(nodes, options):
         spatial.oil.nodes = nodes + " oil"
         spatial.oil.locations = nodes
     else:
-        spatial.oil.nodes = ["Africa oil"]
-        spatial.oil.locations = ["Africa"]
+        spatial.oil.nodes = ["Earth oil"]
+        spatial.oil.locations = ["Earth"]
 
     # gas
 
@@ -672,13 +672,13 @@ def define_spatial(nodes, options):
             spatial.gas.industry_cc = nodes + " gas for industry CC"
         spatial.gas.biogas_to_gas = nodes + " biogas to gas"
     else:
-        spatial.gas.nodes = ["Africa gas"]
-        spatial.gas.locations = ["Africa"]
-        spatial.gas.biogas = ["Africa biogas"]
+        spatial.gas.nodes = ["Earth gas"]
+        spatial.gas.locations = ["Earth"]
+        spatial.gas.biogas = ["Earth biogas"]
         spatial.gas.industry = ["gas for industry"]
         if snakemake.config["sector"]["cc"]:
             spatial.gas.industry_cc = ["gas for industry CC"]
-        spatial.gas.biogas_to_gas = ["Africa biogas to gas"]
+        spatial.gas.biogas_to_gas = ["Earth biogas to gas"]
 
     spatial.gas.df = pd.DataFrame(vars(spatial.gas), index=spatial.nodes)
 
@@ -691,9 +691,9 @@ def define_spatial(nodes, options):
         spatial.coal.locations = nodes
         spatial.coal.industry = nodes + " coal for industry"
     else:
-        spatial.coal.nodes = ["Africa coal"]
-        spatial.coal.locations = ["Africa"]
-        spatial.coal.industry = ["Africa coal for industry"]
+        spatial.coal.nodes = ["Earth coal"]
+        spatial.coal.locations = ["Earth"]
+        spatial.coal.industry = ["Earth coal for industry"]
 
     spatial.coal.df = pd.DataFrame(vars(spatial.coal), index=spatial.nodes)
 
@@ -705,8 +705,8 @@ def define_spatial(nodes, options):
         spatial.lignite.nodes = nodes + " lignite"
         spatial.lignite.locations = nodes
     else:
-        spatial.lignite.nodes = ["Africa lignite"]
-        spatial.lignite.locations = ["Africa"]
+        spatial.lignite.nodes = ["Earth lignite"]
+        spatial.lignite.locations = ["Earth"]
 
     spatial.lignite.df = pd.DataFrame(vars(spatial.lignite), index=spatial.nodes)
 
@@ -926,7 +926,7 @@ def add_co2(n, costs):
     n.add(
         "Bus",
         "co2 atmosphere",
-        location="Africa",  # TODO Ignoed by pypsa check
+        location="Earth",  # TODO Ignoed by pypsa check
         carrier="co2",
     )
 
@@ -1520,7 +1520,7 @@ def add_industry(n, costs):
 
     # industrial_demand.set_index("TWh/a (MtCO2/a)", inplace=True)
 
-    # n.add("Bus", "gas for industry", location="Africa", carrier="gas for industry")
+    # n.add("Bus", "gas for industry", location="Earth", carrier="gas for industry")
     n.madd(
         "Bus",
         spatial.gas.industry,
@@ -1546,7 +1546,7 @@ def add_industry(n, costs):
     n.madd(
         "Link",
         spatial.gas.industry,
-        # bus0="Africa gas",
+        # bus0="Earth gas",
         bus0=spatial.gas.nodes,
         # bus1="gas for industry",
         bus1=spatial.gas.industry,
@@ -1561,7 +1561,7 @@ def add_industry(n, costs):
             "Link",
             spatial.gas.industry_cc,
             # suffix=" gas for industry CC",
-            # bus0="Africa gas",
+            # bus0="Earth gas",
             bus0=spatial.gas.nodes,
             bus1=spatial.gas.industry,
             bus2="co2 atmosphere",
@@ -1696,7 +1696,7 @@ def add_industry(n, costs):
         p_set=industrial_elec,
     )
 
-    n.add("Bus", "process emissions", location="Africa", carrier="process emissions")
+    n.add("Bus", "process emissions", location="Earth", carrier="process emissions")
 
     # this should be process emissions fossil+feedstock
     # then need load on atmosphere for feedstock emissions that are currently going to atmosphere via Link Fischer-Tropsch demand
@@ -2212,7 +2212,7 @@ def add_heat(n, costs):
                 n.madd(
                     "Link",
                     h_nodes[name] + " urban central gas CHP CC",
-                    # bus0="Africa gas",
+                    # bus0="Earth gas",
                     bus0=spatial.gas.nodes,
                     bus1=h_nodes[name],
                     bus2=h_nodes[name] + " urban central heat",
@@ -2253,7 +2253,7 @@ def add_heat(n, costs):
                 "Link",
                 h_nodes[name] + f" {name} micro gas CHP",
                 p_nom_extendable=True,
-                # bus0="Africa gas",
+                # bus0="Earth gas",
                 bus0=spatial.gas.nodes,
                 bus1=h_nodes[name],
                 bus2=h_nodes[name] + f" {name} heat",


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. I am proposing to convert conventional generators (e.g. coal, lignite, biomass, oil and etc) from generators to link with stores and generators. Currently it is implemented for OCGT in `add_generation` function of `prepare_sector_networks` and oil in `add_oil` functions. However, the current implementation is not fully correct as existing OCGT generators from elec network is not removed when added as a link. 

This PR aims to convert technologies listed in `conventional_generation` section of `sector` section of config to links, and remove from generators. Having stores and links for conventional carriers is practical when defining new technologies that uses those carriers (eg. carbon capture). In addition, it will be possible to keep existing capacities and transfer them to links based on the option in config.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
