### PR TITLE
Fix missing comma for other energy in build_energy_totals calculation

### DIFF
--- a/scripts/build_base_energy_totals.py
+++ b/scripts/build_base_energy_totals.py
@@ -452,7 +452,7 @@ if __name__ == "__main__":
 
     other_energy = [
         "consumption not elsewhere specified (other)",
-        "consumption not elsewhere specified (other)"
+        "consumption not elsewhere specified (other)",
         "Consumption not elsewhere specified (other)",
         "Consumption by other consumers not elsewhere specified",
         "consumption by other consumers not elsewhere specified",


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. This PR aims to fix the missing comma for `other_energy` in `build_energy_totals.py` script. I have noticed that other energy source for US was not accounted while still being high (191 TWh). Making closer looked showed that we missed comma, as a result proper rows were not selected. Below I show the entry for other energy.

![image](https://github.com/user-attachments/assets/0165c685-43db-4aa9-9bbf-4ac7f766bd54)


## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
