### PR TITLE
Fix missing focus_weights on cluster network params

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -697,6 +697,7 @@ if config["augmented_line_connection"].get("add_to_snakefile", False) == False:
             countries=config["countries"],
             gadm_layer_id=config["build_shape_options"]["gadm_layer_id"],
             cluster_options=config["cluster_options"],
+            focus_weights=config.get("focus_weights", None),
         input:
             network="networks/" + RDIR + "elec_s{simpl}.nc",
             country_shapes="resources/" + RDIR + "shapes/country_shapes.geojson",

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -27,6 +27,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **Minor Changes and bug-fixing**
 
+* Fix missing focus_weights on cluster network without augmented_line_connections, minimize warnings on subregions
+
 * Align structure of the components with consistency checks in the updated PyPSA version `PR #1315 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1315>`__
 
 * Prevent computation of powerplantmatching if replace option is selected for custom_powerplants `PR #1281 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1281>`__

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -27,7 +27,7 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **Minor Changes and bug-fixing**
 
-* Fix missing focus_weights on cluster network without augmented_line_connections, minimize warnings on subregions
+* Fix missing focus_weights on cluster_network params without augmented_line_connections, minimize warnings on subregions `PR #1348 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1348>`__
 
 * Align structure of the components with consistency checks in the updated PyPSA version `PR #1315 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1315>`__
 

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -985,13 +985,17 @@ def nearest_shape(n, path_shapes, distance_crs):
 
     for i in n.buses.index:
         point = Point(n.buses.loc[i, "x"], n.buses.loc[i, "y"])
-        distance = shapes.distance(point).sort_values()
-        if distance.iloc[0] < 1:
-            n.buses.loc[i, "country"] = distance.index[0]
+        contains = shapes.contains(point)
+        if contains.any():
+            n.buses.loc[i, "country"] = contains.idxmax()
         else:
-            logger.info(
-                f"The bus {i} is {distance.iloc[0]} km away from {distance.index[0]} "
-            )
+            distance = shapes.distance(point).sort_values()
+            if distance.iloc[0] < 1:
+                n.buses.loc[i, "country"] = distance.index[0]
+            else:
+                logger.info(
+                    f"The bus {i} is {distance.iloc[0]} km away from {distance.index[0]} "
+                )
 
     return n
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

 - Fix missing ``focus_weights`` on cluster network params without ``augmented_line_connections``
 - minimize warnings on subregions due to distance crs 
   - if I set it to ``to_crs(distance)`` as suggested, it will lead to wrong results
   - The value of the distance itself is not relevant, it just aims to collect buses on the coastlines.


## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
