### PR TITLE
Bugfix readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,9 @@
 
 version: 2
 
+sphinx:
+  configuration: doc/conf.py
+
 build:
   os: ubuntu-22.04
   tools:

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -23,6 +23,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 * Fix overlapping bus regions when alternative clustering is selected `PR #1287 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1287>`__
 
+* Fix readthedocs by explicitly specifying the location of the Sphinx config `PR #1292 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1292>`__
+
 PyPSA-Earth 0.6.0
 =================
 


### PR DESCRIPTION
Minor changes:
- fix readthedocs by explicitly defining a config file in .readthedocs.yaml

# Closes #1291 .

## Changes proposed in this Pull Request

Minor changes:
- fix readthedocs by explicitely providing Sphinx config file in .readthedocs.yaml

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
