### PR TITLE
Fix AL emissions

### DIFF
--- a/scripts/build_industry_demand.py
+++ b/scripts/build_industry_demand.py
@@ -226,7 +226,8 @@ if __name__ == "__main__":
         # Reindex and fill missing values with 0.0
         AL_prod_tom = AL_prod_tom.reindex(countries_geo, fill_value=0.0)
 
-        AL_emissions = AL_prod_tom * emission_factors["non-ferrous metals"]
+        # Estimate emissions for aluminum production and converting from ktons to tons
+        AL_emissions = AL_prod_tom * emission_factors["non-ferrous metals"] * 1000
 
         Steel_emissions = (
             geo_locs[geo_locs.industry == "iron and steel"]

--- a/scripts/build_industry_demand.py
+++ b/scripts/build_industry_demand.py
@@ -35,7 +35,7 @@ def country_to_nodal(industrial_production, keys):
     for country, sector in product(countries, sectors):
         buses = keys.index[keys.country == country]
 
-        if sector not in dist_keys.columns or dist_keys[sector].sum() == 0:
+        if sector not in keys.columns or keys[sector].sum() == 0:
             mapping = "gdp"
         else:
             mapping = sector


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. This PR aims to fix the calculation part of the emissions from aluminum industry. Aluminum is generally emission intensive industry. I have noticed that `AL_prod_tom` is given in ktons. Finally, when we calculate emissions, the current code just multiplies by `emission_factors["non-ferrous metals"]`, please see: https://github.com/pypsa-meets-earth/pypsa-earth/blob/f5c362d08bb334ecb0b515d1e96e0b19c2c5d646/scripts/build_industry_demand.py#L229 
However, we need to also convert from ktons to tons, similar as we do for other industry emissions. This is a minor bug fix. Additionally, I have seen that function `country_to_nodal` uses global parameter `dist_keys` instead of given parameter `keys`. This was also fixed. What do you think, @davide-f, @hazemakhalek ?

![image](https://github.com/user-attachments/assets/8d12bba5-ad67-4b23-bd20-8c74eddc9feb)


## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
