### PR TITLE
Improved customization of maximum AC/DC lines capacity expansion

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -73,7 +73,7 @@ ATLITE_NPROCESSES = config["atlite"].get("nprocesses", 4)
 wildcard_constraints:
     simpl="[a-zA-Z0-9]*|all",
     clusters="[0-9]+(m|flex)?|all|min",
-    ll="(v|c)([0-9\.]+|opt|all)|all",
+    ll="(v|c|l)([0-9\.]+|opt|all)|all",
     opts="[-+a-zA-Z0-9\.]*",
     unc="[-+a-zA-Z0-9\.]*",
     sopts="[-+a-zA-Z0-9\.\s]*",

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -226,12 +226,14 @@ lines:
     500.: "HVDC XLPE 1000"
   s_max_pu: 0.7
   s_nom_max: .inf
+  s_nom_max_min: -.inf
   length_factor: 1.25
   under_construction: "zero" # 'zero': set capacity to zero, 'remove': remove, 'keep': with full capacity
 
 links:
   p_max_pu: 1.0
   p_nom_max: .inf
+  p_nom_max_min: -.inf
   under_construction: "zero" # 'zero': set capacity to zero, 'remove': remove, 'keep': with full capacity
 
 transformers:

--- a/doc/configtables/lines.csv
+++ b/doc/configtables/lines.csv
@@ -3,5 +3,6 @@ ac_types,--,"Values should specify a `line type in PyPSA <https://pypsa.readthed
 dc_types, --, "Values should specify a `line type in PyPSA <https://pypsa.readthedocs.io/en/latest/components.html#line-types>`_ for DC-lines. Keys should specify the corresponding voltage level (e.g. 220., 300. and 380. kV)", "Specifies DC-line types."
 s_max_pu,--,"Value in [0.,1.]","Correction factor for line capacities (``s_nom``) to approximate :math:`N-1` security and reserve capacity for reactive power flows"
 s_nom_max,MW,"float","Global upper limit for the maximum capacity of each extendable line."
+s_nom_max_min,MW,"float","Global lower limit for the maximum capacity of each extendable line."
 length_factor,--,float,"Correction factor to account for the fact that buses are *not* connected by lines through air-line distance."
 under_construction,--,"One of {'zero': set capacity to zero, 'remove': remove completely, 'keep': keep with full capacity}","Specifies how to handle lines which are currently under construction."

--- a/doc/configtables/links.csv
+++ b/doc/configtables/links.csv
@@ -1,4 +1,5 @@
 ,Unit,Values,Description
 p_max_pu,--,"Value in [0.,1.]",Correction factor for link capacities ``p_nom``.
 p_nom_max,MW,float,Global upper limit for the maximum capacity of each extendable DC link.
+p_nom_max_min,MW,float,Global lower limit for the maximum capacity of each extendable DC link.
 under_construction,--,"One of {'zero', 'remove', 'keep'}", "Specifies how to handle lines which are currently under construction. 'zero': set capacity to zero; 'remove': remove completely, 'keep': keep with full capacity."

--- a/doc/wildcards.rst
+++ b/doc/wildcards.rst
@@ -62,8 +62,9 @@ It is handled in the rule :mod:`prepare_network`.
 The wildcard, in general, consists of two parts:
 
     1. The first part can be
-       ``v`` (for setting a limit on line volume) or
-       ``c`` (for setting a limit on line cost)
+       ``v`` (for setting a limit on line volume), or
+       ``c`` (for setting a limit on line cost), or
+       ``l`` (for a line-specific limit on line expansion).
 
     2. The second part can be
        ``opt`` or a float bigger than one (e.g. 1.25).
@@ -80,6 +81,9 @@ The wildcard, in general, consists of two parts:
 
        (c) ``c1.25`` will allow to build a transmission network that
            costs no more than 25 % more than the current system.
+
+       (d) ``l1.25`` will allow to build a transmission network where
+           each line is no more than 25 % its actual capacity.
 
 .. _opts:
 

--- a/doc/wildcards.rst
+++ b/doc/wildcards.rst
@@ -83,7 +83,7 @@ The wildcard, in general, consists of two parts:
            costs no more than 25 % more than the current system.
 
        (d) ``l1.25`` will allow to build a transmission network where
-           each line is no more than 25 % its actual capacity.
+           each line is expanded to no more than 25% of its capacity.
 
 .. _opts:
 

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -216,7 +216,6 @@ def set_transmission_limit(n, ll_type, factor, costs, lines, links):
         n.links.loc[links_dc_b, "p_nom_min"] = n.links.loc[links_dc_b, "p_nom"]
         n.links.loc[links_dc_b, "p_nom_extendable"] = True
 
-    
     if ll_type == "l":
         n.lines["s_nom_max"] = n.lines["s_nom"] * float(factor)
         n.links.loc[links_dc_b, "p_nom_max"] = n.links.loc[links_dc_b, "p_nom"] * float(

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -216,7 +216,13 @@ def set_transmission_limit(n, ll_type, factor, costs, lines, links):
         n.links.loc[links_dc_b, "p_nom_min"] = n.links.loc[links_dc_b, "p_nom"]
         n.links.loc[links_dc_b, "p_nom_extendable"] = True
 
-    if (factor != "opt") and (ll_type != "l"):
+    
+    if ll_type == "l":
+        n.lines["s_nom_max"] = n.lines["s_nom"] * float(factor)
+        n.links.loc[links_dc_b, "p_nom_max"] = n.links.loc[links_dc_b, "p_nom"] * float(
+            factor
+        )
+    elif factor != "opt":  # implicitly also ll_type != "l"
         con_type = "expansion_cost" if ll_type == "c" else "volume_expansion"
         rhs = float(factor) * ref
         n.add(
@@ -226,11 +232,6 @@ def set_transmission_limit(n, ll_type, factor, costs, lines, links):
             sense="<=",
             constant=rhs,
             carrier_attribute="AC, DC",
-        )
-    elif ll_type == "l":
-        n.lines["s_nom_max"] = n.lines["s_nom"] * float(factor)
-        n.links.loc[links_dc_b, "p_nom_max"] = n.links.loc[links_dc_b, "p_nom"] * float(
-            factor
         )
 
     set_line_nom_max(n, lines, links)
@@ -338,9 +339,9 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "prepare_network",
             simpl="",
-            clusters="2",
-            ll="copt",
-            opts="1H",
+            clusters="4",
+            ll="c1",
+            opts="Co2L-4H",
             # configfile="test/config.sector.yaml",
         )
 


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request
This PR proposes two features:
1. integration of an option (lines/links->s_nom_max_min) to specify a minimum s_nom_max for all lines/links when performing capacity expansion for them
2. integration of the new "l{factor}" option for wildcard ll that allows to perform a line-wise capacity: example "l1.5" specify a maximum capacity expansion of +50% the initial capacity of each line.

Documentation and release note is likely to be improved

## Checklist

- [ ] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
