### PR TITLE
Length based pipeline efficiency

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -522,6 +522,14 @@ sector:
   lignite:
     spatial_lignite: false
 
+  # TODO: move this section to a different file
+  # efficiencies for length based link efficiencies. Copied from PyPSA-Eur.
+  transmission_efficiency:
+    H2 pipeline:
+      efficiency_static: 1
+      efficiency_per_1000km: 1 # 0.982
+      compression_per_1000km: 0.018
+
   international_bunkers: false #Whether or not to count the emissions of international aviation and navigation
 
   oil:

--- a/scripts/add_extra_components.py
+++ b/scripts/add_extra_components.py
@@ -264,25 +264,24 @@ def attach_hydrogen_pipelines(n, costs, config):
         carrier="H2 pipeline",
     )
 
-    # TODO: when using the lossy_bidirectional_links fix, move this line AFTER lossy_bidirectional_links()
+    # TODO: when using the lossy_bidirectional_links fix, move this line AFTER lossy_bidirectional_links() 
     # set the pipelines's efficiency
-    set_length_based_efficiency(n, "H2 pipeline", " H2", config)
+    set_length_based_efficiency(n, "H2 pipeline", " H2",config)
 
 
-def set_length_based_efficiency(
-    n: pypsa.components.Network, carrier: str, bus_suffix: str, config: dict
-) -> None:
-    """
+def set_length_based_efficiency(n: pypsa.components.Network, carrier: str, bus_suffix: str, config: dict) -> None:
+
+    '''
     Set the efficiency of all links of type carrier in network n based on their length and the values specified in the config.
     Additionally add the length based electricity demand, required for compression (if applicable).
-    """
+    '''
 
     # get the links length based efficiency and required compression
     efficiencies = config["sector"]["transmission_efficiency"][carrier]
     efficiency_static = efficiencies.get("efficiency_static", 1)
     efficiency_per_1000km = efficiencies.get("efficiency_per_1000km", 1)
     compression_per_1000km = efficiencies.get("compression_per_1000km", 0)
-
+ 
     # indetify all links of type carrier
     carrier_i = n.links.loc[n.links.carrier == carrier].index
 
@@ -294,19 +293,15 @@ def set_length_based_efficiency(
 
     # set the links's electricity demand for compression
     if compression_per_1000km > 0:
-        n.links.loc[carrier_i, "bus2"] = n.links.loc[
-            carrier_i, "bus0"
-        ].str.removesuffix(bus_suffix)
+        n.links.loc[carrier_i, "bus2"] = n.links.loc[carrier_i, "bus0"].str.removesuffix(bus_suffix)
         # TODO: use these lines to set bus 2 instead, once n.buses.location is functional and remove bus_suffix.
-        """
+        '''
         n.links.loc[carrier_i, "bus2"] = n.links.loc[carrier_i, "bus0"].map(
             n.buses.location
         )  # electricity
-        """
+        '''
         n.links.loc[carrier_i, "efficiency2"] = (
-            -compression_per_1000km
-            * n.links.loc[carrier_i, "length"]
-            / 1e3  # TODO: change to length_original when using the lossy_bidirectional_links fix
+            -compression_per_1000km * n.links.loc[carrier_i, "length"] / 1e3 # TODO: change to length_original when using the lossy_bidirectional_links fix
         )
 
 

--- a/scripts/add_extra_components.py
+++ b/scripts/add_extra_components.py
@@ -264,24 +264,25 @@ def attach_hydrogen_pipelines(n, costs, config):
         carrier="H2 pipeline",
     )
 
-    # TODO: when using the lossy_bidirectional_links fix, move this line AFTER lossy_bidirectional_links() 
+    # TODO: when using the lossy_bidirectional_links fix, move this line AFTER lossy_bidirectional_links()
     # set the pipelines's efficiency
-    set_length_based_efficiency(n, "H2 pipeline", " H2",config)
+    set_length_based_efficiency(n, "H2 pipeline", " H2", config)
 
 
-def set_length_based_efficiency(n: pypsa.components.Network, carrier: str, bus_suffix: str, config: dict) -> None:
-
-    '''
+def set_length_based_efficiency(
+    n: pypsa.components.Network, carrier: str, bus_suffix: str, config: dict
+) -> None:
+    """
     Set the efficiency of all links of type carrier in network n based on their length and the values specified in the config.
     Additionally add the length based electricity demand, required for compression (if applicable).
-    '''
+    """
 
     # get the links length based efficiency and required compression
     efficiencies = config["sector"]["transmission_efficiency"][carrier]
     efficiency_static = efficiencies.get("efficiency_static", 1)
     efficiency_per_1000km = efficiencies.get("efficiency_per_1000km", 1)
     compression_per_1000km = efficiencies.get("compression_per_1000km", 0)
- 
+
     # indetify all links of type carrier
     carrier_i = n.links.loc[n.links.carrier == carrier].index
 
@@ -293,15 +294,19 @@ def set_length_based_efficiency(n: pypsa.components.Network, carrier: str, bus_s
 
     # set the links's electricity demand for compression
     if compression_per_1000km > 0:
-        n.links.loc[carrier_i, "bus2"] = n.links.loc[carrier_i, "bus0"].str.removesuffix(bus_suffix)
+        n.links.loc[carrier_i, "bus2"] = n.links.loc[
+            carrier_i, "bus0"
+        ].str.removesuffix(bus_suffix)
         # TODO: use these lines to set bus 2 instead, once n.buses.location is functional and remove bus_suffix.
-        '''
+        """
         n.links.loc[carrier_i, "bus2"] = n.links.loc[carrier_i, "bus0"].map(
             n.buses.location
         )  # electricity
-        '''
+        """
         n.links.loc[carrier_i, "efficiency2"] = (
-            -compression_per_1000km * n.links.loc[carrier_i, "length"] / 1e3 # TODO: change to length_original when using the lossy_bidirectional_links fix
+            -compression_per_1000km
+            * n.links.loc[carrier_i, "length"]
+            / 1e3  # TODO: change to length_original when using the lossy_bidirectional_links fix
         )
 
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -986,11 +986,8 @@ if __name__ == "__main__":
 
     is_sector_coupled = "sopts" in snakemake.wildcards.keys()
 
-    if is_sector_coupled:
-        overrides = override_component_attrs(snakemake.input.overrides)
-        n = pypsa.Network(snakemake.input.network, override_component_attrs=overrides)
-    else:
-        n = pypsa.Network(snakemake.input.network)
+    overrides = override_component_attrs(snakemake.input.overrides)
+    n = pypsa.Network(snakemake.input.network, override_component_attrs=overrides)
 
     if snakemake.params.augmented_line_connection.get("add_to_snakefile"):
         n.lines.loc[n.lines.index.str.contains("new"), "s_nom_min"] = (


### PR DESCRIPTION
# !!!Not tested yet, don't review!!!
# Closes #1213.

## Changes proposed in this Pull Request
Major changes:
- change the efficiency of H2 pipelines from a static value (that is somewhat faulty see BR #1213) to a length based calculation similar to PyPSA-Eur in scripts/add_extra_components.py.

Minor changes:
- override the networks component attributes in scripts/add_extra_components.py and scripts/solve_network.py to accomodate the length based efficiencies.
- add the transmission efficiencies of H2 pipelines to the config.

## Checklist

- [ ] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
