### PR TITLE
Add fixes for administrative codes

### DIFF
--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -59,6 +59,7 @@ def get_GADM_filename(country_code):
         "UM": "UMI",  # united states minor outlying islands
         "SJ": "SJM",  # svalbard
         "CX": "CXR",  # Christmas island
+        "IC": "ESP",  # canary islands
     }
 
     if country_code in special_codes_GADM:
@@ -436,6 +437,11 @@ def download_WorldPop(
     size_min : int
         Minimum size of each file to download
     """
+
+    # from the administrative perspective, canary islands belong to Spain
+    if country_code == "IC":
+        country_code = "ESP"
+
     if worldpop_method == "api":
         return download_WorldPop_API(country_code, year, update, out_logging, size_min)
 


### PR DESCRIPTION
A PR created for demonstrating purposes to support running the model for Canary Islands (`IC` country code).

The main issue is that Canary islands administratively belong to Spain which means that it's possible to load inputs for them only together with data for mainland country. A better approach should definitely exist, and probably can be developed as a part of [pypsa-distribution](https://github.com/pypsa-meets-earth/pypsa-distribution) model.

## Checklist

- [ ] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
