### PR TITLE
update to latest technology-data release

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -362,7 +362,7 @@ renewable:
 # Costs Configuration
 costs:
   year: 2030
-  version: v0.10.0
+  version: v0.12.0
   discountrate: [0.071] #, 0.086, 0.111]
   # [EUR/USD] ECB: https://www.ecb.europa.eu/stats/exchange/eurofxref/html/eurofxref-graph-usd.en.html # noqa: E501
   USD2013_to_EUR2013: 0.7532 # [EUR/USD] ECB: https://www.ecb.europa.eu/stats/exchange/eurofxref/html/eurofxref-graph-usd.en.html

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -12,6 +12,7 @@ Upcoming release
 This part of documentation collects descriptive release notes to capture the main improvements introduced by developing the model before the next release.
 
 **New Features and Major Changes**
+* Update to `technology-data` version v0.12.0 `PR #1452 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1452>`__
 
 * Add a command-line interface in ``databundle_cli.py`` that will be triggered if ``retrieve_databundle_light.py`` fails to retrieve all necessary files, providing a fallback to assist with debugging the issue `PR #1366 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1366>`__
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
Update to v0.12.0 of technology-data. Differently from what mentioned yesterday, it is safe to switch to v0.12.0 now until US-cost configurations are integrated, as the "generic" folder does not contain any changes, only additional technologies which are not yet in PyPSA-Earth or corrections to already present values. There will be soon a patch release to include some additional technologies, but that will be only necessary when #1227 is ready for integration! @ekatef @davide-f @yerbol-akhmetov 

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
