### PR TITLE
Drop non string entries in country column of CO2_emissions data in `prepare_transport_data_input`

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -42,6 +42,8 @@ E.g. if a new rule becomes available describe how to use it `make test` and in o
 
 * Fix bugs in `prepare_sector_network.py` related to links with H2 buses and bug of re-addition of H2 and battery carriers in present `PR #1145 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1145>`_
 
+* Drop entries that contain non-string elements in country column of `CO2_emissions_csv` data in `prepare_transport_data_input.py` script `PR #1166 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1166>`_
+
 PyPSA-Earth 0.4.1
 =================
 

--- a/scripts/prepare_transport_data_input.py
+++ b/scripts/prepare_transport_data_input.py
@@ -103,6 +103,13 @@ def download_CO2_emissions():
     # Drop region names that have no ISO2:
     CO2_emissions = CO2_emissions[CO2_emissions.country != "not found"]
 
+    # Drop region names where country column contains list of countries
+    CO2_emissions = CO2_emissions[
+        CO2_emissions.apply(
+            lambda x: False if not isinstance(x.country, str) else True, axis=1
+        )
+    ]
+
     return CO2_emissions
 
 

--- a/scripts/prepare_transport_data_input.py
+++ b/scripts/prepare_transport_data_input.py
@@ -104,7 +104,7 @@ def download_CO2_emissions():
 
     # Drop region names where country column contains list of countries
     CO2_emissions = CO2_emissions[
-        CO2_emissions.country.apply(lambda x: isinstance(x, str), axis=1)
+        CO2_emissions.country.apply(lambda x: isinstance(x, str))
     ]
     return CO2_emissions
 

--- a/scripts/prepare_transport_data_input.py
+++ b/scripts/prepare_transport_data_input.py
@@ -104,11 +104,8 @@ def download_CO2_emissions():
 
     # Drop region names where country column contains list of countries
     CO2_emissions = CO2_emissions[
-        CO2_emissions.apply(
-            lambda x: False if not isinstance(x.country, str) else True, axis=1
-        )
+        CO2_emissions.country.apply(lambda x: isinstance(x, str), axis=1)
     ]
-
     return CO2_emissions
 
 

--- a/scripts/prepare_transport_data_input.py
+++ b/scripts/prepare_transport_data_input.py
@@ -95,9 +95,8 @@ def download_CO2_emissions():
     # Add ISO2 country code for each country
     CO2_emissions = CO2_emissions.rename(columns={"Country Name": "Country"})
     cc = coco.CountryConverter()
-    Country = pd.Series(CO2_emissions["Country"])
-    CO2_emissions["country"] = cc.pandas_convert(
-        series=Country, to="ISO2", not_found="not found"
+    CO2_emissions.loc[:, "country"] = cc.pandas_convert(
+        series=CO2_emissions["Country"], to="ISO2", not_found="not found"
     )
 
     # Drop region names that have no ISO2:


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. Here I propose to update `download_co2_emissions` function in `prepare_transport_data_input.py` script to drop entries where country column contains not string. This issue appeared very recently, as I have noticed it in the CI check. Great thanks for @finozzifa, who pointed out the error location and proposed the solution.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
