### PR TITLE
Revise format of Discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The diagram below depicts one representative clustered node for the sector-coupl
 ## How to get involved
 
 There are multiple ways to get involved and learn more about our work:
-1. **Join our forum** and communication platform on [**PyPSA-meets-Earth**](https://discord.gg/AnuJBk23FU) Discord Server
+1. **Join** [**our Discord Server**](https://discord.gg/AnuJBk23FU) to connect in discussion channels, get help in the support forum, and join our meetings
 2. **Chat on Discord with us** in the following open meetings:
     - **General initiative meeting** for project news and [high-level code updates](https://docs.google.com/document/d/1r6wm2RBe0DWFngmItpFfSFHA-CnUmVcVTkIKmthdW3g/edit?usp=sharing). Held every [fourth Thursday 16-17:00 (UK time)](https://drive.google.com/file/d/1naH4WwW9drkOkOJ3PLO4fyWdkZQi5-_w/view?usp=share_link) and is a perfect place to meet the community and get a high-level update on PyPSA ecosystem relevant for PyPSA-Earth developments.
     - **Weekly developers meetings**


### PR DESCRIPTION
## Changes proposed in this Pull Request

It has been discovered that finding Discord invitation is not obvious at all in the current README. The PR aims to improve clarity of that 

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
