### PR TITLE
Do not compute powerplants from ppm if replace option is used

### DIFF
--- a/data/custom_powerplants.csv
+++ b/data/custom_powerplants.csv
@@ -1,1 +1,1 @@
-Name,Fueltype,Technology,Set,Country,Capacity,Efficiency,Duration,Volume_Mm3,DamHeight_m,StorageCapacity_MWh,DateIn,DateRetrofit,DateMothball,DateOut,lat,lon,EIC,projectID,bus
+Name,Fueltype,Technology,Set,Country,Capacity,Efficiency,Duration,Volume_Mm3,DamHeight_m,StorageCapacity_MWh,DateIn,DateRetrofit,DateOut,lat,lon,EIC,projectID,bus

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -42,6 +42,8 @@ PyPSA-Earth 0.6.0
 
 * Update BW, NG and BJ tutorial databundles to include gadm-like sources from geoboundaries `PR #1257 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1257>`__
 
+* Prevent computation of powerplantmatching if replace option is selected for custom_powerplants `PR #1281 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1281>`__
+
 
 PyPSA-Earth 0.5.0
 =================

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -16,6 +16,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **Minor Changes and bug-fixing**
 
+* Prevent computation of powerplantmatching if replace option is selected for custom_powerplants `PR #1281 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1281>`__
+
 
 PyPSA-Earth 0.6.0
 =================
@@ -41,8 +43,6 @@ PyPSA-Earth 0.6.0
 * Added electricity bus to Fischer-Tropsch in prepare_sector_network.py `PR #1226 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1226>`__
 
 * Update BW, NG and BJ tutorial databundles to include gadm-like sources from geoboundaries `PR #1257 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1257>`__
-
-* Prevent computation of powerplantmatching if replace option is selected for custom_powerplants `PR #1281 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1281>`__
 
 
 PyPSA-Earth 0.5.0

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -337,13 +337,16 @@ if __name__ == "__main__":
     else:
         config["main_query"] = ""
 
-    ppl = (
-        pm.powerplants(from_url=False, update=True, config_update=config)
-        .powerplant.fill_missing_decommissioning_years()
-        .query('Fueltype not in ["Solar", "Wind"] and Country in @countries_names')
-        .powerplant.convert_country_to_alpha2()
-        .pipe(replace_natural_gas_technology)
-    )
+    if snakemake.config["electricity"]["custom_powerplants"] != "replace":
+        ppl = (
+            pm.powerplants(from_url=False, update=True, config_update=config)
+            .powerplant.fill_missing_decommissioning_years()
+            .query('Fueltype not in ["Solar", "Wind"] and Country in @countries_names')
+            .powerplant.convert_country_to_alpha2()
+            .pipe(replace_natural_gas_technology)
+        )
+    else:
+        ppl = pd.DataFrame()
 
     ppl = add_custom_powerplants(
         ppl, snakemake.input, snakemake.config


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. The following changes aim to reduce unwanted computation if `replace` option is selected in the config while using custom powerplants data. It helps to avoid long computation of powerplants from powerplantmatching for some large countries.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
