### PR TITLE
add wiki table to complement number of vehicles per country in transport_data csv

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -13,6 +13,7 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **New Features and Major Changes**
 
+* Add wikipedia source to transport_data `PR #1244 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1244>`__
 
 **Minor Changes and bug-fixing**
 

--- a/scripts/prepare_transport_data_input.py
+++ b/scripts/prepare_transport_data_input.py
@@ -14,72 +14,84 @@ from _helpers import BASE_DIR
 
 logger = logging.getLogger(__name__)
 
+
 def _add_iso2_code_per_country_and_clean_data(df):
-    
+
     cc = coco.CountryConverter()
     df["country"] = cc.pandas_convert(
-        series=pd.Series(df["Country"]), to="ISO2", not_found="not found")
-    
+        series=pd.Series(df["Country"]), to="ISO2", not_found="not found"
+    )
+
     df = df[df.country != "not found"]
-    
+
     # Drop region names where country column contains list of countries
     df = df[df.country.apply(lambda x: isinstance(x, str))]
-    
+
     df = df.drop_duplicates(subset=["country"])
-    
+
     return df
+
 
 def download_number_of_vehicles():
     """
-    Downloads and returns the number of registered vehicles 
+    Downloads and returns the number of registered vehicles
     as tabular data from WHO and Wikipedia.
-    
-    The csv data from the WHO website is imported 
-    from 'https://apps.who.int/gho/data/node.main.A995'. 
-    A few countries are missing in the WHO list (e.g. South Africa, Algeria). 
-    Therefore, the number of vehicles per country table from Wikipedia 
+
+    The csv data from the WHO website is imported
+    from 'https://apps.who.int/gho/data/node.main.A995'.
+    A few countries are missing in the WHO list (e.g. South Africa, Algeria).
+    Therefore, the number of vehicles per country table from Wikipedia
     is also imported for completion (prio 2):
     'https://en.wikipedia.org/wiki/List_of_countries_and_territories_by_motor_vehicles_per_capita'.
     """
-    
+
     def _download_vehicles_data_from_gho():
-        url = ("https://apps.who.int/gho/athena/data/GHO/RS_194?filter=COUNTRY:*&ead=&x-sideaxis=COUNTRY;YEAR;DATASOURCE&x-topaxis=GHO&profile=crosstable&format=csv")
+        url = "https://apps.who.int/gho/athena/data/GHO/RS_194?filter=COUNTRY:*&ead=&x-sideaxis=COUNTRY;YEAR;DATASOURCE&x-topaxis=GHO&profile=crosstable&format=csv"
         storage_options = {"User-Agent": "Mozilla/5.0"}
         df = pd.read_csv(url, storage_options=storage_options, encoding="utf8")
-        
-        df.rename(columns={"Countries, territories and areas": "Country",
-                           "Number of registered vehicles": "number cars"},
-                  inplace=True)
-        
+
+        df.rename(
+            columns={
+                "Countries, territories and areas": "Country",
+                "Number of registered vehicles": "number cars",
+            },
+            inplace=True,
+        )
+
         df["number cars"] = df["number cars"].str.replace(" ", "").replace("", np.nan)
-        
+
         df = df.dropna(subset=["number cars"])
-        
+
         return df[["Country", "number cars"]]
 
     def _download_vehicles_data_from_wiki():
-        url = ("https://en.wikipedia.org/wiki/List_of_countries_and_territories_by_motor_vehicles_per_capita")
+        url = "https://en.wikipedia.org/wiki/List_of_countries_and_territories_by_motor_vehicles_per_capita"
         df = pd.read_html(url)[0]
-        
-        df.rename(columns={"Location": "Country", "Vehicles": "number cars"},
-                  inplace=True)
-        
+
+        df.rename(
+            columns={"Location": "Country", "Vehicles": "number cars"}, inplace=True
+        )
+
         return df[["Country", "number cars"]]
-    
+
     try:
-        nbr_vehicles = pd.concat([_download_vehicles_data_from_gho(),
-                                  _download_vehicles_data_from_wiki()],
-                                 ignore_index=True)
-        
+        nbr_vehicles = pd.concat(
+            [_download_vehicles_data_from_gho(), _download_vehicles_data_from_wiki()],
+            ignore_index=True,
+        )
+
         nbr_vehicles["number cars"] = nbr_vehicles["number cars"].astype(int)
-    
+
         nbr_vehicles = _add_iso2_code_per_country_and_clean_data(nbr_vehicles)
 
         return nbr_vehicles
-    
+
     except Exception as e:
-        logger.warning("Failed to read the file:", e,
-                       "\nReturning an empty df and falling back on the hard-coded data.")
+        logger.warning(
+            "Failed to read the file:",
+            e,
+            "\nReturning an empty df and falling back on the hard-coded data.",
+        )
         return pd.DataFrame()
 
 
@@ -90,27 +102,25 @@ def download_CO2_emissions():
     The dataset is downloaded from the following link: https://data.worldbank.org/indicator/EN.CO2.TRAN.ZS?view=map
     It is until the year 2014. # TODO: Maybe search for more recent years.
     """
-    
+
     try:
-        url = (
-            "https://api.worldbank.org/v2/en/indicator/EN.CO2.TRAN.ZS?downloadformat=excel"
-        )
-        
+        url = "https://api.worldbank.org/v2/en/indicator/EN.CO2.TRAN.ZS?downloadformat=excel"
+
         CO2_emissions = pd.read_excel(url, sheet_name="Data", skiprows=[0, 1, 2])
-        
+
         CO2_emissions = CO2_emissions[
             ["Country Name", "Country Code", "Indicator Name", "2014"]
         ]
 
         # Calculate efficiency based on CO2 emissions from transport (% of total fuel combustion)
         CO2_emissions["average fuel efficiency"] = (100 - CO2_emissions["2014"]) / 100
-        
+
         CO2_emissions = CO2_emissions.dropna(subset=["average fuel efficiency"])
 
         CO2_emissions = CO2_emissions.rename(columns={"Country Name": "Country"})
 
         CO2_emissions = _add_iso2_code_per_country_and_clean_data(CO2_emissions)
-        
+
         CO2_emissions["average fuel efficiency"] = CO2_emissions[
             "average fuel efficiency"
         ].astype(float)
@@ -119,12 +129,11 @@ def download_CO2_emissions():
             "average fuel efficiency"
         ].round(3)
 
-        return CO2_emissions[['country', 'average fuel efficiency']]
-    
+        return CO2_emissions[["country", "average fuel efficiency"]]
+
     except Exception as e:
         logger.warning("Failed to read the file:", e)
         return pd.DataFrame()
-
 
 
 if __name__ == "__main__":

--- a/scripts/prepare_transport_data_input.py
+++ b/scripts/prepare_transport_data_input.py
@@ -73,10 +73,7 @@ def download_number_of_vehicles():
         df = pd.read_html(url)[0]
 
         df.rename(
-            columns={
-                "Location": "Country", 
-                "Vehicles": "number cars"}, 
-            inplace=True
+            columns={"Location": "Country", "Vehicles": "number cars"}, inplace=True
         )
 
         return df[["Country", "number cars"]]
@@ -84,21 +81,25 @@ def download_number_of_vehicles():
     try:
         nbr_vehicles = pd.concat(
             [_download_vehicles_data_from_gho(), _download_vehicles_data_from_wiki()],
-            ignore_index=True)
+            ignore_index=True,
+        )
     except Exception as e:
-        logger.warning("Failed to read the file:", e,
-                       "\nReturning an empty df and falling back on the hard-coded data.")
+        logger.warning(
+            "Failed to read the file:",
+            e,
+            "\nReturning an empty df and falling back on the hard-coded data.",
+        )
         return pd.DataFrame()
-    
+
     nbr_vehicles["number cars"] = nbr_vehicles["number cars"].astype(int)
 
     nbr_vehicles = _add_iso2_code_per_country_and_clean_data(nbr_vehicles)
 
     # Drops duplicates and keeps WHO-GHO data in case of duplicates
-    nbr_vehicles = nbr_vehicles.drop_duplicates(subset=["country"],keep="first")
+    nbr_vehicles = nbr_vehicles.drop_duplicates(subset=["country"], keep="first")
 
     return nbr_vehicles
-    
+
 
 def download_CO2_emissions():
     """
@@ -107,8 +108,10 @@ def download_CO2_emissions():
     The dataset is downloaded from the following link: https://data.worldbank.org/indicator/EN.CO2.TRAN.ZS?view=map
     It is until the year 2014. # TODO: Maybe search for more recent years.
     """
-    
-    url = "https://api.worldbank.org/v2/en/indicator/EN.CO2.TRAN.ZS?downloadformat=excel"
+
+    url = (
+        "https://api.worldbank.org/v2/en/indicator/EN.CO2.TRAN.ZS?downloadformat=excel"
+    )
 
     # Read the 'Data' sheet directly from the Excel file at the provided URL
     try:
@@ -124,13 +127,13 @@ def download_CO2_emissions():
 
     # Calculate efficiency based on CO2 emissions from transport (% of total fuel combustion)
     CO2_emissions["average fuel efficiency"] = (100 - CO2_emissions["2014"]) / 100
-    
+
     CO2_emissions = CO2_emissions.dropna(subset=["average fuel efficiency"])
 
     CO2_emissions = CO2_emissions.rename(columns={"Country Name": "Country"})
 
     CO2_emissions = _add_iso2_code_per_country_and_clean_data(CO2_emissions)
-    
+
     CO2_emissions["average fuel efficiency"] = CO2_emissions[
         "average fuel efficiency"
     ].astype(float)
@@ -139,8 +142,7 @@ def download_CO2_emissions():
         "average fuel efficiency"
     ].round(3)
 
-    return CO2_emissions[['country', 'average fuel efficiency']]
-
+    return CO2_emissions[["country", "average fuel efficiency"]]
 
 
 if __name__ == "__main__":

--- a/scripts/prepare_transport_data_input.py
+++ b/scripts/prepare_transport_data_input.py
@@ -12,56 +12,75 @@ import numpy as np
 import pandas as pd
 from _helpers import BASE_DIR
 
-# logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
+def _add_iso2_code_per_country_and_clean_data(df):
+    
+    cc = coco.CountryConverter()
+    df["country"] = cc.pandas_convert(
+        series=pd.Series(df["Country"]), to="ISO2", not_found="not found")
+    
+    df = df[df.country != "not found"]
+    
+    # Drop region names where country column contains list of countries
+    df = df[df.country.apply(lambda x: isinstance(x, str))]
+    
+    df = df.drop_duplicates(subset=["country"])
+    
+    return df
 
 def download_number_of_vehicles():
     """
-    Downloads the Number of registered vehicles as .csv File.
-
-    The following csv file was downloaded from the webpage
-    https://apps.who.int/gho/data/node.main.A995
-    as a .csv file.
+    Downloads and returns the number of registered vehicles 
+    as tabular data from WHO and Wikipedia.
+    
+    The csv data from the WHO website is imported 
+    from 'https://apps.who.int/gho/data/node.main.A995'. 
+    A few countries are missing in the WHO list (e.g. South Africa, Algeria). 
+    Therefore, the number of vehicles per country table from Wikipedia 
+    is also imported for completion (prio 2):
+    'https://en.wikipedia.org/wiki/List_of_countries_and_territories_by_motor_vehicles_per_capita'.
     """
-    fn = "https://apps.who.int/gho/athena/data/GHO/RS_194?filter=COUNTRY:*&ead=&x-sideaxis=COUNTRY;YEAR;DATASOURCE&x-topaxis=GHO&profile=crosstable&format=csv"
-    storage_options = {"User-Agent": "Mozilla/5.0"}
+    
+    def _download_vehicles_data_from_gho():
+        url = ("https://apps.who.int/gho/athena/data/GHO/RS_194?filter=COUNTRY:*&ead=&x-sideaxis=COUNTRY;YEAR;DATASOURCE&x-topaxis=GHO&profile=crosstable&format=csv")
+        storage_options = {"User-Agent": "Mozilla/5.0"}
+        df = pd.read_csv(url, storage_options=storage_options, encoding="utf8")
+        
+        df.rename(columns={"Countries, territories and areas": "Country",
+                           "Number of registered vehicles": "number cars"},
+                  inplace=True)
+        
+        df["number cars"] = df["number cars"].str.replace(" ", "").replace("", np.nan)
+        
+        df = df.dropna(subset=["number cars"])
+        
+        return df[["Country", "number cars"]]
 
-    # Read the 'Data' sheet directly from the csv file at the provided URL
+    def _download_vehicles_data_from_wiki():
+        url = ("https://en.wikipedia.org/wiki/List_of_countries_and_territories_by_motor_vehicles_per_capita")
+        df = pd.read_html(url)[0]
+        
+        df.rename(columns={"Location": "Country", "Vehicles": "number cars"},
+                  inplace=True)
+        
+        return df[["Country", "number cars"]]
+    
     try:
-        Nbr_vehicles_csv = pd.read_csv(
-            fn, storage_options=storage_options, encoding="utf8"
-        )
-        print("File read successfully.")
+        nbr_vehicles = pd.concat([_download_vehicles_data_from_gho(),
+                                  _download_vehicles_data_from_wiki()],
+                                 ignore_index=True)
+        
+        nbr_vehicles["number cars"] = nbr_vehicles["number cars"].astype(int)
+    
+        nbr_vehicles = _add_iso2_code_per_country_and_clean_data(nbr_vehicles)
+
+        return nbr_vehicles
+    
     except Exception as e:
-        print("Failed to read the file:", e)
+        logger.warning("Failed to read the file:", e,
+                       "\nReturning an empty df and falling back on the hard-coded data.")
         return pd.DataFrame()
-
-    Nbr_vehicles_csv = Nbr_vehicles_csv.rename(
-        columns={
-            "Countries, territories and areas": "Country",
-            "Number of registered vehicles": "number cars",
-        }
-    )
-
-    # Add ISO2 country code for each country
-    cc = coco.CountryConverter()
-    Country = pd.Series(Nbr_vehicles_csv["Country"])
-    Nbr_vehicles_csv["country"] = cc.pandas_convert(
-        series=Country, to="ISO2", not_found="not found"
-    )
-
-    # # Remove spaces, Replace empty values with NaN
-    Nbr_vehicles_csv["number cars"] = (
-        Nbr_vehicles_csv["number cars"].str.replace(" ", "").replace("", np.nan)
-    )
-
-    # Drop rows with NaN values in 'number cars'
-    Nbr_vehicles_csv = Nbr_vehicles_csv.dropna(subset=["number cars"])
-
-    # convert the 'number cars' to integer
-    Nbr_vehicles_csv["number cars"] = Nbr_vehicles_csv["number cars"].astype(int)
-
-    return Nbr_vehicles_csv
 
 
 def download_CO2_emissions():
@@ -71,40 +90,41 @@ def download_CO2_emissions():
     The dataset is downloaded from the following link: https://data.worldbank.org/indicator/EN.CO2.TRAN.ZS?view=map
     It is until the year 2014. # TODO: Maybe search for more recent years.
     """
-    url = (
-        "https://api.worldbank.org/v2/en/indicator/EN.CO2.TRAN.ZS?downloadformat=excel"
-    )
-
-    # Read the 'Data' sheet directly from the Excel file at the provided URL
+    
     try:
+        url = (
+            "https://api.worldbank.org/v2/en/indicator/EN.CO2.TRAN.ZS?downloadformat=excel"
+        )
+        
         CO2_emissions = pd.read_excel(url, sheet_name="Data", skiprows=[0, 1, 2])
-        print("File read successfully.")
+        
+        CO2_emissions = CO2_emissions[
+            ["Country Name", "Country Code", "Indicator Name", "2014"]
+        ]
+
+        # Calculate efficiency based on CO2 emissions from transport (% of total fuel combustion)
+        CO2_emissions["average fuel efficiency"] = (100 - CO2_emissions["2014"]) / 100
+        
+        CO2_emissions = CO2_emissions.dropna(subset=["average fuel efficiency"])
+
+        CO2_emissions = CO2_emissions.rename(columns={"Country Name": "Country"})
+
+        CO2_emissions = _add_iso2_code_per_country_and_clean_data(CO2_emissions)
+        
+        CO2_emissions["average fuel efficiency"] = CO2_emissions[
+            "average fuel efficiency"
+        ].astype(float)
+
+        CO2_emissions.loc[:, "average fuel efficiency"] = CO2_emissions[
+            "average fuel efficiency"
+        ].round(3)
+
+        return CO2_emissions[['country', 'average fuel efficiency']]
+    
     except Exception as e:
-        print("Failed to read the file:", e)
+        logger.warning("Failed to read the file:", e)
         return pd.DataFrame()
 
-    CO2_emissions = CO2_emissions[
-        ["Country Name", "Country Code", "Indicator Name", "2014"]
-    ]
-
-    # Calculate efficiency based on CO2 emissions from transport (% of total fuel combustion)
-    CO2_emissions["average fuel efficiency"] = (100 - CO2_emissions["2014"]) / 100
-
-    # Add ISO2 country code for each country
-    CO2_emissions = CO2_emissions.rename(columns={"Country Name": "Country"})
-    cc = coco.CountryConverter()
-    CO2_emissions.loc[:, "country"] = cc.pandas_convert(
-        series=CO2_emissions["Country"], to="ISO2", not_found="not found"
-    )
-
-    # Drop region names that have no ISO2:
-    CO2_emissions = CO2_emissions[CO2_emissions.country != "not found"]
-
-    # Drop region names where country column contains list of countries
-    CO2_emissions = CO2_emissions[
-        CO2_emissions.country.apply(lambda x: isinstance(x, str))
-    ]
-    return CO2_emissions
 
 
 if __name__ == "__main__":
@@ -120,34 +140,21 @@ if __name__ == "__main__":
     # store_path_data = Path.joinpath(Path().cwd(), "data")
     # country_list = country_list_to_geofk(snakemake.config["countries"])'
 
-    # Downloaded and prepare vehicles_csv:
-    vehicles_csv = download_number_of_vehicles().copy()
+    # Downloaded and prepare vehicles data:
+    vehicles_df = download_number_of_vehicles().copy()
 
-    # Downloaded and prepare CO2_emissions_csv:
-    CO2_emissions_csv = download_CO2_emissions().copy()
+    # Downloaded and prepare CO2_emissions data:
+    CO2_emissions_df = download_CO2_emissions().copy()
 
-    if vehicles_csv.empty or CO2_emissions_csv.empty:
+    if vehicles_df.empty or CO2_emissions_df.empty:
         # In case one of the urls is not working, we can use the hard-coded data
         src = BASE_DIR + "/data/temp_hard_coded/transport_data.csv"
         dest = snakemake.output.transport_data_input
         shutil.copy(src, dest)
     else:
         # Join the DataFrames by the 'country' column
-        merged_df = pd.merge(vehicles_csv, CO2_emissions_csv, on="country")
+        merged_df = pd.merge(vehicles_df, CO2_emissions_df, on="country")
         merged_df = merged_df[["country", "number cars", "average fuel efficiency"]]
-
-        # Drop rows with NaN values in 'average fuel efficiency'
-        merged_df = merged_df.dropna(subset=["average fuel efficiency"])
-
-        # Convert the 'average fuel efficiency' to float
-        merged_df["average fuel efficiency"] = merged_df[
-            "average fuel efficiency"
-        ].astype(float)
-
-        # Round the 'average fuel efficiency' to three decimal places
-        merged_df.loc[:, "average fuel efficiency"] = merged_df[
-            "average fuel efficiency"
-        ].round(3)
 
         # Save the merged DataFrame to a CSV file
         merged_df.to_csv(


### PR DESCRIPTION
Currently, the number of registered vehicles per country (part of resources/transport_data.csv) is downloaded from the WHO Global Health Observatory data repository. A few countries are missing in the WHO list (e.g. South Africa, Algeria). 

## Changes proposed in this Pull Request

* Fill in the missing countries with the number of vehicles per country from Wikipedia 'https://en.wikipedia.org/wiki/List_of_countries_and_territories_by_motor_vehicles_per_capita'
* The proposed concatenation of downloaded vehicle data will prioritise the WHO list -> existing model instances for previously available countries will not be affected.
* Refactoring and restructuring of the code in the prepare_transport_data_input.py script

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine:
    - With the changes, the code behaves as expected: Number of vehicles for a few more countries are added. However, it seems that the World Bank's CO2_emission API changed in November and the requested data, CO2 emissions from transport in % of total fuel combustion, is no longer available. Since this is not part of the proposed contribution of this pull request, I'll write a separate issue about it. 
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
