### PR TITLE
Replace pyomo with linopy

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -39,6 +39,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 * Add CITATION.cff to guide users on how cite PyPSA-Earth. Insert the DOI badge in the README linking to the very first PyPSA-Earth paper. `PR #1316 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1316>`__
 
+* Remove pyomo from cluster_network and introduce scip. `PR #1320 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1323>`__
+
 PyPSA-Earth 0.6.0
 =================
 

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-name: pypsa-earth
+name: pypsa-earth-scip
 channels:
 - conda-forge
 - bioconda
@@ -44,7 +44,7 @@ dependencies:
 - pydoe2
 - shapely!=2.0.4
 - pre-commit
-- scip!=9.2.0
+- scip!=9.2.0  # dependency of pyscipopt, temporary fix
 - matplotlib<=3.5.2
 - reverse-geocode
 - country_converter

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-name: pypsa-earth-scip
+name: pypsa-earth
 channels:
 - conda-forge
 - bioconda

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -44,7 +44,7 @@ dependencies:
 - pydoe2
 - shapely!=2.0.4
 - pre-commit
-- pyomo
+- scip!=9.2.0
 - matplotlib<=3.5.2
 - reverse-geocode
 - country_converter

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -343,6 +343,7 @@ def distribute_clusters(
     )
 
     m.add_constraints(clusters.sum() == n_clusters, name="tot")
+    # leave out constant in objective (L * n_clusters) ** 2 as it doesn't affect the clustering results
     m.objective = (
         clusters * clusters - 2 * clusters * distribution_factor * n_clusters
     ).sum()

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -121,6 +121,7 @@ Exemplary unsolved network clustered to 37 nodes:
     :align: center
 """
 
+import logging
 import os
 from functools import reduce
 
@@ -137,7 +138,6 @@ from _helpers import (
     update_config_dictionary,
     update_p_nom_max,
 )
-import logging
 from add_electricity import load_costs
 from build_shapes import add_gdp_data, add_population_data
 from pypsa.clustering.spatial import (

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -127,7 +127,7 @@ from functools import reduce
 import geopandas as gpd
 import numpy as np
 import pandas as pd
-import pyomo.environ as po
+import linopy
 import pypsa
 from _helpers import (
     REGION_COLS,
@@ -336,47 +336,19 @@ def distribute_clusters(
         distribution_factor.sum(), 1.0, rtol=1e-3
     ), f"Country weights L must sum up to 1.0 when distributing clusters. Is {distribution_factor.sum()}."
 
-    m = po.ConcreteModel()
-
-    def n_bounds(model, *n_id):
-        """
-        Create a function that makes a bound pair for pyomo.
-
-        Use n_bounds(model, n_id) if N is Single-Index
-        Use n_bounds(model, *n_id) if N is Multi-Index
-        Example: https://pyomo.readthedocs.io/en/stable/pyomo_modeling_components/Variables.html
-
-        Returns
-        -------
-        bounds = A function (or Python object) that gives a (lower,upper) bound pair i.e.(1,10) for the variable
-        """
-        return (1, N[n_id])
-
-    m.n = po.Var(list(distribution_factor.index), bounds=n_bounds, domain=po.Integers)
-    m.tot = po.Constraint(expr=(po.summation(m.n) == n_clusters))
-    m.objective = po.Objective(
-        expr=sum(
-            (m.n[i] - distribution_factor.loc[i] * n_clusters) ** 2
-            for i in distribution_factor.index
-        ),
-        sense=po.minimize,
-    )
-
-    opt = po.SolverFactory(solver_name)
-    if not opt.has_capability("quadratic_objective"):
-        logger.warning(
-            f"The configured solver `{solver_name}` does not support quadratic objectives. Falling back to `ipopt`."
-        )
-        opt = po.SolverFactory("ipopt")
-
-    results = opt.solve(m)
-    assert (
-        results["Solver"][0]["Status"] == "ok"
-    ), f"Solver returned non-optimally: {results}"
-
-    return (
-        pd.Series(m.n.get_values(), index=distribution_factor.index).round().astype(int)
-    )
+    m = linopy.Model()
+    clusters = m.add_variables(
+        lower=1, upper=N, coords=[L.index], name="n", integer=True)
+    
+    m.add_constraints(clusters.sum() == n_clusters, name="tot")
+    m.objective = (
+        clusters * clusters - 2 * clusters * L * n_clusters
+    )  # + (L * n_clusters) ** 2 (constant)
+    if solver_name == "gurobi":
+        logger.getLogger("gurobipy").propagate = False
+    
+    m.solve(solver_name=solver_name)
+    return m.solution["n"].to_series().astype(int)
 
 
 def busmap_for_gadm_clusters(inputs, n, gadm_layer_id, geo_crs, country_list):
@@ -653,7 +625,7 @@ if __name__ == "__main__":
         from _helpers import mock_snakemake
 
         snakemake = mock_snakemake(
-            "cluster_network", network="elec", simpl="", clusters="4"
+            "cluster_network", network="elec", simpl="", clusters="10"
         )
     configure_logging(snakemake)
 

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -339,13 +339,13 @@ def distribute_clusters(
 
     m = linopy.Model()
     clusters = m.add_variables(
-        lower=1, upper=N, coords=[L.index], name="n", integer=True
+        lower=1, upper=N, coords=[distribution_factor.index], name="n", integer=True
     )
 
     m.add_constraints(clusters.sum() == n_clusters, name="tot")
     m.objective = (
-        clusters * clusters - 2 * clusters * L * n_clusters
-    )  # + (L * n_clusters) ** 2 (constant)
+        clusters * clusters - 2 * clusters * distribution_factor * n_clusters
+    ).sum()
     if solver_name == "gurobi":
         logging.getLogger("gurobipy").propagate = False
     elif solver_name not in ["scip", "cplex", "xpress", "copt", "mosek"]:

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -137,6 +137,7 @@ from _helpers import (
     update_config_dictionary,
     update_p_nom_max,
 )
+import logging
 from add_electricity import load_costs
 from build_shapes import add_gdp_data, add_population_data
 from pypsa.clustering.spatial import (
@@ -346,8 +347,12 @@ def distribute_clusters(
         clusters * clusters - 2 * clusters * L * n_clusters
     )  # + (L * n_clusters) ** 2 (constant)
     if solver_name == "gurobi":
-        logger.getLogger("gurobipy").propagate = False
-
+        logging.getLogger("gurobipy").propagate = False
+    elif solver_name not in ["scip", "cplex", "xpress", "copt", "mosek"]:
+        logger.error(
+            f"The configured solver `{solver_name}` does not support quadratic objectives. Falling back to `scip`."
+        )
+        solver_name = "scip"
     m.solve(solver_name=solver_name)
     return m.solution["n"].to_series().astype(int)
 

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -626,7 +626,7 @@ if __name__ == "__main__":
         from _helpers import mock_snakemake
 
         snakemake = mock_snakemake(
-            "cluster_network", network="elec", simpl="", clusters="10"
+            "cluster_network", network="elec", simpl="", clusters="4"
         )
     configure_logging(snakemake)
 

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -125,9 +125,9 @@ import os
 from functools import reduce
 
 import geopandas as gpd
+import linopy
 import numpy as np
 import pandas as pd
-import linopy
 import pypsa
 from _helpers import (
     REGION_COLS,
@@ -338,15 +338,16 @@ def distribute_clusters(
 
     m = linopy.Model()
     clusters = m.add_variables(
-        lower=1, upper=N, coords=[L.index], name="n", integer=True)
-    
+        lower=1, upper=N, coords=[L.index], name="n", integer=True
+    )
+
     m.add_constraints(clusters.sum() == n_clusters, name="tot")
     m.objective = (
         clusters * clusters - 2 * clusters * L * n_clusters
     )  # + (L * n_clusters) ** 2 (constant)
     if solver_name == "gurobi":
         logger.getLogger("gurobipy").propagate = False
-    
+
     m.solve(solver_name=solver_name)
     return m.solution["n"].to_series().astype(int)
 


### PR DESCRIPTION
# Closes #1320 .

## Changes proposed in this Pull Request
This PR aim to remove pyomo from cluster_network.py and replace it with linopy. Scip was also introduced to be used in cases solver (glpk and cbc) does not support quadratic objectives.

The changes were adapted from [pypsa-eur](https://github.com/PyPSA/pypsa-eur/blame/master/scripts/cluster_network.py#L182-L197)

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
