### PR TITLE
Fix typo (RDIR->SECDIR)

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1461,7 +1461,9 @@ rule build_clustered_population_layouts:
         pop_layout_rural="resources/"
         + SECDIR
         + "population_shares/pop_layout_rural_{planning_horizons}.nc",
-        gdp_layout="resources/" + RDIR + "gdp_shares/gdp_layout_{planning_horizons}.nc",
+        gdp_layout="resources/"
+        + SECDIR
+        + "gdp_shares/gdp_layout_{planning_horizons}.nc",
         regions_onshore="resources/"
         + RDIR
         + "bus_regions/regions_onshore_elec_s{simpl}_{clusters}.geojson",


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. This PR tends to fix the issue with input of `build_clustered_population_layouts` rule. `gdp_layout` needs to be stored in `SECDIR` as noted by @finozzifa, not RDIR. It was a type left from previous PR #1544. @davide-f 

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
