### PR TITLE
Remove space in rail transport oil and electricity carriers

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2813,7 +2813,7 @@ def add_rail_transport(n, costs):
         spatial.nodes,
         suffix=" rail transport oil",
         bus=spatial.oil.nodes,
-        carrier=" rail transport oil",
+        carrier="rail transport oil",
         p_set=p_set_oil * 1e6 / 8760,
     )
 
@@ -2822,7 +2822,7 @@ def add_rail_transport(n, costs):
         spatial.nodes,
         suffix=" rail transport electricity",
         bus=spatial.nodes,
-        carrier=" rail transport electricity",
+        carrier="rail transport electricity",
         p_set=p_set_elec * 1e6 / 8760,
     )
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. This minor PR aims to fix typo and remove white space in front of ` rail transport oil` and `rail transport electricity`.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
