### PR TITLE
Documentation challenge: add a section for sector-coupled network rules in docs

### DIFF
--- a/doc/create_electricity_network_model.rst
+++ b/doc/create_electricity_network_model.rst
@@ -3,7 +3,7 @@
 .. SPDX-License-Identifier: CC-BY-4.0
 
 ##########################################
-Simplifying Networks
+Building electricity networks
 ##########################################
 
 The simplification ``snakemake`` rules prepare **approximations** of the full model, for which it is computationally viable to co-optimize generation, storage and transmission capacities.

--- a/doc/create_sector_coupled_network_model.rst
+++ b/doc/create_sector_coupled_network_model.rst
@@ -1,0 +1,9 @@
+.. SPDX-FileCopyrightText:  PyPSA-Earth and PyPSA-Eur Authors
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
+##########################################
+Building sector-coupled networks
+##########################################
+
+Documentation will be added soon.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -136,6 +136,25 @@ Documentation
    configuration
    costs
 
+**Rules Overview**
+
+* :doc:`retrieve`
+* :doc:`preparation`
+* :doc:`sector`
+* :doc:`solving`
+* :doc:`plotting`
+
+.. toctree::
+   :hidden:
+   :maxdepth: 2
+   :caption: Rules Overview
+
+   retrieve
+   preparation
+   sector
+   solving
+   plotting
+
 **Work flow and API**
 
 * :doc:`structure`

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -136,25 +136,6 @@ Documentation
    configuration
    costs
 
-**Rules Overview**
-
-* :doc:`retrieve`
-* :doc:`preparation`
-* :doc:`sector`
-* :doc:`solving`
-* :doc:`plotting`
-
-.. toctree::
-   :hidden:
-   :maxdepth: 2
-   :caption: Rules Overview
-
-   retrieve
-   preparation
-   sector
-   solving
-   plotting
-
 **Work flow and API**
 
 * :doc:`structure`

--- a/doc/rules_overview.rst
+++ b/doc/rules_overview.rst
@@ -11,7 +11,8 @@ Rules overview
 
 * :doc:`download_and_filter`
 * :doc:`populate_data`
-* :doc:`create_network_model`
+* :doc:`create_electricity_network_model`
+* :doc:`create_sector_coupled_network_model`
 * :doc:`solving`
 * :doc:`plotting`
 
@@ -22,6 +23,7 @@ Rules overview
 
    download_and_filter
    populate_data
-   create_network_model
+   create_electricity_network_model
+   create_sector_coupled_network_model
    solving
    plotting


### PR DESCRIPTION
# Closes #1380 

## Changes proposed in this Pull Request
The two changes are based on based on [PyPSA-EUR docs](https://pypsa-eur.readthedocs.io/en/latest/index.html):
- A new section `Building sector-coupled networks` on sector-coupled network rules was added in the documentation. The section is still empty and should be filled with the description of all the sector-coupled network rules.
- Name update of the former `Simplifying Netowrks` section into `Building electricity networks`

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
