### PR TITLE
Correct a version number of the test configs

### DIFF
--- a/test/config.custom.yaml
+++ b/test/config.custom.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: CC0-1.0
 
 ### CHANGES TO CONFIG.TUTORIAL.YAML ###
-version: 0.5.0
+version: 0.4.1
 
 run:
   name: "custom"

--- a/test/config.landlock.yaml
+++ b/test/config.landlock.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: CC0-1.0
 
 ### CHANGES TO CONFIG.TUTORIAL.YAML ###
-version: 0.5.0
+version: 0.4.1
 
 countries: ["BW"]
 

--- a/test/config.monte_carlo.yaml
+++ b/test/config.monte_carlo.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: CC0-1.0
 
 ### CHANGES TO CONFIG.TUTORIAL.YAML ###
-version: 0.5.0
+version: 0.4.1
 
 monte_carlo:
   options:

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-version: 0.5.0
+version: 0.4.1
 tutorial: true
 
 run:

--- a/test/config.test_myopic.yaml
+++ b/test/config.test_myopic.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-version: 0.5.0
+version: 0.4.1
 logging_level: INFO
 tutorial: true
 


### PR DESCRIPTION
Fixing the config versions used to run tests. Currently, there is a mismatch which results in CI throwing warnings in the logs

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
