### PR TITLE
Fix prepare_ports for custom data

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -33,6 +33,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **Minor Changes and bug-fixing**
 
+* Fix prepare_ports script to generate both outputs if export ports with custom data is selected. `PR #1424 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1424>`__
+
 * Update the applications list for PyPSA-Earth model. `PR #1413 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1413>`__
 
 * Fix problem with a discontinued World Bank data source in prepare_transport_data_input `PR #1410 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1410>`__

--- a/scripts/prepare_ports.py
+++ b/scripts/prepare_ports.py
@@ -77,7 +77,6 @@ if __name__ == "__main__":
     # store_path_data = Path.joinpath(Path().cwd(), "data")
     # country_list = country_list_to_geofk(snakemake.config["countries"])'
 
-
     df = download_ports().copy()
 
     # Add ISO2 country code for each country

--- a/scripts/prepare_ports.py
+++ b/scripts/prepare_ports.py
@@ -77,72 +77,73 @@ if __name__ == "__main__":
     # store_path_data = Path.joinpath(Path().cwd(), "data")
     # country_list = country_list_to_geofk(snakemake.config["countries"])'
 
+
+    df = download_ports().copy()
+
+    # Add ISO2 country code for each country
+    df = df.rename(
+        columns={
+            "Country Code": "country_full_name",
+            "Latitude": "y",
+            "Longitude": "x",
+            "Main Port Name": "name",
+        }
+    )
+    df["country"] = df.country_full_name.apply(
+        lambda x: coco.convert(names=x, to="ISO2", not_found=None)
+    )
+
+    # Drop small islands that have no ISO2:
+    df = df[df.country_full_name != "Wake Island"]
+    df = df[df.country_full_name != "Johnson Atoll"]
+    df = df[df.country_full_name != "Midway Islands"]
+
+    # Select the columns that we need to keep
+    df = df.reset_index()
+    df = df[
+        [
+            "World Port Index Number",
+            "Region Name",
+            "name",
+            "Alternate Port Name",
+            "country",
+            "World Water Body",
+            "Liquified Natural Gas Terminal Depth (m)",
+            "Harbor Size",
+            "Harbor Type",
+            "Harbor Use",
+            "country_full_name",
+            "y",
+            "x",
+        ]
+    ]
+
+    # Drop ports that are very small and that have unknown size (Unknown size ports are in total 19 and not suitable for H2 - checked visually)
+    ports = df.loc[df["Harbor Size"].isin(["Small", "Large", "Medium"])]
+
+    ports.insert(8, "Harbor_size_nr", 1)
+    ports.loc[ports["Harbor Size"].isin(["Small"]), "Harbor_size_nr"] = 1
+    ports.loc[ports["Harbor Size"].isin(["Medium"]), "Harbor_size_nr"] = 2
+    ports.loc[ports["Harbor Size"].isin(["Large"]), "Harbor_size_nr"] = 3
+
+    df1 = ports.copy()
+    df1 = df1.groupby(["country_full_name"]).sum("Harbor_size_nr")
+    df1 = df1[["Harbor_size_nr"]]
+    df1 = df1.rename(columns={"Harbor_size_nr": "Total_Harbor_size_nr"})
+
+    ports = ports.set_index("country_full_name").join(df1, how="left")
+
+    ports["fraction"] = ports["Harbor_size_nr"] / ports["Total_Harbor_size_nr"]
+
+    ports.to_csv(snakemake.output[0], sep=",", encoding="utf-8", header="true")
+
     if snakemake.params.custom_export:
         custom_export_path = Path(BASE_DIR).joinpath(
             "data", "custom", "export_ports.csv"
         )
         shutil.copy(custom_export_path, snakemake.output[1])
+
     else:
-
-        df = download_ports().copy()
-
-        # Add ISO2 country code for each country
-        df = df.rename(
-            columns={
-                "Country Code": "country_full_name",
-                "Latitude": "y",
-                "Longitude": "x",
-                "Main Port Name": "name",
-            }
-        )
-        df["country"] = df.country_full_name.apply(
-            lambda x: coco.convert(names=x, to="ISO2", not_found=None)
-        )
-
-        # Drop small islands that have no ISO2:
-        df = df[df.country_full_name != "Wake Island"]
-        df = df[df.country_full_name != "Johnson Atoll"]
-        df = df[df.country_full_name != "Midway Islands"]
-
-        # Select the columns that we need to keep
-        df = df.reset_index()
-        df = df[
-            [
-                "World Port Index Number",
-                "Region Name",
-                "name",
-                "Alternate Port Name",
-                "country",
-                "World Water Body",
-                "Liquified Natural Gas Terminal Depth (m)",
-                "Harbor Size",
-                "Harbor Type",
-                "Harbor Use",
-                "country_full_name",
-                "y",
-                "x",
-            ]
-        ]
-
-        # Drop ports that are very small and that have unknown size (Unknown size ports are in total 19 and not suitable for H2 - checked visually)
-        ports = df.loc[df["Harbor Size"].isin(["Small", "Large", "Medium"])]
-
-        ports.insert(8, "Harbor_size_nr", 1)
-        ports.loc[ports["Harbor Size"].isin(["Small"]), "Harbor_size_nr"] = 1
-        ports.loc[ports["Harbor Size"].isin(["Medium"]), "Harbor_size_nr"] = 2
-        ports.loc[ports["Harbor Size"].isin(["Large"]), "Harbor_size_nr"] = 3
-
-        df1 = ports.copy()
-        df1 = df1.groupby(["country_full_name"]).sum("Harbor_size_nr")
-        df1 = df1[["Harbor_size_nr"]]
-        df1 = df1.rename(columns={"Harbor_size_nr": "Total_Harbor_size_nr"})
-
-        ports = ports.set_index("country_full_name").join(df1, how="left")
-
-        ports["fraction"] = ports["Harbor_size_nr"] / ports["Total_Harbor_size_nr"]
-
-        ports.to_csv(snakemake.output[0], sep=",", encoding="utf-8", header="true")
-
         filter_ports(ports).to_csv(
             snakemake.output[1], sep=",", encoding="utf-8", header="true"
         )


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request

This PR adapts the prepare_ports script to allow custom ports to be used for the export ports. Currently, if `config["custom_data"]["export_ports"]` is `True` , the script does not generate `ports` output:

    output:
        ports="resources/" + SECDIR + "ports.csv",
        export_ports="resources/" + SECDIR + "export_ports.csv",

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
