### PR TITLE
Documenting and moving `focus_weights` to `cluster_options`

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -104,7 +104,7 @@ cluster_options:
       ramp_limit_up: max
       ramp_limit_down: max
       efficiency: mean
-  focus_weights: false # When a value specified, set the share of nodes allocated to each country
+  focus_weights: null # When a value specified, set the share of nodes allocated to each country
     # country: share
 
 build_shape_options:

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -104,7 +104,7 @@ cluster_options:
       ramp_limit_up: max
       ramp_limit_down: max
       efficiency: mean
-  focus_weights:      # When a value specified, set the share of nodes allocated to each country
+  focus_weights: false # When a value specified, set the share of nodes allocated to each country
     # country: share
 
 build_shape_options:

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -104,7 +104,7 @@ cluster_options:
       ramp_limit_up: max
       ramp_limit_down: max
       efficiency: mean
-  focus_weights: null # When a value specified, set the share of nodes allocated to each country
+  focus_weights:      # When a value specified, set the share of nodes allocated to each country
     # country: share
 
 build_shape_options:

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -104,7 +104,7 @@ cluster_options:
       ramp_limit_up: max
       ramp_limit_down: max
       efficiency: mean
-  focus_weights: # When specified, set the share of nodes allocated to each country
+  focus_weights: false # When a value specified, set the share of nodes allocated to each country
     # country: share
 
 build_shape_options:

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -104,6 +104,7 @@ cluster_options:
       ramp_limit_up: max
       ramp_limit_down: max
       efficiency: mean
+  focus_weights: None # {country: factor} When specified, set the proportion of nodes assigned to each country
 
 build_shape_options:
   gadm_layer_id: 1 # GADM level area used for the gadm_shapes. Codes are country-dependent but roughly: 0: country, 1: region/county-like, 2: municipality-like

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -104,7 +104,8 @@ cluster_options:
       ramp_limit_up: max
       ramp_limit_down: max
       efficiency: mean
-  focus_weights: None # {country: factor} When specified, set the proportion of nodes assigned to each country
+  focus_weights: # When specified, set the share of nodes allocated to each country
+    # country: share
 
 build_shape_options:
   gadm_layer_id: 1 # GADM level area used for the gadm_shapes. Codes are country-dependent but roughly: 0: country, 1: region/county-like, 2: municipality-like

--- a/doc/configtables/cluster_options.csv
+++ b/doc/configtables/cluster_options.csv
@@ -1,30 +1,30 @@
 ,Unit,Values,Description
 simplify_network,,,
--- to_substations, bool,"{True, False}",False: network is simplified to nodes with positive or negative power injection (i.e. substations or offwind connections).
--- algorithm,,"{hac, kmeans, modularity}","Clustering algorithm used in the simplify_network rule. Options available are Hierarchical Agglomerative Clustering (HAC), k-means, or greedy modularity."
--- feature,,"Str in the format ‘carrier1+carrier2+...+carrierN-X’, where CarrierI can be from {‘solar’, ‘onwind’, ‘offwind’, ‘ror’} and X is one of {‘cap’, ‘time’}. Examples: solar+offwind-cap, solar-time",Only for Hierarchical Agglomerative Clustering (HAC). Feature(s) used to do the clustering.
--- exclude_carriers,,"List of Str like [ 'solar', 'onwind'] or empy list []",Carriers not considered in the simplify_network rule. Can be any set of carriers (conventional or renewable).
--- remove_stubs, bool,"{True, False}","True: Stub lines and links, i.e. dead-ends of the network, are sequentially removed from the network."
--- remove_stubs_across_borders, bool,"{True, False}",True: Stub lines and links can be removed across borders.
--- p_threshold_drop_isolated, MW, positive number,Isolated buses are discarded if bus mean power is below the `p_threshold_drop_isolated`.
--- p_threshold_merge_isolated, MW, positive number,Isolated buses are merged into a single isolated bus if bus mean power is below `p_threshold_merge_isolated`.
--- s_threshold_fetch_isolated, [-], positive number,Isolated networks are merged into a backbone network of a respective country if the network load comprises a share of the national load less than p_threshold_fetch_isolated.
+-- to_substations, bool, "{True, False}", "False: network is simplified to nodes with positive or negative power injection (i.e. substations or offwind connections)."
+-- algorithm,, "{hac, kmeans, modularity}", "Clustering algorithm used in the simplify_network rule. Options available are Hierarchical Agglomerative Clustering (HAC), k-means, or greedy modularity."
+-- feature,, "Str in the format ‘carrier1+carrier2+...+carrierN-X’, where CarrierI can be from {‘solar’, ‘onwind’, ‘offwind’, ‘ror’} and X is one of {‘cap’, ‘time’}. Examples: solar+offwind-cap, solar-time", "Only for Hierarchical Agglomerative Clustering (HAC). Feature(s) used to do the clustering."
+-- exclude_carriers,, "List of Str like [ 'solar', 'onwind'] or empy list []", "Carriers not considered in the simplify_network rule. Can be any set of carriers (conventional or renewable)."
+-- remove_stubs, bool, "{True, False}", "True: Stub lines and links, i.e. dead-ends of the network, are sequentially removed from the network."
+-- remove_stubs_across_borders, bool, "{True, False}", "True: Stub lines and links can be removed across borders."
+-- p_threshold_drop_isolated, MW, positive number, "Isolated buses are discarded if bus mean power is below the `p_threshold_drop_isolated`."
+-- p_threshold_merge_isolated, MW, positive number, "Isolated buses are merged into a single isolated bus if bus mean power is below `p_threshold_merge_isolated`."
+-- s_threshold_fetch_isolated, [-], positive number, "Isolated networks are merged into a backbone network of a respective country if the network load comprises a share of the national load less than p_threshold_fetch_isolated."
 cluster_network,,,
--- algorithm,,"{hac, kmeans}",Clustering algorithm used in the cluster_network rule. Options available are Hierarchical Agglomerative Clustering (HAC) or k-means.
--- feature,,"Str in the format ‘carrier1+carrier2+...+carrierN-X’, where CarrierI can be from {‘solar’, ‘onwind’, ‘offwind’, ‘ror’} and X is one of {‘cap’, ‘time’}. Examples: solar+offwind-cap, solar-time",Only for Hierarchical Agglomerative Clustering (HAC). Feature(s) used to do the clustering.
--- exclude_carriers,,"List of Str like [ 'solar', 'onwind'] or empy list []",Carriers not considered in the cluster_network rule. Can be any set of carriers (conventional or renewable).
-alternative_clustering, bool,"{True, False}",False: use Voronoi shapes in the clustering. True: use GADM shapes in the clustering.
-distribute_cluster,,"{['load'], ['pop'], ['gdp']}","Distributes cluster nodes per country according to load (['load']), population (['pop']) or GDP (['gdp'])."
-out_logging, bool,"{True, False}",True: Logging is printed to the console.
+-- algorithm,,"{hac, kmeans}", "Clustering algorithm used in the cluster_network rule. Options available are Hierarchical Agglomerative Clustering (HAC) or k-means."
+-- feature,,"Str in the format ‘carrier1+carrier2+...+carrierN-X’, where CarrierI can be from {‘solar’, ‘onwind’, ‘offwind’, ‘ror’} and X is one of {‘cap’, ‘time’}. Examples: solar+offwind-cap, solar-time", "Only for Hierarchical Agglomerative Clustering (HAC). Feature(s) used to do the clustering."
+-- exclude_carriers,, "List of Str like [ 'solar', 'onwind'] or empy list []", "Carriers not considered in the cluster_network rule. Can be any set of carriers (conventional or renewable)."
+alternative_clustering, bool, "{True, False}", "False: use Voronoi shapes in the clustering. True: use GADM shapes in the clustering."
+distribute_cluster,, "{['load'], ['pop'], ['gdp']}", "Distributes cluster nodes per country according to load (['load']), population (['pop']) or GDP (['gdp'])."
+out_logging, bool, "{True, False}", "True: Logging is printed to the console."
 aggregation_strategies,,,
 -- generators,,,
--- -- p_nom,,"{min, mean, max, sum}","Indicates how the p_nom of the aggregated generator is computed from the original p_nom values. For example, if sum, then all values within each cluster are summed to represent the new generator."
--- -- p_nom_max,,"{min, mean, max, sum}",Indicates how the p_nom_max of the aggregated generator is computed from the original p_nom_max values.
--- -- p_nom_min,,"{min, mean, max, sum}",Indicates how the p_nom_min of the aggregated generator is computed from the original p_nom_min values.
--- -- p_min_pu,,"{min, mean, max, sum}",Indicates how the p_min_pu of the aggregated generator is computed from the original p_min_pu values.
--- -- marginal_cost,,"{min, mean, max, sum}",Indicates how the marginal_cost of the aggregated generator is computed from the original marginal_cost values.
--- -- commitable,,{any},"Indicates how the commit status of the aggregated generator is set depending on the original values of the generators. Unit Commitment is currently under development, so should be left to ``any``."
--- -- ramp_limit_up,,"{min, mean, max, sum}",Indicates how the ramp_limit_up of the aggregated generator is computed from the original ramp_limit_up values.
--- -- ramp_limit_down,,"{min, mean, max, sum}",Indicates how the ramp_limit_down of the aggregated generator is computed from the original ramp_limit_down values.
--- -- efficiency,,"{min, mean, max, sum}",Indicates how the efficiency of the aggregated generator is computed from the original efficiency values.
-focus_weights,,Dict consisting of {country: factor} such as {NG: 0.4},"When specified, set the proportion of nodes assigned to each country. The sum of focus weights must be less than or equal to 1."
+-- -- p_nom,, "{min, mean, max, sum}", "Indicates how the p_nom of the aggregated generator is computed from the original p_nom values. For example, if sum, then all values within each cluster are summed to represent the new generator."
+-- -- p_nom_max,, "{min, mean, max, sum}", "Indicates how the p_nom_max of the aggregated generator is computed from the original p_nom_max values."
+-- -- p_nom_min,, "{min, mean, max, sum}", "Indicates how the p_nom_min of the aggregated generator is computed from the original p_nom_min values."
+-- -- p_min_pu,, "{min, mean, max, sum}", "Indicates how the p_min_pu of the aggregated generator is computed from the original p_min_pu values."
+-- -- marginal_cost,, "{min, mean, max, sum}", "Indicates how the marginal_cost of the aggregated generator is computed from the original marginal_cost values."
+-- -- commitable,,"{any}", "Indicates how the commit status of the aggregated generator is set depending on the original values of the generators. Unit Commitment is currently under development, so should be left to ``any``."
+-- -- ramp_limit_up,, "{min, mean, max, sum}", "Indicates how the ramp_limit_up of the aggregated generator is computed from the original ramp_limit_up values."
+-- -- ramp_limit_down,, "{min, mean, max, sum}", "Indicates how the ramp_limit_down of the aggregated generator is computed from the original ramp_limit_down values."
+-- -- efficiency,, "{min, mean, max, sum}", "Indicates how the efficiency of the aggregated generator is computed from the original efficiency values."
+focus_weights,, "Dict consisting of {country: share} such as {NG: 0.4}", "When specified, set the share of nodes allocated to each country. The sum of focus weights must be less than or equal to 1."

--- a/doc/configtables/cluster_options.csv
+++ b/doc/configtables/cluster_options.csv
@@ -1,29 +1,30 @@
 ,Unit,Values,Description
 simplify_network,,,
--- to_substations, bool, "{True, False}", "False: network is simplified to nodes with positive or negative power injection (i.e. substations or offwind connections)."
--- algorithm,, "{hac, kmeans, modularity}", "Clustering algorithm used in the simplify_network rule. Options available are Hierarchical Agglomerative Clustering (HAC), k-means, or greedy modularity."
--- feature,, "Str in the format ‘carrier1+carrier2+...+carrierN-X’, where CarrierI can be from {‘solar’, ‘onwind’, ‘offwind’, ‘ror’} and X is one of {‘cap’, ‘time’}. Examples: solar+offwind-cap, solar-time", "Only for Hierarchical Agglomerative Clustering (HAC). Feature(s) used to do the clustering."
--- exclude_carriers,, "List of Str like [ 'solar', 'onwind'] or empy list []", "Carriers not considered in the simplify_network rule. Can be any set of carriers (conventional or renewable)."
--- remove_stubs, bool, "{True, False}", "True: Stub lines and links, i.e. dead-ends of the network, are sequentially removed from the network."
--- remove_stubs_across_borders, bool, "{True, False}", "True: Stub lines and links can be removed across borders."
--- p_threshold_drop_isolated, MW, positive number, "Isolated buses are discarded if bus mean power is below the `p_threshold_drop_isolated`."
--- p_threshold_merge_isolated, MW, positive number, "Isolated buses are merged into a single isolated bus if bus mean power is below `p_threshold_merge_isolated`."
--- s_threshold_fetch_isolated, [-], positive number, "Isolated networks are merged into a backbone network of a respective country if the network load comprises a share of the national load less than p_threshold_fetch_isolated."
+-- to_substations, bool,"{True, False}",False: network is simplified to nodes with positive or negative power injection (i.e. substations or offwind connections).
+-- algorithm,,"{hac, kmeans, modularity}","Clustering algorithm used in the simplify_network rule. Options available are Hierarchical Agglomerative Clustering (HAC), k-means, or greedy modularity."
+-- feature,,"Str in the format ‘carrier1+carrier2+...+carrierN-X’, where CarrierI can be from {‘solar’, ‘onwind’, ‘offwind’, ‘ror’} and X is one of {‘cap’, ‘time’}. Examples: solar+offwind-cap, solar-time",Only for Hierarchical Agglomerative Clustering (HAC). Feature(s) used to do the clustering.
+-- exclude_carriers,,"List of Str like [ 'solar', 'onwind'] or empy list []",Carriers not considered in the simplify_network rule. Can be any set of carriers (conventional or renewable).
+-- remove_stubs, bool,"{True, False}","True: Stub lines and links, i.e. dead-ends of the network, are sequentially removed from the network."
+-- remove_stubs_across_borders, bool,"{True, False}",True: Stub lines and links can be removed across borders.
+-- p_threshold_drop_isolated, MW, positive number,Isolated buses are discarded if bus mean power is below the `p_threshold_drop_isolated`.
+-- p_threshold_merge_isolated, MW, positive number,Isolated buses are merged into a single isolated bus if bus mean power is below `p_threshold_merge_isolated`.
+-- s_threshold_fetch_isolated, [-], positive number,Isolated networks are merged into a backbone network of a respective country if the network load comprises a share of the national load less than p_threshold_fetch_isolated.
 cluster_network,,,
--- algorithm,,"{hac, kmeans}", "Clustering algorithm used in the cluster_network rule. Options available are Hierarchical Agglomerative Clustering (HAC) or k-means."
--- feature,,"Str in the format ‘carrier1+carrier2+...+carrierN-X’, where CarrierI can be from {‘solar’, ‘onwind’, ‘offwind’, ‘ror’} and X is one of {‘cap’, ‘time’}. Examples: solar+offwind-cap, solar-time", "Only for Hierarchical Agglomerative Clustering (HAC). Feature(s) used to do the clustering."
--- exclude_carriers,, "List of Str like [ 'solar', 'onwind'] or empy list []", "Carriers not considered in the cluster_network rule. Can be any set of carriers (conventional or renewable)."
-alternative_clustering, bool, "{True, False}", "False: use Voronoi shapes in the clustering. True: use GADM shapes in the clustering."
-distribute_cluster,, "{['load'], ['pop'], ['gdp']}", "Distributes cluster nodes per country according to load (['load']), population (['pop']) or GDP (['gdp'])."
-out_logging, bool, "{True, False}", "True: Logging is printed to the console."
+-- algorithm,,"{hac, kmeans}",Clustering algorithm used in the cluster_network rule. Options available are Hierarchical Agglomerative Clustering (HAC) or k-means.
+-- feature,,"Str in the format ‘carrier1+carrier2+...+carrierN-X’, where CarrierI can be from {‘solar’, ‘onwind’, ‘offwind’, ‘ror’} and X is one of {‘cap’, ‘time’}. Examples: solar+offwind-cap, solar-time",Only for Hierarchical Agglomerative Clustering (HAC). Feature(s) used to do the clustering.
+-- exclude_carriers,,"List of Str like [ 'solar', 'onwind'] or empy list []",Carriers not considered in the cluster_network rule. Can be any set of carriers (conventional or renewable).
+alternative_clustering, bool,"{True, False}",False: use Voronoi shapes in the clustering. True: use GADM shapes in the clustering.
+distribute_cluster,,"{['load'], ['pop'], ['gdp']}","Distributes cluster nodes per country according to load (['load']), population (['pop']) or GDP (['gdp'])."
+out_logging, bool,"{True, False}",True: Logging is printed to the console.
 aggregation_strategies,,,
 -- generators,,,
--- -- p_nom,, "{min, mean, max, sum}", "Indicates how the p_nom of the aggregated generator is computed from the original p_nom values. For example, if sum, then all values within each cluster are summed to represent the new generator."
--- -- p_nom_max,, "{min, mean, max, sum}", "Indicates how the p_nom_max of the aggregated generator is computed from the original p_nom_max values."
--- -- p_nom_min,, "{min, mean, max, sum}", "Indicates how the p_nom_min of the aggregated generator is computed from the original p_nom_min values."
--- -- p_min_pu,, "{min, mean, max, sum}", "Indicates how the p_min_pu of the aggregated generator is computed from the original p_min_pu values."
--- -- marginal_cost,, "{min, mean, max, sum}", "Indicates how the marginal_cost of the aggregated generator is computed from the original marginal_cost values."
--- -- commitable,,"{any}", "Indicates how the commit status of the aggregated generator is set depending on the original values of the generators. Unit Commitment is currently under development, so should be left to ``any``."
--- -- ramp_limit_up,, "{min, mean, max, sum}", "Indicates how the ramp_limit_up of the aggregated generator is computed from the original ramp_limit_up values."
--- -- ramp_limit_down,, "{min, mean, max, sum}", "Indicates how the ramp_limit_down of the aggregated generator is computed from the original ramp_limit_down values."
--- -- efficiency,, "{min, mean, max, sum}", "Indicates how the efficiency of the aggregated generator is computed from the original efficiency values."
+-- -- p_nom,,"{min, mean, max, sum}","Indicates how the p_nom of the aggregated generator is computed from the original p_nom values. For example, if sum, then all values within each cluster are summed to represent the new generator."
+-- -- p_nom_max,,"{min, mean, max, sum}",Indicates how the p_nom_max of the aggregated generator is computed from the original p_nom_max values.
+-- -- p_nom_min,,"{min, mean, max, sum}",Indicates how the p_nom_min of the aggregated generator is computed from the original p_nom_min values.
+-- -- p_min_pu,,"{min, mean, max, sum}",Indicates how the p_min_pu of the aggregated generator is computed from the original p_min_pu values.
+-- -- marginal_cost,,"{min, mean, max, sum}",Indicates how the marginal_cost of the aggregated generator is computed from the original marginal_cost values.
+-- -- commitable,,{any},"Indicates how the commit status of the aggregated generator is set depending on the original values of the generators. Unit Commitment is currently under development, so should be left to ``any``."
+-- -- ramp_limit_up,,"{min, mean, max, sum}",Indicates how the ramp_limit_up of the aggregated generator is computed from the original ramp_limit_up values.
+-- -- ramp_limit_down,,"{min, mean, max, sum}",Indicates how the ramp_limit_down of the aggregated generator is computed from the original ramp_limit_down values.
+-- -- efficiency,,"{min, mean, max, sum}",Indicates how the efficiency of the aggregated generator is computed from the original efficiency values.
+focus_weights,,Dict consisting of {country: factor} such as {NG: 0.4},"When specified, set the proportion of nodes assigned to each country. The sum of focus weights must be less than or equal to 1."

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -21,7 +21,7 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **Minor Changes and bug-fixing**
 
-* The configuration setting for ``focus_weights`` has been moved from ``focus_weights:`` to ``cluster_options: focus_weights:``. Backwards compatibility to old config files is maintained.
+* The configuration setting for ``focus_weights`` has been moved from ``focus_weights:`` to ``cluster_options: focus_weights:``. Backwards compatibility to old config files is maintained `PR #1565 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1565>`__
 
 * Disable distribute_cluster only for one subnetwork and country `PR #1539 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1539>`__
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -21,6 +21,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **Minor Changes and bug-fixing**
 
+* The configuration setting for ``focus_weights`` has been moved from ``focus_weights:`` to ``cluster_options: focus_weights:``. Backwards compatibility to old config files is maintained.
+
 * Disable distribute_cluster only for one subnetwork and country `PR #1539 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1539>`__
 
 * Reintroduce sanitize_carriers and sanitize_location to reduce the number of warnings related to components with undefined carriers `PR #1555 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1555>`__

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -619,7 +619,10 @@ if __name__ == "__main__":
     alternative_clustering = snakemake.params.cluster_options["alternative_clustering"]
     distribution_cluster = snakemake.params.cluster_options["distribute_cluster"]
     gadm_layer_id = snakemake.params.build_shape_options["gadm_layer_id"]
-    focus_weights = snakemake.params.get("focus_weights", None)
+    focus_weights = (
+        snakemake.params.focus_weights
+        or snakemake.params.cluster_options["focus_weights"]
+    )
     country_list = snakemake.params.countries
     geo_crs = snakemake.params.geo_crs
 

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -312,7 +312,7 @@ def distribute_clusters(
         n_clusters >= len(N) and n_clusters <= N.sum()
     ), f"Number of clusters must be {len(N)} <= n_clusters <= {N.sum()} for this selection of countries."
 
-    if focus_weights is not None:
+    if focus_weights:
         total_focus = sum(list(focus_weights.values()))
 
         assert (

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -1123,7 +1123,10 @@ if __name__ == "__main__":
         build_shape_options = snakemake.params.build_shape_options
         country_list = snakemake.params.countries
         distribution_cluster = snakemake.params.cluster_options["distribute_cluster"]
-        focus_weights = snakemake.params.focus_weights
+        focus_weights = (
+            snakemake.params.focus_weights
+            or snakemake.params.cluster_options["focus_weights"]
+        )
         gadm_layer_id = snakemake.params.build_shape_options["gadm_layer_id"]
         geo_crs = snakemake.params.crs["geo_crs"]
         renewable_config = snakemake.params.renewable


### PR DESCRIPTION
## Changes proposed in this Pull Request

``focus_weights`` is undocumented because it functions as a standalone configuration. When not explicitly used, it is simply omitted from ``config.default.yaml``. Similar to the approach taken in PyPSA-Eur, we need to relocate ``focus_weights`` to a more appropriate section.

> The configuration setting for ``focus_weights`` has been moved from ``focus_weights:`` to ``cluster_options: focus_weights:``. Backwards compatibility to old config files is maintained.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
