### PR TITLE
Drop duplicate hydrogen ports in `add_export.py`

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -67,6 +67,8 @@ E.g. if a new rule becomes available describe how to use it `make test` and in o
 
 * Restore string values of tech_colors in config file `PR #1205 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1205>`_
 
+* Remove duplicate entries from hydrogen export ports `PR #1233 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1233>`_
+
 PyPSA-Earth 0.4.1
 =================
 

--- a/scripts/add_export.py
+++ b/scripts/add_export.py
@@ -66,6 +66,9 @@ def select_ports(n):
     hydrogen_buses_ports = n.buses.loc[ports.index + " H2"]
     hydrogen_buses_ports.index.name = "Bus"
 
+    # drop duplicate ports if exists
+    hydrogen_buses_ports = hydrogen_buses_ports.drop_duplicates()
+
     return hydrogen_buses_ports
 
 

--- a/scripts/add_export.py
+++ b/scripts/add_export.py
@@ -60,14 +60,14 @@ def select_ports(n):
         axis=1,
     )
 
-    ports = ports.set_index("gadm_{}".format(gadm_level))
+    # TODO: revise if ports quantity and property by shape become relevant
+    # drop duplicated entries
+    gcol = "gadm_{}".format(gadm_level)
+    ports_sel = ports.loc[~ports[gcol].duplicated(keep="first")].set_index(gcol)
 
     # Select the hydrogen buses based on nodes with ports
-    hydrogen_buses_ports = n.buses.loc[ports.index + " H2"]
+    hydrogen_buses_ports = n.buses.loc[ports_sel.index + " H2"]
     hydrogen_buses_ports.index.name = "Bus"
-
-    # drop duplicate ports if exists
-    hydrogen_buses_ports = hydrogen_buses_ports.drop_duplicates()
 
     return hydrogen_buses_ports
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. This PR aims to minor a bug related to duplicate entries of H2 export ports which prevents addition of links that connect `H2 export bus` and H2 buses. This issue happens particularly for US, where multiple ports are available. The PR is linked to issue #1231. Dropping the duplicates solve the issue.
![image](https://github.com/user-attachments/assets/b9fc32c7-2301-4430-b764-8d1412489d62)


## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
