### PR TITLE
Fixing unintentional indent leading to overestimation of emission prices (run multiple times instead of just once)

### DIFF
--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -392,37 +392,37 @@ if __name__ == "__main__":
                 add_gaslimit(n, snakemake.params.electricity.get("gaslimit"), Nyears)
                 logger.info("Setting gas usage limit according to config value.")
 
-        for o in opts:
-            oo = o.split("+")
-            suptechs = map(lambda c: c.split("-", 2)[0], n.carriers.index)
-            if oo[0].startswith(tuple(suptechs)):
-                carrier = oo[0]
-                # handles only p_nom_max as stores and lines have no potentials
-                attr_lookup = {
-                    "p": "p_nom_max",
-                    "c": "capital_cost",
-                    "m": "marginal_cost",
-                }
-                attr = attr_lookup[oo[1][0]]
-                factor = float(oo[1][1:])
-                if carrier == "AC":  # lines do not have carrier
-                    n.lines[attr] *= factor
-                else:
-                    comps = {"Generator", "Link", "StorageUnit", "Store"}
-                    for c in n.iterate_components(comps):
-                        sel = c.df.carrier.str.contains(carrier)
-                        c.df.loc[sel, attr] *= factor
+    for o in opts:
+        oo = o.split("+")
+        suptechs = map(lambda c: c.split("-", 2)[0], n.carriers.index)
+        if oo[0].startswith(tuple(suptechs)):
+            carrier = oo[0]
+            # handles only p_nom_max as stores and lines have no potentials
+            attr_lookup = {
+                "p": "p_nom_max",
+                "c": "capital_cost",
+                "m": "marginal_cost",
+            }
+            attr = attr_lookup[oo[1][0]]
+            factor = float(oo[1][1:])
+            if carrier == "AC":  # lines do not have carrier
+                n.lines[attr] *= factor
+            else:
+                comps = {"Generator", "Link", "StorageUnit", "Store"}
+                for c in n.iterate_components(comps):
+                    sel = c.df.carrier.str.contains(carrier)
+                    c.df.loc[sel, attr] *= factor
 
-        for o in opts:
-            if "Ep" in o:
-                m = re.findall("[0-9]*\.?[0-9]+$", o)
-                if len(m) > 0:
-                    logger.info("Setting emission prices according to wildcard value.")
-                    add_emission_prices(n, dict(co2=float(m[0])))
-                else:
-                    logger.info("Setting emission prices according to config value.")
-                    add_emission_prices(n, snakemake.params.costs["emission_prices"])
-                break
+    for o in opts:
+        if "Ep" in o:
+            m = re.findall("[0-9]*\.?[0-9]+$", o)
+            if len(m) > 0:
+                logger.info("Setting emission prices according to wildcard value.")
+                add_emission_prices(n, dict(co2=float(m[0])))
+            else:
+                logger.info("Setting emission prices according to config value.")
+                add_emission_prices(n, snakemake.params.costs["emission_prices"])
+            break
 
     ll_type, factor = snakemake.wildcards.ll[0], snakemake.wildcards.ll[1:]
     set_transmission_limit(n, ll_type, factor, costs, Nyears)


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request

- Removed one indent in lines 395 to 425, as discussed in Discord support channel: https://discord.com/channels/911692131440148490/1374313993228910644/1374313993228910644.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
