### PR TITLE
Add psuedo `branch()` to streamline snakemake workflow

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1116,8 +1116,7 @@ rule prepare_sector_network:
         + RDIR
         + "bus_regions/regions_onshore_elec_s{simpl}_{clusters}.geojson",
         pipelines=branch(
-            "H2" in config["electricity"]["extendable_carriers"]["Store"]
-            and config["sector"]["hydrogen"]["network"],
+            config["sector"]["hydrogen"]["network"],
             branch(
                 config["custom_data"]["gas_network"],
                 "data/custom/pipelines.csv",

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -703,7 +703,6 @@ sector:
 
   h2_cavern: true
   marginal_cost_storage: 0
-  fischer_tropsch: true
   methanation: true
   helmeth: true
   dac: true
@@ -712,6 +711,7 @@ sector:
   space_heat_share: 0.6 # the share of space heating from all heating. Remainder goes to water heating.
   airport_sizing_factor: 3
 
+  fischer_tropsch: true
   min_part_load_fischer_tropsch: 0.9
 
   conventional_generation: # generator : carrier

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -518,6 +518,18 @@ existing_capacities:
   - uranium
 
 sector:
+  enable:
+    heat: true
+    biomass: true
+    industry: true
+    shipping: true
+    aviation: true
+    land_transport: true
+    rail_transport: true
+    agriculture: true
+    residential: true
+    services: true
+
   gas:
     spatial_gas: true # ALWAYS TRUE
     network: false # ALWAYS FALSE for now (NOT USED)
@@ -691,6 +703,7 @@ sector:
 
   h2_cavern: true
   marginal_cost_storage: 0
+  fischer_tropsch: true
   methanation: true
   helmeth: true
   dac: true

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -13,7 +13,7 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **New Features and Major Changes**
 
-* Add pseudo `branch()` to streamline snakemake workflow. Replace this with Snakemake implementation if Snakemake >= 8.3.0. Added an option to configure which sector components to include which when disabled, irrelevant rules are skipped automatically `PR #1583 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1538>`__
+* Add pseudo `branch()` to streamline snakemake workflow. Replace this with Snakemake implementation if Snakemake >= 8.3.0. Added an option to configure which sector components to include which when disabled, irrelevant rules are skipped automatically `PR #1538 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1538>`__
 
 **Minor Changes and bug-fixing**
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -13,6 +13,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **New Features and Major Changes**
 
+* Add pseudo `branch()` to streamline snakemake workflow. Replace this with Snakemake implementation if Snakemake >= 8.3.0. Added an option to configure which sector components to include which when disabled, irrelevant rules are skipped automatically `PR #1583 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1538>`__
+
 **Minor Changes and bug-fixing**
 
 PyPSA-Earth 0.7.0

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -1811,3 +1811,14 @@ def set_length_based_efficiency(n, carrier, bus_suffix, transmission_efficiency)
         """
         # set the required compression demand
         n.links.loc[carrier_i, "efficiency2"] = -compression_per_1000km * lengths / 1e3
+
+
+def branch(condition, then, otherwise):
+    """
+    This is a placeholder function that exists in Snakemake versions > 8.3.0.
+    It can be removed once Snakemake is updated to a compatible version.
+    """
+    if condition:
+        return then
+    else:
+        return otherwise

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -1813,7 +1813,7 @@ def set_length_based_efficiency(n, carrier, bus_suffix, transmission_efficiency)
         n.links.loc[carrier_i, "efficiency2"] = -compression_per_1000km * lengths / 1e3
 
 
-def branch(condition, then, otherwise):
+def branch(condition, then, otherwise=[]):
     """
     This is a placeholder function that exists in Snakemake versions > 8.3.0.
     It can be removed once Snakemake is updated to a compatible version.

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -1813,12 +1813,20 @@ def set_length_based_efficiency(n, carrier, bus_suffix, transmission_efficiency)
         n.links.loc[carrier_i, "efficiency2"] = -compression_per_1000km * lengths / 1e3
 
 
-def branch(condition, then, otherwise=[]):
+def branch(condition, then, otherwise=None):
     """
     This is a placeholder function that exists in Snakemake versions > 8.3.0.
     It can be removed once Snakemake is updated to a compatible version.
     """
     if condition:
         return then
-    else:
-        return otherwise
+
+    if otherwise is None:
+        if isinstance(then, dict):
+            return {}
+        elif isinstance(then, str):
+            return []
+        else:
+            return None
+
+    return otherwise

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -628,7 +628,7 @@ if __name__ == "__main__":
     )
 
     # TODO: not implemented in -sec yet
-    # if options["heating"]:
+    # if options["enable"]["heat"]:
     #     time_dep_hp_cop = options["time_dep_hp_cop"]
     #     ashp_cop = (
     #         xr.open_dataarray(snakemake.input.cop_air_total)

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1222,14 +1222,17 @@ def add_co2(n, costs, co2_network):
         )
 
 
-def add_aviation(n, cost):
+def add_aviation(n, cost, energy_totals, airports_fn):
+    # Load data required for aviation and navigation
+    # TODO follow the same structure as land transport and heat
+
     all_aviation = ["total international aviation", "total domestic aviation"]
 
     aviation_demand = (
         energy_totals.loc[countries, all_aviation].sum(axis=1).sum()  # * 1e6 / 8760
     )
 
-    airports = pd.read_csv(snakemake.input.airports, keep_default_na=False)
+    airports = pd.read_csv(airports_fn, keep_default_na=False)
     airports = airports[airports.country.isin(countries)]
 
     gadm_layer_id = snakemake.params.gadm_layer_id
@@ -1377,10 +1380,8 @@ def h2_hc_conversions(n, costs):
         )
 
 
-def add_shipping(n, costs):
-    ports = pd.read_csv(
-        snakemake.input.ports, index_col=None, keep_default_na=False
-    ).squeeze()
+def add_shipping(n, costs, energy_totals, ports_fn):
+    ports = pd.read_csv(ports_fn, index_col=None, keep_default_na=False).squeeze()
     ports = ports[ports.country.isin(countries)]
 
     gadm_layer_id = snakemake.params.gadm_layer_id
@@ -1527,8 +1528,18 @@ def add_shipping(n, costs):
         )
 
 
-def add_industry(n, costs):
+def add_industry(
+    n,
+    costs,
+    industrial_demand_fn,
+):
     logger.info("adding industrial demand")
+
+    # Load industry demand data
+    industrial_demand = pd.read_csv(
+        industrial_demand_fn, index_col=0, header=0
+    )  # * 1e6
+
     # 1e6 to convert TWh to MWh
 
     # industrial_demand.reset_index(inplace=True)
@@ -1840,10 +1851,27 @@ Missing data:
 """
 
 
-def add_land_transport(n, costs):
+def add_land_transport(
+    n,
+    costs,
+    transport_fn,
+    avail_profile_fn,
+    dsm_profile_fn,
+    nodal_transport_data_fn,
+):
     """
     Function to add land transport to network.
     """
+    # Get the data required for land transport
+    # TODO Leon, This contains transport demand, right? if so let's change it to transport_demand?
+    transport = pd.read_csv(transport_fn, index_col=0, parse_dates=True).reindex(
+        columns=spatial.nodes, fill_value=0.0
+    )
+
+    avail_profile = pd.read_csv(avail_profile_fn, index_col=0, parse_dates=True)
+    dsm_profile = pd.read_csv(dsm_profile_fn, index_col=0, parse_dates=True)
+    nodal_transport_data = pd.read_csv(nodal_transport_data_fn, index_col=0)
+    # TODO nodal_transport_data only includes no. of cars, change name to something descriptive?
     # TODO options?
 
     logger.info("adding land transport")
@@ -2013,7 +2041,7 @@ def add_land_transport(n, costs):
         )
 
 
-def create_nodes_for_heat_sector():
+def create_nodes_for_heat_sector(district_heat_share):
     # TODO pop_layout
 
     # rural are areas with low heating density and individual heating
@@ -2058,7 +2086,31 @@ def create_nodes_for_heat_sector():
     return h_nodes, dist_fraction_node, urban_fraction
 
 
-def add_heat(n, costs):
+def add_heat(
+    n,
+    costs,
+    heat_demand_fn,
+    solar_thermal_fn,
+    gshp_cop_fn,
+    ashp_cop_fn,
+    district_heat_share_fn,
+):
+    # Load data required for heat sector
+    heat_demand = pd.read_csv(
+        heat_demand_fn, index_col=0, header=[0, 1], parse_dates=True
+    ).fillna(0)
+    # Solar thermal availability profiles
+    solar_thermal = pd.read_csv(solar_thermal_fn, index_col=0, parse_dates=True)
+    # Ground-sourced heatpump coefficient of performance
+    gshp_cop = pd.read_csv(gshp_cop_fn, index_col=0, parse_dates=True)
+    # Air-sourced heatpump coefficient of performance
+    ashp_cop = pd.read_csv(
+        ashp_cop_fn, index_col=0, parse_dates=True
+    )  # only needed with heat dep. hp cop allowed from config
+    # TODO add option heat_dep_hp_cop to the config
+
+    # Share of district heating at each node
+    district_heat_share = pd.read_csv(district_heat_share_fn, index_col=0)
     # TODO options?
     # TODO pop_layout?
 
@@ -2066,7 +2118,9 @@ def add_heat(n, costs):
 
     sectors = ["residential", "services"]
 
-    h_nodes, dist_fraction, urban_fraction = create_nodes_for_heat_sector()
+    h_nodes, dist_fraction, urban_fraction = create_nodes_for_heat_sector(
+        district_heat_share
+    )
 
     # NB: must add costs of central heating afterwards (EUR 400 / kWpeak, 50a, 1% FOM from Fraunhofer ISE)
 
@@ -2398,7 +2452,7 @@ def add_dac(n, costs):
     )
 
 
-def add_services(n, costs):
+def add_services(n, costs, energy_totals):
     temporal_resolution = n.snapshot_weightings.generators
     buses = spatial.nodes.intersection(n.loads_t.p_set.columns)
 
@@ -2491,7 +2545,14 @@ def add_services(n, costs):
     )
 
 
-def add_agriculture(n, costs):
+def add_agriculture(n, costs, nodal_energy_totals_fn):
+    nodal_energy_totals = pd.read_csv(
+        nodal_energy_totals_fn,
+        index_col=0,
+        keep_default_na=False,
+        na_values=[""],
+    )
+
     n.madd(
         "Load",
         spatial.nodes,
@@ -2571,7 +2632,7 @@ def p_set_from_scaling(col, scaling, energy_totals, nhours):
     )
 
 
-def add_residential(n, costs):
+def add_residential(n, costs, energy_totals):
     # need to adapt for many countries #TODO
 
     # if snakemake.config["custom_data"]["heat_demand"]:
@@ -2904,7 +2965,13 @@ def add_custom_water_cost(n):
         # print(n.links.filter(like=country, axis=0).filter(like='lectrolysis', axis=0).marginal_cost)
 
 
-def add_rail_transport(n, costs):
+def add_rail_transport(n, costs, nodal_energy_totals_fn):
+    nodal_energy_totals = pd.read_csv(
+        nodal_energy_totals_fn,
+        index_col=0,
+        keep_default_na=False,
+        na_values=[""],
+    )
     p_set_elec = nodal_energy_totals.loc[spatial.nodes, "electricity rail"]
     p_set_oil = (nodal_energy_totals.loc[spatial.nodes, "total rail"]) - p_set_elec
 
@@ -3022,6 +3089,8 @@ if __name__ == "__main__":
 
     # Load all sector wildcards
     options = snakemake.params.sector_options
+    enable = options["enable"]
+    extendable_storage = snakemake.params.electricity["extendable_carriers"]["Store"]
 
     # Load input network
     overrides = override_component_attrs(snakemake.input.overrides)
@@ -3073,65 +3142,12 @@ if __name__ == "__main__":
 
     # TODO logging
 
-    nodal_energy_totals = pd.read_csv(
-        snakemake.input.nodal_energy_totals,
-        index_col=0,
-        keep_default_na=False,
-        na_values=[""],
-    )
     energy_totals = pd.read_csv(
         snakemake.input.energy_totals,
         index_col=0,
         keep_default_na=False,
         na_values=[""],
     )
-    # Get the data required for land transport
-    # TODO Leon, This contains transport demand, right? if so let's change it to transport_demand?
-    transport = pd.read_csv(
-        snakemake.input.transport, index_col=0, parse_dates=True
-    ).reindex(columns=spatial.nodes, fill_value=0.0)
-
-    avail_profile = pd.read_csv(
-        snakemake.input.avail_profile, index_col=0, parse_dates=True
-    )
-    dsm_profile = pd.read_csv(
-        snakemake.input.dsm_profile, index_col=0, parse_dates=True
-    )
-    nodal_transport_data = pd.read_csv(  # TODO This only includes no. of cars, change name to something descriptive?
-        snakemake.input.nodal_transport_data, index_col=0
-    )
-
-    # Load data required for the heat sector
-    heat_demand = pd.read_csv(
-        snakemake.input.heat_demand, index_col=0, header=[0, 1], parse_dates=True
-    ).fillna(0)
-    # Ground-sourced heatpump coefficient of performance
-    gshp_cop = pd.read_csv(
-        snakemake.input.gshp_cop, index_col=0, parse_dates=True
-    )  # only needed with heat dep. hp cop allowed from config
-    # TODO add option heat_dep_hp_cop to the config
-
-    # Air-sourced heatpump coefficient of performance
-    ashp_cop = pd.read_csv(
-        snakemake.input.ashp_cop, index_col=0, parse_dates=True
-    )  # only needed with heat dep. hp cop allowed from config
-
-    # Solar thermal availability profiles
-    solar_thermal = pd.read_csv(
-        snakemake.input.solar_thermal, index_col=0, parse_dates=True
-    )
-    gshp_cop = pd.read_csv(snakemake.input.gshp_cop, index_col=0, parse_dates=True)
-
-    # Share of district heating at each node
-    district_heat_share = pd.read_csv(snakemake.input.district_heat_share, index_col=0)
-
-    # Load data required for aviation and navigation
-    # TODO follow the same structure as land transport and heat
-
-    # Load industry demand data
-    industrial_demand = pd.read_csv(
-        snakemake.input.industrial_demand, index_col=0, header=0
-    )  # * 1e6
 
     ##########################################################################
     ############## Functions adding different carrires and sectors ###########
@@ -3157,36 +3173,84 @@ if __name__ == "__main__":
     add_generation(n, costs, existing_capacities, existing_efficiencies, existing_nodes)
 
     # remove H2 and battery technologies added in elec-only model
-    remove_carrier_related_components(n, carriers_to_drop=["H2", "battery"])
+    remove_carrier_related_components(n, carriers_to_drop=extendable_storage)
 
-    add_hydrogen(n, costs)  # TODO add costs
+    if "H2" in extendable_storage:
+        add_hydrogen(n, costs)  # TODO add costs
 
-    add_storage(n, costs)
+    if "battery" in extendable_storage:
+        add_storage(n, costs)
 
-    H2_liquid_fossil_conversions(n, costs)
+    if options["fischer_tropsch"]:
+        H2_liquid_fossil_conversions(n, costs)
 
     h2_hc_conversions(n, costs)
-    add_heat(n, costs)
-    add_biomass(n, costs)
 
-    add_industry(n, costs)
+    if enable["heat"]:
+        add_heat(
+            n,
+            costs,
+            heat_demand_fn=snakemake.input.heat_demand,
+            solar_thermal_fn=snakemake.input.solar_thermal,
+            gshp_cop_fn=snakemake.input.gshp_cop,
+            ashp_cop_fn=snakemake.input.ashp_cop,
+            district_heat_share_fn=snakemake.input.district_heat_share,
+        )
 
-    add_shipping(n, costs)
+    if enable["biomass"]:
+        add_biomass(n, costs)
 
-    # Add_aviation runs with dummy data
-    add_aviation(n, costs)
+    if enable["industry"]:
+        add_industry(
+            n,
+            costs,
+            industrial_demand_fn=snakemake.input.industrial_demand,
+        )
 
-    # prepare_transport_data(n)
+    if enable["shipping"]:
+        add_shipping(
+            n,
+            costs,
+            energy_totals,
+            ports_fn=snakemake.input.ports,
+        )
 
-    add_land_transport(n, costs)
+    if enable["aviation"]:
+        # aviation runs with dummy data
+        add_aviation(
+            n,
+            costs,
+            energy_totals,
+            airports_fn=snakemake.input.airports,
+        )
 
-    # if snakemake.config["custom_data"]["transport_demand"]:
-    add_rail_transport(n, costs)
+    if enable["land_transport"]:
+        # prepare_transport_data(n)
 
-    # if snakemake.config["custom_data"]["custom_sectors"]:
-    add_agriculture(n, costs)
-    add_residential(n, costs)
-    add_services(n, costs)
+        add_land_transport(
+            n,
+            costs,
+            transport_fn=snakemake.input.transport,
+            avail_profile_fn=snakemake.input.avail_profile,
+            dsm_profile_fn=snakemake.input.dsm_profile,
+            nodal_transport_data=snakemake.input.nodal_transport_data,
+        )
+
+    if enable["rail_transport"]:
+        add_rail_transport(
+            n, costs, nodal_energy_totals_fn=snakemake.input.nodal_energy_totals
+        )
+
+    if enable["agriculture"]:
+        add_agriculture(
+            n, costs, nodal_energy_totals_fn=snakemake.input.nodal_energy_totals
+        )
+
+    if enable["residential"]:
+        add_residential(n, costs, energy_totals)
+
+    if enable["services"]:
+        add_services(n, costs, energy_totals)
 
     if options.get("electricity_distribution_grid", False):
         add_electricity_distribution_grid(n, costs)

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3090,7 +3090,6 @@ if __name__ == "__main__":
     # Load all sector wildcards
     options = snakemake.params.sector_options
     enable = options["enable"]
-    extendable_storage = snakemake.params.electricity["extendable_carriers"]["Store"]
 
     # Load input network
     overrides = override_component_attrs(snakemake.input.overrides)
@@ -3173,13 +3172,11 @@ if __name__ == "__main__":
     add_generation(n, costs, existing_capacities, existing_efficiencies, existing_nodes)
 
     # remove H2 and battery technologies added in elec-only model
-    remove_carrier_related_components(n, carriers_to_drop=extendable_storage)
+    remove_carrier_related_components(n, carriers_to_drop=["H2", "battery"])
 
-    if "H2" in extendable_storage:
-        add_hydrogen(n, costs)  # TODO add costs
+    add_hydrogen(n, costs)  # TODO add costs
 
-    if "battery" in extendable_storage:
-        add_storage(n, costs)
+    add_storage(n, costs)
 
     if options["fischer_tropsch"]:
         H2_liquid_fossil_conversions(n, costs)

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3233,7 +3233,7 @@ if __name__ == "__main__":
             transport_fn=snakemake.input.transport,
             avail_profile_fn=snakemake.input.avail_profile,
             dsm_profile_fn=snakemake.input.dsm_profile,
-            nodal_transport_data=snakemake.input.nodal_transport_data,
+            nodal_transport_data_fn=snakemake.input.nodal_transport_data,
         )
 
     if enable["rail_transport"]:


### PR DESCRIPTION
## Changes proposed in this Pull Request

This is part of the discussion in issue #1507. Ideally, this should be handled using Snakemake version ≥ 8.3.0. However, until issue #1312 (or a similar future enhancement) is resolved, this serves as the next best alternative.

The immediate improvement is to eliminate duplicate `cluster_network` rules. A more robust solution would be to structure `prepare_sector_network.py` so that if a particular config is not enabled, the corresponding input-generating rules are not activated

Things that can be streamlined:
- `build_industry_demand`
- `prepare_transport_data`
- `prepare_airport`
- `prepare_ports`
- `prepare_heat_data`

<img width="2321" height="1444" alt="sector" src="https://github.com/user-attachments/assets/d761ccbc-2f71-4663-91b8-2d736b17ef99" />

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [x] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
