### PR TITLE
Fix namibia geofk

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -81,7 +81,7 @@ cluster_options:
     feature: solar+onwind-time # only for hac. choose from: [solar+onwind-time, solar+onwind-cap, solar-time, solar-cap, solar+offwind-cap] etc.
     exclude_carriers: []
     remove_stubs: true
-    remove_stubs_across_borders: true
+    remove_stubs_across_borders: false
     p_threshold_drop_isolated: 20 # [MW] isolated buses are being discarded if bus mean power is below the specified threshold
     p_threshold_merge_isolated: 300 # [MW] isolated buses are being merged into a single isolated bus if a bus mean power is below the specified threshold
     s_threshold_fetch_isolated: false # [-] a share of the national load for merging an isolated network into a backbone network

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -45,11 +45,11 @@ scenario:
   simpl: [""]
   ll: ["copt"]
   clusters: [10]
-  opts: [Co2L-3H]
+  opts: [Co2L-3h]
   planning_horizons: # investment years for myopic and perfect; or costs year for overnight
   - 2030
   sopts:
-  - "144H"
+  - "144h"
   demand:
   - "AB"
 

--- a/configs/regions_definition_config.yaml
+++ b/configs/regions_definition_config.yaml
@@ -586,3 +586,4 @@ iso_to_geofk_dict:
   TC: "central-america"  # Turks and Caicos Islands
   FK: "south-america"  # Falkland
   GF: "south-america"  # French-Guyana
+  "NA": "namibia"  # Namibia

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -43,6 +43,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 * Fix mixup of plant locations for hydro inflow and inflow overestimation `PR #1322 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1322>`__
 
+* Fix namibia geofk, line country tag mismatch and minor fixes `PR #1330 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1330>`__
+
 PyPSA-Earth 0.6.0
 =================
 

--- a/scripts/build_osm_network.py
+++ b/scripts/build_osm_network.py
@@ -37,7 +37,6 @@ LINES_COLUMNS = [
     "bus1",
     "length",
     "dc",
-    "country",
     "geometry",
     "bounds",
 ]

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -39,7 +39,7 @@ Outputs
 Description
 -----------
 
-The configuration options ``electricity: powerplants_filter`` and ``electricity: custom_powerplants`` can be used to control whether data should be retrieved from the original powerplants database or from custom amendmends. These specify `pandas.query <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.query.html>`_ commands.
+The configuration options ``electricity: powerplants_filter`` and ``electricity: custom_powerplants`` can be used to control whether data should be retrieved from the original powerplants database or from custom amendments. These specify `pandas.query <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.query.html>`_ commands.
 
 1. Adding all powerplants from custom:
 


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request
- Fixes "NA" not found in earth-osm
- Drops warning of future unsupported "H" option in favour of "h" for opts
- Drop country tag for lines that sometimes lead to errors in the clustering phase

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
