### PR TITLE
Fix path to costs file

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -2060,7 +2060,7 @@ if config["foresight"] == "myopic":
             network=RESDIR
             + "prenetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_{h2export}export.nc",
             network_p=solved_previous_horizon,  #solved network at previous time step
-            costs=CDIR + "costs_{planning_horizons}.csv",
+            costs="resources/" + RDIR + "costs_{planning_horizons}.csv",
             cop_soil_total="resources/"
             + SECDIR
             + "cops/cop_soil_total_elec_s{simpl}_{clusters}_{planning_horizons}.nc",


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. This PR aims to fix the path to `costs_{planning_horizon}.csv` in the `add_brownfield` rule of the Snakefile. It was causing the error while trying myopic runs.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
