### PR TITLE
fix missing country attribute

### DIFF
--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -129,7 +129,6 @@ import geopandas as gpd
 import linopy
 import numpy as np
 import pandas as pd
-import pycountry
 import pypsa
 from _helpers import (
     REGION_COLS,
@@ -178,9 +177,8 @@ def weighting_for_country(n, x):
     w = g + l
 
     if w.max() == 0.0:
-        country = pycountry.countries.get(alpha_2=x.name[0])
         logger.warning(
-            f"Null weighting for buses of country {country.name if country else x.name[0]}: returned default uniform weighting"
+            f"Null weighting for buses of country {x.name[0]}: returned default uniform weighting"
         )
         return pd.Series(1.0, index=w.index)
     else:

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -129,8 +129,8 @@ import geopandas as gpd
 import linopy
 import numpy as np
 import pandas as pd
-import pypsa
 import pycountry
+import pypsa
 from _helpers import (
     REGION_COLS,
     configure_logging,

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -130,6 +130,7 @@ import linopy
 import numpy as np
 import pandas as pd
 import pypsa
+import pycountry
 from _helpers import (
     REGION_COLS,
     configure_logging,
@@ -177,8 +178,9 @@ def weighting_for_country(n, x):
     w = g + l
 
     if w.max() == 0.0:
+        country = pycountry.countries.get(alpha_2=x.name[0])
         logger.warning(
-            f"Null weighting for buses of country {x.country.iloc[0]}: returned default uniform weighting"
+            f"Null weighting for buses of country {country.name if country else x.name[0]}: returned default uniform weighting"
         )
         return pd.Series(1.0, index=w.index)
     else:


### PR DESCRIPTION
# Closes # (if applicable).
#1442

## Changes proposed in this Pull Request
If the buses of a country have null weighting, we recieve an Error as we dont have the attribute 'country' for the logger.warning.
x.name[0]  returns us the country alpha-2 code. I would propose to convert it into the country name and use it for the logger.warning.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [x] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
