### PR TITLE
Use only SECDIR for sector output (RESDIR)

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -51,8 +51,8 @@ run = config.get("run", {})
 RDIR = run["name"] + "/" if run.get("name") else ""
 CDIR = RDIR if not run.get("shared_cutouts") else ""
 SECDIR = run["sector_name"] + "/" if run.get("sector_name") else ""
-SDIR = config["summary_dir"].strip("/") + f"/{RDIR}{SECDIR}"
-RESDIR = config["results_dir"].strip("/") + f"/{RDIR}{SECDIR}"
+SDIR = config["summary_dir"].strip("/") + f"/{SECDIR}"
+RESDIR = config["results_dir"].strip("/") + f"/{SECDIR}"
 COSTDIR = config["costs_dir"]
 
 load_data_paths = get_load_paths_gegis("data", config)


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. Here I propose to change RESDIR so that sector results are stored in `SECDIR` folder, rather than nested RESDIR/SECDIR structure. @davide-f 

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.